### PR TITLE
Expand rhs generation to cover many more features

### DIFF
--- a/ciscript
+++ b/ciscript
@@ -9,3 +9,4 @@ cd ../runtime/datastructures
 cargo test
 cd ../../build
 ./tools/test_rhs/test_rhs ../test/test.kore | diff - ../test/test.ll
+./tools/test_rhs/test_rhs ../test/imp.kore | diff - ../test/imp.ll

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -320,6 +320,7 @@ public:
   }
 
   std::string getName() const;
+  KOREObjectSort *getSort() const { return sort; }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}
@@ -406,6 +407,8 @@ public:
   static KOREMetaStringPattern *Create(const std::string &Contents) {
     return new KOREMetaStringPattern(Contents);
   }
+
+  std::string getContents() { return contents; }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -84,8 +84,10 @@ private:
 };
 
 enum class SortCategory {
-  Map, List, Set, Int, Float, StringBuffer, Bool, MInt, Symbol
+  Uncomputed, Map, List, Set, Int, Float, StringBuffer, Bool, MInt, Symbol
 };
+
+class KOREDefinition;
 
 class KOREObjectCompositeSort : public KOREObjectSort {
 private:
@@ -99,7 +101,7 @@ public:
   }
 
   const std::string getName() const { return name; }
-  const SortCategory getCategory() const { return category; }
+  SortCategory getCategory(KOREDefinition *definition);
 
   virtual bool isConcrete() const override { return true; }
   virtual KOREObjectSort *substitute(const substitution &subst) override;
@@ -109,18 +111,7 @@ public:
   virtual bool operator==(const KOREObjectSort &other) const override;
 
 private:
-  KOREObjectCompositeSort(const std::string &Name) : name(Name) {
-    if (name == "Map") category = SortCategory::Map;
-    else if (name == "List") category = SortCategory::List;
-    else if (name == "Set") category = SortCategory::Set;
-    else if (name == "Array") category = SortCategory::List;
-    else if (name == "Int") category = SortCategory::Int;
-    else if (name == "Float") category = SortCategory::Float;
-    else if (name == "StringBuffer") category = SortCategory::StringBuffer;
-    else if (name == "Bool") category = SortCategory::Bool;
-    else if (name == "MInt") category = SortCategory::MInt;
-    else category = SortCategory::Symbol;
-  }
+  KOREObjectCompositeSort(const std::string &Name) : name(Name), category(SortCategory::Uncomputed) {}
 };
 
 class KOREMetaCompositeSort : public KOREMetaSort {
@@ -146,7 +137,6 @@ public:
 
 struct HashSymbol;
 
-class KOREDefinition;
 class KOREObjectSymbolDeclaration;
 
 class KOREObjectSymbol : public KORESymbol {
@@ -197,8 +187,8 @@ public:
   bool operator==(KOREObjectSymbol other) const;
   bool operator!=(KOREObjectSymbol other) const { return !(*this == other); }
 
-  std::string layoutString() const;
   uint8_t length() const;
+  std::string layoutString(KOREDefinition *) const;
 
   bool isConcrete() const;
   bool isPolymorphic() const;

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -284,6 +284,8 @@ private:
   KOREMetaVariable(const std::string &Name) : name(Name) { }
 };
 
+class KOREObjectVariablePattern;
+
 // KOREPattern
 class KOREPattern {
 public:
@@ -292,6 +294,9 @@ public:
      to the specified map, mapping their symbol name to the list of all instances
      of that symbol. */
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) = 0;
+  /* adds all the object level variables contained recursively in the current pattern
+     to the specified map, mapping their variable name to the variable itself. */
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) = 0;
 };
 
 class KOREObjectPattern : public KOREPattern {
@@ -318,6 +323,7 @@ public:
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &map) override { map.insert({name->getName(), this}); }
 
 private:
   KOREObjectVariablePattern(KOREObjectVariable *Name, KOREObjectSort *Sort)
@@ -338,6 +344,7 @@ public:
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) override {}
 
 private:
   KOREMetaVariablePattern(KOREMetaVariable *Name, KOREMetaSort *Sort)
@@ -361,6 +368,7 @@ public:
   void addArgument(KOREPattern *Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override;
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) override;
 
 private:
   KOREObjectCompositePattern(KOREObjectSymbol *Constructor)
@@ -383,6 +391,7 @@ public:
   void addArgument(KOREPattern *Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override;
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) override;
 
 private:
   KOREMetaCompositePattern(KOREMetaSymbol *Constructor)
@@ -400,6 +409,7 @@ public:
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) override {}
 
 private:
   KOREMetaStringPattern(const std::string &Contents) : contents(Contents) { }
@@ -416,6 +426,7 @@ public:
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &) override {}
+  virtual void markVariables(llvm::StringMap<KOREObjectVariablePattern *> &) override {}
 
 private:
   KOREMetaCharPattern(char Contents) : contents(Contents) { }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -178,7 +178,7 @@ public:
   const std::vector<KOREObjectSort *> &getArguments() const {
     return arguments;
   }
-  const KOREObjectSort *getSort() const { return sort; }
+  KOREObjectSort *getSort() const { return sort; }
   uint32_t getTag() const { assert(firstTag == lastTag); return firstTag; }
   uint16_t getLayout() const { return layout; }
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -178,7 +178,8 @@ public:
   const std::vector<KOREObjectSort *> &getArguments() const {
     return arguments;
   }
-  KOREObjectSort *getSort() const { return sort; }
+  const KOREObjectSort *getSort() const { return sort; }
+  KOREObjectSort *getSort() { return sort; }
   uint32_t getTag() const { assert(firstTag == lastTag); return firstTag; }
   uint16_t getLayout() const { return layout; }
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -187,7 +187,6 @@ public:
   bool operator==(KOREObjectSymbol other) const;
   bool operator!=(KOREObjectSymbol other) const { return !(*this == other); }
 
-  uint8_t length() const;
   std::string layoutString(KOREDefinition *) const;
 
   bool isConcrete() const;

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -15,7 +15,7 @@ std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Con
 
 /* returns the llvm::Type corresponding to the type of the result of calling createTerm
    on the specified pattern. */
-llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Value *> &substitution, KOREDefinition *definition, llvm::LLVMContext &Context, llvm::Module *Module);
+llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Type *> &substitution, KOREDefinition *definition, llvm::Module *Module);
 
 /* adds code to the specified basic block in the specified module which constructs
    an llvm value corresponding to the specified KORE RHS pattern and substitution in the

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -9,6 +9,44 @@
 
 namespace kllvm {
 
+class CreateTerm {
+private:
+  llvm::StringMap<llvm::Value *> &Substitution;
+  KOREDefinition *Definition;
+  llvm::BasicBlock *CurrentBlock;
+  llvm::BasicBlock *StuckBlock;
+  llvm::Module *Module;
+  llvm::LLVMContext &Ctx;
+  bool canGetStuck;
+
+  llvm::Value *createHook(KOREObjectCompositePattern *hookAtt, KOREObjectCompositePattern *pattern);
+  llvm::Value *createFunctionCall(std::string name, KOREObjectCompositePattern *pattern);
+  llvm::Value *createToken(SortCategory sort, std::string contents);
+public:
+  CreateTerm(
+    llvm::StringMap<llvm::Value *> &Substitution,
+    KOREDefinition *Definition,
+    llvm::BasicBlock *EntryBlock,
+    llvm::BasicBlock *StuckBlock,
+    llvm::Module *Module) :
+      Substitution(Substitution),
+      Definition(Definition),
+      CurrentBlock(EntryBlock),
+      StuckBlock(StuckBlock),
+      Module(Module),
+      Ctx(Module->getContext()),
+      canGetStuck(false) {}
+
+/* adds code to the specified basic block in the specified module which constructs
+   an llvm value corresponding to the specified KORE RHS pattern and substitution in the
+   specified definition, and returns the value itself. */
+  llvm::Value *operator()(KOREPattern *pattern);
+
+  llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
+
+  bool hasStuckBlock() const { return canGetStuck; }
+};
+
 /* Creates a new llvm::Module with the predefined declarations common to all llvm modules
    in the llvm backend. */
 std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Context);
@@ -17,10 +55,8 @@ std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Con
    on the specified pattern. */
 llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Type *> &substitution, KOREDefinition *definition, llvm::Module *Module);
 
-/* adds code to the specified basic block in the specified module which constructs
-   an llvm value corresponding to the specified KORE RHS pattern and substitution in the
-   specified definition, and returns the value itself. */
-llvm::Value *createTerm(KOREPattern *pattern, llvm::StringMap<llvm::Value *> &substitution, KOREDefinition *definition, llvm::BasicBlock *block, llvm::Module *Module);
+/** creates a function that applies the specified rule once it has matched, and returns the name of the function. */
+std::string makeApplyRuleFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *Module);
 
 }
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -205,6 +205,12 @@ void KOREObjectCompositePattern::markSymbols(std::map<std::string, std::vector<K
   }
 }
 
+void KOREObjectCompositePattern::markVariables(llvm::StringMap<KOREObjectVariablePattern *> &map) {
+  for (KOREPattern *arg : arguments) {
+    arg->markVariables(map);
+  }
+}
+
 void KOREMetaCompositePattern::addArgument(KOREPattern *Argument) {
   arguments.push_back(Argument);
 }
@@ -212,6 +218,12 @@ void KOREMetaCompositePattern::addArgument(KOREPattern *Argument) {
 void KOREMetaCompositePattern::markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &map) {
   for (KOREPattern *arg : arguments) {
     arg->markSymbols(map);
+  }
+}
+
+void KOREMetaCompositePattern::markVariables(llvm::StringMap<KOREObjectVariablePattern *> &map) {
+  for (KOREPattern *arg : arguments) {
+    arg->markVariables(map);
   }
 }
 

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -130,43 +130,6 @@ std::string KOREObjectSymbol::layoutString(KOREDefinition *definition) const {
   return result;
 }
 
-uint8_t KOREObjectSymbol::length() const {
-  uint8_t length = 1;
-  for (auto arg : arguments) {
-    auto sort = dynamic_cast<KOREObjectCompositeSort *>(arg);
-    switch(sort->getCategory()) {
-    case SortCategory::Map:
-      length += 3;
-      break;
-    case SortCategory::List:
-      length += 7;
-      break;
-    case SortCategory::Set:
-      length += 3;
-      break;
-    case SortCategory::Int:
-      length += 2;
-      break;
-    case SortCategory::Float:
-      length += 4;
-      break;
-    case SortCategory::StringBuffer:
-      length += 1;
-      break;
-    case SortCategory::Bool:
-      length += 1;
-      break;
-    case SortCategory::MInt:
-      assert(false && "not implemented yet: MInt");
-    case SortCategory::Symbol:
-      length += 1;
-      break;
-    }
-  }
-  return length;
-}
-
-
 bool KOREObjectSymbol::isConcrete() const {
   for (auto sort : arguments) {
     if (!sort->isConcrete()) {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -281,6 +281,8 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
           }
         }
       }
+    } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
+      return top->getArguments()[1];
     }
   }
   assert(false && "could not compute right hand side of axiom");

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -13,6 +13,10 @@
 namespace kllvm {
 
 std::string LLVM_HEADER = R"LLVM(
+; Linux target
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
+
 ; K types in LLVM
 
 ; A K value in the LLVM backend can be one of the following values:

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -148,7 +148,7 @@ llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Type *> &substi
   if (auto variable = dynamic_cast<KOREObjectVariablePattern *>(pattern)) {
     return substitution.lookup(variable->getName());
   } else if (auto constructor = dynamic_cast<KOREObjectCompositePattern *>(pattern)) {
-    const KOREObjectSymbol *symbol = constructor->getConstructor();
+    KOREObjectSymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
     if (symbol->getName() == "\\dv") {
       auto sort = dynamic_cast<KOREObjectCompositeSort *>(symbol->getArguments()[0]);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1,5 +1,7 @@
 #include "kllvm/codegen/CreateTerm.h"
 
+#include <gmp.h>
+
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
@@ -159,16 +161,206 @@ llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Type *> &substi
   }
 }
 
-llvm::Value *createTerm(KOREPattern *pattern, llvm::StringMap<llvm::Value *> &substitution, KOREDefinition *definition, llvm::BasicBlock *block, llvm::Module *Module) {
+llvm::Value *CreateTerm::createToken(SortCategory sort, std::string contents) {
+  switch(sort) {
+  case SortCategory::Map:
+  case SortCategory::List:
+  case SortCategory::Set:
+    assert (false && "cannot create tokens of collection category");
+  case SortCategory::Int: {
+    llvm::Constant *global = Module->getOrInsertGlobal("int_" + contents, Module->getTypeByName(INT_STRUCT));
+    llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    if (!globalVar->hasInitializer()) {
+      mpz_t value;
+      mpz_init_set_str(value, contents.c_str(), 10);
+      size_t size = mpz_size(value);
+      int sign = mpz_sgn(value);
+      llvm::ArrayType *limbsType = llvm::ArrayType::get(llvm::Type::getInt64Ty(Ctx), size);
+      llvm::Constant *limbs = Module->getOrInsertGlobal("int_" + contents + "_limbs", limbsType);
+      llvm::GlobalVariable *limbsVar = llvm::dyn_cast<llvm::GlobalVariable>(limbs);
+      std::vector<llvm::Constant *> allocdLimbs;
+      for (size_t i = 0; i < size; i++) {
+        allocdLimbs.push_back(llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), value->_mp_d[i]));
+      }
+      limbsVar->setInitializer(llvm::ConstantArray::get(limbsType, allocdLimbs));
+      llvm::ConstantInt *numLimbs = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), size);
+      llvm::Constant *mp_size = llvm::ConstantExpr::getMul(numLimbs, llvm::ConstantInt::getSigned(llvm::Type::getInt32Ty(Ctx), sign));
+      globalVar->setInitializer(llvm::ConstantStruct::get(Module->getTypeByName(INT_STRUCT), {numLimbs, mp_size, llvm::ConstantExpr::getPointerCast(limbsVar, llvm::Type::getInt64PtrTy(Ctx))}));
+      mpz_clear(value);
+    }
+    return global;
+  }
+  case SortCategory::Float:
+  case SortCategory::StringBuffer:
+  case SortCategory::MInt:
+    assert(false && "not implemented yet: tokens");
+  case SortCategory::Bool:
+    return llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), contents == "true");
+  case SortCategory::Symbol: {
+    llvm::StructType *StringType = llvm::StructType::get(Ctx, {Module->getTypeByName(BLOCKHEADER_STRUCT), llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), contents.size())});
+    llvm::Constant *global = Module->getOrInsertGlobal("token_" + contents, StringType);
+    llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    if (!globalVar->hasInitializer()) {
+      llvm::StructType *BlockHeaderType = Module->getTypeByName(BLOCKHEADER_STRUCT);
+      llvm::Constant *BlockHeader = llvm::ConstantStruct::get(BlockHeaderType, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), contents.size()));
+      globalVar->setInitializer(llvm::ConstantStruct::get(StringType, BlockHeader, llvm::ConstantDataArray::getString(Ctx, contents, false)));
+    }
+    return llvm::ConstantExpr::getPointerCast(global, llvm::PointerType::getUnqual(Module->getTypeByName(BLOCK_STRUCT)));
+  }
+  }
+}
+
+llvm::Value *CreateTerm::createHook(KOREObjectCompositePattern *hookAtt, KOREObjectCompositePattern *pattern) {
+  assert(hookAtt->getArguments().size() == 1);
+  auto strPattern = dynamic_cast<KOREMetaStringPattern *>(hookAtt->getArguments()[0]);
+  std::string name = strPattern->getContents();
+  if (name == "BOOL.and" || name == "BOOL.andThen") {
+    assert(pattern->getArguments().size() == 2);
+    llvm::Value *firstArg = (*this)(pattern->getArguments()[0]);
+    llvm::BasicBlock *CondBlock = CurrentBlock;
+    llvm::BasicBlock *TrueBlock = llvm::BasicBlock::Create(Ctx, "then", CurrentBlock->getParent());
+    llvm::BasicBlock *MergeBlock = llvm::BasicBlock::Create(Ctx, "hook_BOOL_and", CurrentBlock->getParent());
+    llvm::BranchInst *Branch = llvm::BranchInst::Create(TrueBlock, MergeBlock, firstArg, CurrentBlock);
+    CurrentBlock = TrueBlock;
+    llvm::Value *secondArg = (*this)(pattern->getArguments()[1]);
+    Branch = llvm::BranchInst::Create(MergeBlock, CurrentBlock);
+    llvm::PHINode *Phi = llvm::PHINode::Create(llvm::Type::getInt1Ty(Ctx), 2, "phi", MergeBlock);
+    Phi->addIncoming(secondArg, CurrentBlock);
+    Phi->addIncoming(firstArg, CondBlock);
+    CurrentBlock = MergeBlock;
+    return Phi;
+  } else if (name == "BOOL.or" || name == "BOOL.orElse") {
+    assert(pattern->getArguments().size() == 2);
+    llvm::Value *firstArg = (*this)(pattern->getArguments()[0]);
+    llvm::BasicBlock *CondBlock = CurrentBlock;
+    llvm::BasicBlock *FalseBlock = llvm::BasicBlock::Create(Ctx, "else", CurrentBlock->getParent());
+    llvm::BasicBlock *MergeBlock = llvm::BasicBlock::Create(Ctx, "hook_BOOL_or", CurrentBlock->getParent());
+    llvm::BranchInst *Branch = llvm::BranchInst::Create(MergeBlock, FalseBlock, firstArg, CurrentBlock);
+    CurrentBlock = FalseBlock;
+    llvm::Value *secondArg = (*this)(pattern->getArguments()[1]);
+    Branch = llvm::BranchInst::Create(MergeBlock, CurrentBlock);
+    llvm::PHINode *Phi = llvm::PHINode::Create(llvm::Type::getInt1Ty(Ctx), 2, "phi", MergeBlock);
+    Phi->addIncoming(secondArg, CurrentBlock);
+    Phi->addIncoming(firstArg, CondBlock);
+    CurrentBlock = MergeBlock;
+    return Phi;
+  } else if (name == "BOOL.not") {
+    assert(pattern->getArguments().size() == 1);
+    llvm::Value *arg = (*this)(pattern->getArguments()[0]);
+    llvm::BinaryOperator *Not = llvm::BinaryOperator::Create(llvm::Instruction::Xor, arg, llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), 1), "hook_BOOL_not", CurrentBlock);
+    return Not;
+  } else if (name == "BOOL.implies") {
+    assert(pattern->getArguments().size() == 2);
+    llvm::Value *firstArg = (*this)(pattern->getArguments()[0]);
+    llvm::BasicBlock *CondBlock = CurrentBlock;
+    llvm::BasicBlock *TrueBlock = llvm::BasicBlock::Create(Ctx, "then", CurrentBlock->getParent());
+    llvm::BasicBlock *MergeBlock = llvm::BasicBlock::Create(Ctx, "hook_BOOL_implies", CurrentBlock->getParent());
+    llvm::BranchInst *Branch = llvm::BranchInst::Create(TrueBlock, MergeBlock, firstArg, CurrentBlock);
+    CurrentBlock = TrueBlock;
+    llvm::Value *secondArg = (*this)(pattern->getArguments()[1]);
+    Branch = llvm::BranchInst::Create(MergeBlock, CurrentBlock);
+    llvm::PHINode *Phi = llvm::PHINode::Create(llvm::Type::getInt1Ty(Ctx), 2, "phi", MergeBlock);
+    Phi->addIncoming(secondArg, CurrentBlock);
+    Phi->addIncoming(llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), 1), CondBlock);
+    CurrentBlock = MergeBlock;
+    return Phi;
+  } else if (name == "BOOL.ne" || name == "BOOL.xor") {
+    assert(pattern->getArguments().size() == 2);
+    llvm::Value *firstArg = (*this)(pattern->getArguments()[0]);
+    llvm::Value *secondArg = (*this)(pattern->getArguments()[1]);
+    llvm::BinaryOperator *Xor = llvm::BinaryOperator::Create(llvm::Instruction::Xor, firstArg, secondArg, "hook_BOOL_ne", CurrentBlock);
+    return Xor;
+  } else if (name == "BOOL.eq") {
+    assert(pattern->getArguments().size() == 2);
+    llvm::Value *firstArg = (*this)(pattern->getArguments()[0]);
+    llvm::Value *secondArg = (*this)(pattern->getArguments()[1]);
+    llvm::ICmpInst *Eq = new llvm::ICmpInst(*CurrentBlock, llvm::CmpInst::ICMP_EQ, firstArg, secondArg, "hook_BOOL_eq");
+    return Eq;
+  } else if (!name.compare(0, 5, "MINT.")) {
+    assert(false && "not implemented yet: MInt");
+  } else {
+    std::string hookName = "hook_" + name.substr(0, name.find('.')) + "_" + name.substr(name.find('.') + 1);
+    return createFunctionCall(hookName, pattern);
+  }
+}
+
+llvm::Value *CreateTerm::createFunctionCall(std::string name, KOREObjectCompositePattern *pattern) {
+  std::vector<llvm::Value *> args;
+  std::vector<llvm::Type *> types;
+  auto returnSort = dynamic_cast<KOREObjectCompositeSort *>(pattern->getConstructor()->getSort());
+  llvm::Type *returnType = getValueType(returnSort->getCategory(Definition), Module);
+  llvm::Value *Retval;
+  bool load = true;
+  switch(returnSort->getCategory(Definition)) {
+  case SortCategory::Int:
+    Retval = allocateBlock(Module->getTypeByName(INT_STRUCT), CurrentBlock);
+    load = false;
+    break;
+  case SortCategory::Float:
+    Retval = allocateBlock(Module->getTypeByName(FLOAT_STRUCT), CurrentBlock);
+    load = false;
+    break;
+  default:
+    Retval = new llvm::AllocaInst(returnType, 0, "", CurrentBlock);
+    break;
+  }
+  args.push_back(Retval);
+  types.push_back(Retval->getType());
+  int i = 0;
+  for (auto sort : pattern->getConstructor()->getArguments()) {
+    auto concreteSort = dynamic_cast<KOREObjectCompositeSort *>(sort);
+    llvm::Value *arg = (*this)(pattern->getArguments()[i++]);
+    switch(concreteSort->getCategory(Definition)) {
+    case SortCategory::Map:
+    case SortCategory::List:
+    case SortCategory::Set: {
+      llvm::AllocaInst *AllocCollection = new llvm::AllocaInst(arg->getType(), 0, "", CurrentBlock);
+      llvm::StoreInst *MoveCollection = new llvm::StoreInst(arg, AllocCollection, CurrentBlock);
+      args.push_back(AllocCollection);
+      types.push_back(AllocCollection->getType());
+      break;
+    }
+    default:
+      args.push_back(arg);
+      types.push_back(arg->getType());
+      break;
+    }
+  }
+  canGetStuck = true;
+  llvm::FunctionType *funcType = llvm::FunctionType::get(llvm::Type::getInt1Ty(Ctx), types, false);
+  llvm::Constant *func = Module->getOrInsertFunction(name, funcType);
+  llvm::CallInst *Call = llvm::CallInst::Create(func, args, "", CurrentBlock);
+  llvm::BasicBlock *MergeBlock = llvm::BasicBlock::Create(Ctx, "notstuck", CurrentBlock->getParent());
+  llvm::BranchInst *Branch = llvm::BranchInst::Create(MergeBlock, StuckBlock, Call, CurrentBlock);
+  CurrentBlock = MergeBlock;
+  if (load) {
+    return new llvm::LoadInst(Retval, "", CurrentBlock);
+  } else {
+    return Retval;
+  }
+}
+
+llvm::Value *CreateTerm::operator()(KOREPattern *pattern) {
   if (auto variable = dynamic_cast<KOREObjectVariablePattern *>(pattern)) {
     return Substitution.lookup(variable->getName());
   } else if (auto constructor = dynamic_cast<KOREObjectCompositePattern *>(pattern)) {
     const KOREObjectSymbol *symbol = constructor->getConstructor();
     assert(symbol->isConcrete() && "not supported yet: sort variables");
+    if (symbol->getName() == "\\dv") {
+      auto sort = dynamic_cast<KOREObjectCompositeSort *>(symbol->getArguments()[0]);
+      auto strPattern = dynamic_cast<KOREMetaStringPattern *>(constructor->getArguments()[0]);
+      return createToken(sort->getCategory(Definition), strPattern->getContents());
+    }
     assert(symbol->getName() != "\\dv" && "not supported yet: \\dv");
     KOREObjectSymbolDeclaration *symbolDecl = Definition->getSymbolDeclarations().lookup(symbol->getName());
     if (symbolDecl->getAttributes().count("function")) {
-      assert(false && "not implemented yet: functions");
+      if (symbolDecl->getAttributes().count("hook")) {
+        return createHook(symbolDecl->getAttributes().lookup("hook"), constructor);
+      } else {
+        std::ostringstream Out;
+        symbol->print(Out);
+        return createFunctionCall("eval_" + Out.str(), constructor);
+      }
     } else if (symbol->getArguments().empty()) {
       llvm::StructType *BlockType = Module->getTypeByName(BLOCK_STRUCT);
       llvm::IntToPtrInst *Cast = new llvm::IntToPtrInst(llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), (((uint64_t)symbol->getTag()) << 32) | 1), llvm::PointerType::getUnqual(BlockType), "", CurrentBlock);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -131,7 +131,7 @@ llvm::StructType *getBlockType(llvm::Module *Module, const KOREObjectSymbol *sym
 llvm::Value *getBlockHeader(llvm::Module *Module, const KOREObjectSymbol *symbol) {
   llvm::StructType *BlockHeaderType = Module->getTypeByName(BLOCKHEADER_STRUCT);
   uint64_t headerVal = symbol->getTag();
-  headerVal |= (uint64_t)symbol->length() << 32;
+  headerVal |= (llvm::DataLayout(Module).getTypeAllocSize(BlockType) / 8) << 32;
   headerVal |= (uint64_t)symbol->getLayout() << 48;
   return llvm::ConstantStruct::get(BlockHeaderType, llvm::ConstantInt::get(llvm::IntegerType::get(Module->getContext(), 64), headerVal));
 }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -122,7 +122,7 @@ llvm::StructType *getBlockType(llvm::Module *Module, const KOREObjectSymbol *sym
   Types.push_back(EmptyArrayType);
   for (KOREObjectSort *arg : symbol->getArguments()) {
     auto sort = dynamic_cast<KOREObjectCompositeSort *>(arg);
-    llvm::Type *type = getValueType(sort->getCategory(), Module);
+    llvm::Type *type = getValueType(sort->getCategory(definition), Module);
     Types.push_back(type);
   }
   return llvm::StructType::get(Module->getContext(), Types);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -133,7 +133,9 @@ llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition,
 llvm::Value *getBlockHeader(llvm::Module *Module, KOREDefinition *definition, const KOREObjectSymbol *symbol, llvm::Type *BlockType) {
   llvm::StructType *BlockHeaderType = Module->getTypeByName(BLOCKHEADER_STRUCT);
   uint64_t headerVal = symbol->getTag();
-  headerVal |= (llvm::DataLayout(Module).getTypeAllocSize(BlockType) / 8) << 32;
+  uint64_t sizeInBytes = llvm::DataLayout(Module).getTypeAllocSize(BlockType);
+  assert(sizeInBytes % 8 == 0);
+  headerVal |= (sizeInBytes / 8) << 32;
   headerVal |= (uint64_t)symbol->getLayout() << 48;
   return llvm::ConstantStruct::get(BlockHeaderType, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Module->getContext()), headerVal));
 }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -351,7 +351,6 @@ llvm::Value *CreateTerm::operator()(KOREPattern *pattern) {
       auto strPattern = dynamic_cast<KOREMetaStringPattern *>(constructor->getArguments()[0]);
       return createToken(sort->getCategory(Definition), strPattern->getContents());
     }
-    assert(symbol->getName() != "\\dv" && "not supported yet: \\dv");
     KOREObjectSymbolDeclaration *symbolDecl = Definition->getSymbolDeclarations().lookup(symbol->getName());
     if (symbolDecl->getAttributes().count("function")) {
       if (symbolDecl->getAttributes().count("hook")) {

--- a/lib/parser/KOREScanner.l
+++ b/lib/parser/KOREScanner.l
@@ -91,7 +91,7 @@ yyin = in;
 }
 
 "\""            { stringBuffer.clear(); BEGIN(STR);           }
-<STR>[^\"\n\\]* { stringBuffer.push_back(yytext[0]);          }
+<STR>[^\"\n\\]* { stringBuffer.append(yytext);                }
 <STR>"\n"       { stringBuffer.push_back('\n'); loc->lines(); }
 <STR>"\\\""     { stringBuffer.push_back('\"');               }
 <STR>"\\\\"     { stringBuffer.push_back('\\');               }

--- a/test/imp.kore
+++ b/test/imp.kore
@@ -1,27 +1,27 @@
 []
 
 module BASIC-K
-  sort K{} []
-  sort KItem{} []
+  sort SortK{} []
+  sort SortKItem{} []
 endmodule []
 
 module KSEQ
   import BASIC-K []
 
-  symbol kseq{}(KItem{}, K{}) : K{} []
-  symbol append{}(K{}, K{}) : K{} []
-  symbol dotk{}() : K{} []
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+  symbol dotk{}() : SortK{} []
 
   axiom{R}
-    \equals{K{},R}(
-      append{}(dotk{}(),K2:K{}),
-      K2:K{})
+    \equals{SortK{},R}(
+      append{}(dotk{}(),K2:SortK{}),
+      K2:SortK{})
   []
 
   axiom{R}
-    \equals{K{},R}(
-      append{}(kseq{}(K1:KItem{},K2:K{}),K3:K{}),
-      kseq{}(K1:KItem{},append{}(K2:K{},K3:K{})))
+    \equals{SortK{},R}(
+      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
+      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
   []
 
 endmodule []
@@ -48,3251 +48,511 @@ module IMP
   import K []
 
 // sorts
-  sort List{} []
-  sort TCellFragment{} []
-  hooked-sort String{} []
-  sort StateCell{} []
-  sort KConfigVar{} []
-  sort TCell{} []
-  sort Ids{} []
-  sort BExp{} []
-  sort StateCellOpt{} []
-  sort Id{} []
-  sort Stream{} []
-  sort Cell{} []
-  hooked-sort Bool{} []
-  sort KCell{} []
-  sort KResult{} []
-  sort Map{} []
-  sort KCellOpt{} []
-  sort Stmt{} []
-  hooked-sort Int{} []
-  hooked-sort Float{} []
-  sort Pgm{} []
-  sort Block{} []
-  sort Set{} []
-  sort IOError{} []
-  sort AExp{} []
+  sort SortList{} [hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,3,197,31)")]
+  sort SortTCellFragment{} []
+  hooked-sort SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(484,3,484,37)")]
+  sort SortStateCell{} []
+  sort SortKConfigVar{} [token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)")]
+  sort SortTCell{} []
+  sort SortIds{} []
+  sort SortBExp{} []
+  sort SortStateCellOpt{} []
+  sort SortId{} [token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(701,3,701,19)")]
+  sort SortCell{} []
+  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(263,3,263,31)")]
+  sort SortKCell{} []
+  sort SortKResult{} []
+  sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(87,3,87,28)"), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)")]
+  sort SortKCellOpt{} []
+  sort SortStmt{} []
+  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,3,320,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.Int")]
+  hooked-sort SortFloat{} [hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,3,402,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)")]
+  sort SortPgm{} []
+  sort SortBlock{} []
+  sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(153,3,153,28)")]
+  sort SortAExp{} []
 
 // symbols
-  symbol LblinitKCell{}(Map{}) : KCell{} []
-  symbol Lbl'Stop'Set{}() : Set{} []
-  hooked-symbol LblInt2String{}(Int{}) : String{} []
-  symbol Lbl'Hash'EBADF'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(Map{}) : List{} []
-  symbol Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblgetKLabel{}(K{}) : KItem{} []
-  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(BExp{}) : BExp{} []
-  hooked-symbol Lbl'Hash'system{}(String{}) : KItem{} []
-  symbol Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol LblisKResult{}(K{}) : Bool{} []
-  symbol Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  hooked-symbol LblchrChar{}(Int{}) : String{} []
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  symbol Lbl'Hash'EOF'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Int{} []
-  symbol Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(String{}, String{}, String{}) : String{} []
-  symbol Lbl'Hash'buffer{}(K{}) : Stream{} []
-  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  symbol Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Ids{}, Stmt{}) : Pgm{} []
-  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(K{}, K{}) : Bool{} []
-  symbol Lbl'Hash'EACCES'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblListItem{}(K{}) : List{} []
-  symbol LblisStateCellOpt{}(K{}) : Bool{} []
-  symbol Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Hash'logToFile{}(String{}, String{}) : K{} []
-  symbol Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  hooked-symbol LblintersectSet{}(Set{}, Set{}) : Set{} []
-  symbol Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisKCellOpt{}(K{}) : Bool{} []
-  symbol Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(Id{}, AExp{}) : Stmt{} []
-  hooked-symbol Lbl'Hash'configuration'Unds'K-REFLECTION'Unds'{}() : K{} []
-  symbol Lbl'Hash'unknownIOError{}(Int{}) : IOError{} []
-  symbol Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisBool{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : K{} []
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(Map{}, K{}) : Map{} []
-  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : String{} []
-  hooked-symbol LblremoveAll{}(Map{}, Set{}) : Map{} []
-  symbol Lbl'-LT-'T'-GT-'{}(KCell{}, StateCell{}) : TCell{} []
-  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : K{} []
-  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  symbol LblisTCell{}(K{}) : Bool{} []
-  hooked-symbol LblSet'Coln'in{}(K{}, Set{}) : Bool{} []
-  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'{}() : Int{} []
-  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String{}(Int{}, String{}) : K{} []
-  hooked-symbol Lbl'Hash'isConcrete{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Hash'argv{}() : List{} []
-  symbol Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Hash'fresh{}(String{}) : KItem{} []
-  symbol Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  symbol Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblsrandInt{}(Int{}) : K{} []
-  symbol LblisIds{}(K{}) : Bool{} []
-  hooked-symbol LblrandInt{}(Int{}) : Int{} []
-  symbol LblisStmt{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  hooked-symbol LblMap'Coln'choice{}(Map{}) : K{} []
-  symbol Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(AExp{}, AExp{}) : BExp{} []
-  symbol Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Unds'Map'Unds'{}(Map{}, Map{}) : Map{} []
-  symbol Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Unds'List'Unds'{}(List{}, List{}) : List{} []
-  symbol Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblSet'Coln'choice{}(Set{}) : K{} []
-  symbol LblisBExp{}(K{}) : Bool{} []
-  symbol Lbl'Hash'EPERM'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(Int{}, Int{}, Int{}) : Int{} []
-  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(String{}, String{}, String{}) : String{} []
-  hooked-symbol Lbl'Hash'getenv{}(String{}) : String{} []
-  symbol Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K{}) : KItem{} []
-  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  symbol Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(Int{}) : AExp{} []
-  hooked-symbol Lbllog2Int{}(Int{}) : Int{} []
-  hooked-symbol Lblsize{}(Set{}) : Int{} []
-  symbol Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(BExp{}, Block{}) : Stmt{} []
-  symbol Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(BExp{}, BExp{}) : BExp{} []
-  hooked-symbol LblfindChar{}(String{}, String{}, Int{}) : Int{} []
-  symbol Lbl'Hash'EDOM'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisK{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'UndsUnds'Int{}(Int{}) : Int{} []
-  symbol Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds'inList'Unds'{}(K{}, List{}) : Bool{} []
-  symbol Lbl'Stop'List{}() : List{} []
-  hooked-symbol Lbl'Hash'parse{}(String{}, String{}) : KItem{} []
-  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(String{}, String{}, String{}, Int{}) : String{} []
-  symbol Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisMap{}(K{}) : Bool{} []
-  symbol Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblnoStateCell{}() : StateCellOpt{} []
-  hooked-symbol Lbl'Hash'opendir'LParUndsRParUnds'K-IO'UndsUnds'String{}(String{}) : KItem{} []
-  symbol LblisTCellFragment{}(K{}) : Bool{} []
-  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K{}) : KItem{} []
-  symbol Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(Int{}) : Int{} []
-  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{S0}(Bool{}, S0, S0) : S0 []
-  hooked-symbol Lbl'Hash'parseInModule{}(String{}, String{}, String{}) : KItem{} []
-  symbol Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  symbol Lbl'Hash'EIO'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblnewUUID'Unds'STRING'Unds'{}() : String{} []
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(Map{}, K{}, K{}) : Map{} []
-  hooked-symbol LblString2Base{}(String{}, Int{}) : Int{} []
-  symbol LblisId{}(K{}) : Bool{} []
-  hooked-symbol LbllengthString{}(String{}) : Int{} []
-  symbol Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  symbol LblinitTCell{}(Map{}) : TCell{} []
-  symbol Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisSet{}(K{}) : Bool{} []
-  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(Int{}, Int{}) : Bool{} []
-  symbol LblfreshId{}(Int{}) : Id{} []
-  symbol Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblupdateMap{}(Map{}, Map{}) : Map{} []
-  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : String{} []
-  hooked-symbol LblrfindChar{}(String{}, String{}, Int{}) : Int{} []
-  hooked-symbol LblMap'Coln'lookup{}(Map{}, K{}) : K{} []
-  symbol LblisString{}(K{}) : Bool{} []
-  hooked-symbol Lblvalues{}(Map{}) : List{} []
-  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  hooked-symbol Lbl'Hash'sort{}(K{}) : String{} []
-  symbol Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(Map{}, Map{}) : Map{} []
-  symbol LblisInt{}(K{}) : Bool{} []
-  hooked-symbol LblfindString{}(String{}, String{}, Int{}) : Int{} []
-  symbol Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(Id{}, Ids{}) : Ids{} []
-  symbol LblisStream{}(K{}) : Bool{} []
-  symbol Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblString2Float{}(String{}) : Float{} []
-  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'{}() : Int{} []
-  symbol LblisCell{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  hooked-symbol LblString2Id{}(String{}) : Id{} []
-  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'UndsUnds'Int{}(Int{}) : Int{} []
-  symbol Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(K{}, K{}) : KItem{} []
-  symbol Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Int{}, String{}, String{}) : KItem{} []
-  hooked-symbol LblList'Coln'get{}(List{}, Int{}) : K{} []
-  symbol Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(AExp{}, AExp{}) : AExp{} []
-  symbol Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Hash'lstat'LParUndsRParUnds'K-IO'UndsUnds'String{}(String{}) : KItem{} []
-  hooked-symbol LblsizeMap{}(Map{}) : Int{} []
-  hooked-symbol LblId2String{}(Id{}) : String{} []
-  symbol Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K{}) : KItem{} []
-  symbol Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblnotBool'Unds'{}(Bool{}) : Bool{} []
-  hooked-symbol LblList'Coln'range{}(List{}, Int{}, Int{}) : List{} []
-  symbol Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(AExp{}, AExp{}) : AExp{} []
-  symbol Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsQuotRBraUnds'Ids{}() : Ids{} []
-  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : K{} []
-  symbol Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Stmt{}, Stmt{}) : Stmt{} []
-  symbol Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K{}) : KItem{} []
-  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(Map{}, Map{}) : Bool{} []
-  hooked-symbol LblrfindString{}(String{}, String{}, Int{}) : Int{} []
-  symbol Lbl'-LT-'state'-GT-'{}(Map{}) : StateCell{} []
-  hooked-symbol LblFloat2String{}(Float{}) : String{} []
-  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(String{}, String{}) : Bool{} []
-  symbol LblisStateCell{}(K{}) : Bool{} []
-  symbol Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}() : KItem{} []
-  symbol Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(K{}, K{}) : Map{} []
-  hooked-symbol LblMap'Coln'lookupOrDefault{}(Map{}, K{}, K{}) : K{} []
-  symbol Lbl'Hash'noparse'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisList{}(K{}) : Bool{} []
-  symbol Lbl'Hash'EINTR'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  hooked-symbol LblcategoryChar{}(String{}) : String{} []
-  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : K{} []
-  hooked-symbol LblBase2String{}(Int{}, Int{}) : String{} []
-  hooked-symbol LblSetItem{}(K{}) : Set{} []
-  symbol LblinitStateCell{}() : StateCell{} []
-  symbol Lbl'Stop'Map{}() : Map{} []
-  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Bool{} []
-  hooked-symbol Lblkeys{}(Map{}) : Set{} []
-  symbol LblisKItem{}(K{}) : Bool{} []
-  hooked-symbol LblSet'Coln'difference{}(Set{}, Set{}) : Set{} []
-  symbol Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(K{}) : KItem{} []
-  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'UndsUnds'String{}(String{}) : Int{} []
-  hooked-symbol LblString2Int{}(String{}) : Int{} []
-  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(Set{}, Set{}) : Bool{} []
-  symbol Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LbldirectionalityChar{}(String{}) : String{} []
-  symbol Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K{}) : KItem{} []
-  hooked-symbol LblsizeList{}(List{}) : Int{} []
-  symbol LblisKConfigVar{}(K{}) : Bool{} []
-  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K{}) : KItem{} []
-  symbol Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}() : Block{} []
-  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'{}() : Int{} []
-  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'UndsUnds'Int{}(Int{}) : K{} []
-  symbol Lbl'-LT-'T'-GT-'-fragment{}(KCellOpt{}, StateCellOpt{}) : TCellFragment{} []
-  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Bool{}, Bool{}) : Bool{} []
-  symbol Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblnoKCell{}() : KCellOpt{} []
-  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisKCell{}(K{}) : Bool{} []
-  hooked-symbol LblFloatFormat{}(Float{}, String{}) : String{} []
-  symbol Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol LblisPgm{}(K{}) : Bool{} []
-  symbol Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblsubstrString{}(String{}, Int{}, Int{}) : String{} []
-  symbol Lbl'-LT-'k'-GT-'{}(K{}) : KCell{} []
-  hooked-symbol LblabsInt{}(Int{}) : Int{} []
-  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : K{} []
-  hooked-symbol Lbl'Unds'andBool'Unds'{}(Bool{}, Bool{}) : Bool{} []
-  symbol LblisAExp{}(K{}) : Bool{} []
-  symbol Lbl'Unds'Set'Unds'{}(Set{}, Set{}) : Set{} []
-  symbol LblfreshInt{}(Int{}) : Int{} []
-  symbol Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(BExp{}, Block{}, Block{}) : Stmt{} []
-  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(K{}) : KItem{} []
-  hooked-symbol LblbitRangeInt{}(Int{}, Int{}, Int{}) : Int{} []
-  symbol Lbl'Hash'EROFS'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol LblordChar{}(String{}) : Int{} []
-  symbol Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(K{}, K{}) : Bool{} []
-  symbol LblisIOError{}(K{}) : Bool{} []
-  symbol LblisFloat{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(String{}, String{}) : Int{} []
-  symbol Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}() : IOError{} []
-  symbol Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}() : IOError{} []
-  hooked-symbol Lbl'Hash'stat'LParUndsRParUnds'K-IO'UndsUnds'String{}(String{}) : KItem{} []
-  hooked-symbol LblsignExtendBitRangeInt{}(Int{}, Int{}, Int{}) : Int{} []
-  symbol Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Stmt{}) : Block{} []
-  symbol LblisBlock{}(K{}) : Bool{} []
-  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(K{}, Map{}) : Bool{} []
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [functional{}(), originalPrd{}(), function{}(), noThread{}(), initializer{}()]
+  symbol Lbl'Stop'Set{}() : SortSet{} [klabel{}(".Set"), functional{}(), constructor{}(), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,18,161,110)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{Set}"), productionID{}("238762799")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [klabel{}("bitRangeInt"), functional{}(), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(364,18,364,108)"), function{}(), productionID{}("98826337")]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(SortString{}) : SortId{} [klabel{}("String2Id"), functional{}(), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(704,17,704,72)"), function{}(), productionID{}("1572256205")]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [functional{}(), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,19,132,79)"), function{}(), productionID{}("1753714541")]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), smtlib{}(">="), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(384,19,384,137)"), function{}(), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1096485705")]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(496,19,496,76)"), function{}(), left{}(), productionID{}("1204481453")]
+  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(356,18,356,134)"), function{}(), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("159475521")]
+  symbol Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(SortBExp{}) : SortBExp{} [functional{}(), strict{}(""), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), productionID{}("1581078471")]
+  hooked-symbol Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("+"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,18,348,140)"), function{}(), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("257459516")]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [function{}(), predicate{}("KResult"), originalPrd{}(), functional{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(388,19,388,52)"), function{}(), productionID{}("2100440237")]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [klabel{}("sizeMap"), functional{}(), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,91)"), function{}(), productionID{}("787122337")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), smtlib{}("distinct"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(387,19,387,148)"), function{}(), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1680503330")]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(520,18,520,120)"), function{}(), productionID{}("2113748097")]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [klabel{}("chrChar"), functional{}(), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(499,21,499,69)"), function{}(), productionID{}("1766869737")]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortFloat{} [klabel{}("String2Float"), functional{}(), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(510,21,510,93)"), function{}(), productionID{}("1551629761")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [klabel{}("randInt"), functional{}(), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(397,18,397,56)"), function{}(), productionID{}("1330247343")]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(519,21,519,112)"), function{}(), productionID{}("1783568981")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), smtlib{}("<="), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(382,19,382,137)"), function{}(), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1236444285")]
+  symbol Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(SortIds{}, SortStmt{}) : SortPgm{} [functional{}(), format{}("%1 %2%3%n%4"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), colors{}("yellow,pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(53,18,53,88)"), productionID{}("858204589")]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [klabel{}("_==K_"), functional{}(), smtlib{}("="), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), equalEqualK{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(727,21,727,144)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}\\mathrel{=_K}{#2}"), productionID{}("575935098")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [klabel{}("log2Int"), functional{}(), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(362,18,362,74)"), function{}(), productionID{}("795321555")]
+  hooked-symbol LblListItem{}(SortK{}) : SortList{} [klabel{}("ListItem"), functional{}(), smtlib{}("smt_seq_elem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(235,19,235,120)"), function{}(), symbol'Kywd'{}(), productionID{}("405896924")]
+  symbol LblisStateCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCellOpt"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(526,19,526,70)"), function{}(), productionID{}("2075952726")]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [klabel{}("ordChar"), functional{}(), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(500,18,500,69)"), function{}(), productionID{}("947553027")]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCellOpt"), originalPrd{}(), functional{}()]
+  symbol Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(SortId{}, SortAExp{}) : SortStmt{} [functional{}(), strict{}("2"), format{}("%1 %2 %3%4"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), productionID{}("417557780")]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortK{}) : SortMap{} [klabel{}("_[_<-undef]"), functional{}(), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(116,18,116,105)"), function{}(), symbol'Kywd'{}(), productionID{}("2104973502")]
+  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,18,354,130)"), function{}(), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("993370665")]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [functional{}(), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(494,21,494,127)"), function{}(), latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), left{}(), productionID{}("1396721535")]
+  symbol Lbl'-LT-'T'-GT-'{}(SortKCell{}, SortStateCell{}) : SortTCell{} [functional{}(), format{}("%1%i%n%2%n%3%d%n%4"), constructor{}(), contentStartLine{}("84"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("17"), topcell{}(), cell{}(), originalPrd{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), color{}("yellow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(84,17,87,21)")]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(527,19,527,70)"), function{}(), productionID{}("1764996806")]
+  symbol LblisTCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCell"), originalPrd{}(), functional{}()]
+  hooked-symbol LblSet'Coln'in{}(SortK{}, SortSet{}) : SortBool{} [klabel{}("Set:in"), functional{}(), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(175,19,175,90)"), function{}(), symbol'Kywd'{}(), productionID{}("2133655103")]
+  symbol Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids'QuotRBraUnds'Ids{}() : SortIds{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,47)"), productionID{}("1976752685")]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortK{} [klabel{}("srandInt"), functional{}(), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(398,16,398,56)"), function{}(), productionID{}("2017797638")]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortK{} [klabel{}("Map:lookupOrDefault"), functional{}(), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(110,16,110,114)"), function{}(), productionID{}("1242027525")]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("or"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,19,275,144)"), function{}(), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(), productionID{}("1351478315")]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [klabel{}("values"), functional{}(), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,19,137,76)"), function{}(), productionID{}("177140066")]
+  symbol LblisIds{}(SortK{}) : SortBool{} [function{}(), predicate{}("Ids"), originalPrd{}(), functional{}()]
+  symbol LblisStmt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Stmt"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("and"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(273,19,273,106)"), function{}(), left{}(), productionID{}("616674002")]
+  symbol Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortBExp{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), seqstrict{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), latex{}("{#1}\\leq{#2}"), productionID{}("1810923540")]
+  symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [index{}("0"), klabel{}("_Map_"), functional{}(), element{}("_|->_"), format{}("%1%n%2"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".Map"), comm{}(), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(95,18,95,172)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("1267149311")]
+  symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [klabel{}("_List_"), functional{}(), element{}("ListItem"), format{}("%1%n%2"), smtlib{}("smt_seq_concat"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".List"), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(230,19,230,180)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("746074699")]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [klabel{}("Int2String"), functional{}(), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(512,21,512,91)"), function{}(), productionID{}("1902671237")]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [klabel{}("findChar"), functional{}(), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(505,18,505,89)"), function{}(), productionID{}("308433917")]
+  symbol LblisBExp{}(SortK{}) : SortBool{} [function{}(), predicate{}("BExp"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("div"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,18,345,93)"), function{}(), left{}(), productionID{}("1848289347")]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("(mod (^ #1 #2) #3)"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(337,18,337,110)"), function{}(), left{}(), productionID{}("1161322357")]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [klabel{}("_==Int_"), functional{}(), smtlib{}("="), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(386,19,386,155)"), function{}(), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("823914581")]
+  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("mod"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(343,18,343,144)"), function{}(), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1777238524")]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [klabel{}("Base2String"), functional{}(), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(513,21,513,92)"), function{}(), productionID{}("403174823")]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(517,21,517,110)"), function{}(), productionID{}("2142565033")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortK{} [klabel{}("Map:choice"), functional{}(), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,16,146,96)"), function{}(), productionID{}("2144838275")]
+  symbol Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(522,19,522,82)"), function{}(), left{}(), productionID{}("629454893")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [klabel{}("size"), functional{}(), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(181,18,181,68)"), function{}(), productionID{}("1345900725")]
+  symbol Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(SortId{}, SortIds{}) : SortIds{} [functional{}(), format{}("%1%2 %3"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,47)"), productionID{}("1976752685"), right{}()]
+  symbol Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(SortInt{}) : SortAExp{} [functional{}(), format{}("%1%2"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(29,20,29,60)"), productionID{}("300983713")]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [klabel{}("absInt"), functional{}(), smtlib{}("int_abs"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(361,18,361,90)"), function{}(), productionID{}("131872530")]
+  symbol Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(SortBExp{}, SortBlock{}) : SortStmt{} [functional{}(), format{}("%1 %2%3%4 %5"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), colors{}("yellow,white,white"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(44,20,44,96)"), productionID{}("332699949")]
+  symbol Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(SortBExp{}, SortBExp{}) : SortBExp{} [functional{}(), strict{}("1"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), left{}(), productionID{}("1932332324")]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}(), functional{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [klabel{}("categoryChar"), functional{}(), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(531,21,531,80)"), function{}(), productionID{}("1651162064")]
+  symbol Lbl'Stop'List{}() : SortList{} [klabel{}(".List"), functional{}(), smtlib{}("smt_seq_nil"), constructor{}(), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,19,232,134)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{List}"), productionID{}("127791068")]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [functional{}(), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(518,21,518,107)"), function{}(), productionID{}("1304589447")]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}(), functional{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [klabel{}("freshInt"), freshGenerator{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(394,18,394,60)"), function{}(), productionID{}("566113173")]
+  symbol LblnoStateCell{}() : SortStateCellOpt{} [cellOptAbsent{}("StateCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblisTCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCellFragment"), originalPrd{}(), functional{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [functional{}(), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,18,334,121)"), function{}(), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), productionID{}("530539368")]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(SortBool{}, SortS0, SortS0) : SortS0 [functional{}(), poly{}("0, 2, 3"), smtlib{}("ite"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(735,16,735,110)"), function{}(), productionID{}("347978868")]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(528,19,528,70)"), function{}(), productionID{}("2101249621")]
+  hooked-symbol LblnewUUID'Unds'STRING'Unds'{}() : SortString{} [hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), impure{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(534,21,534,67)"), function{}(), productionID{}("530486389")]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [klabel{}("rfindString"), functional{}(), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(504,18,504,86)"), function{}(), productionID{}("2129442232")]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortMap{} [functional{}(), prefer{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(113,18,113,84)"), function{}(), productionID{}("1948810915")]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(SortFloat{}) : SortString{} [klabel{}("Float2String"), functional{}(), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(508,21,508,93)"), function{}(), productionID{}("1197251633")]
+  symbol LblisId{}(SortK{}) : SortBool{} [function{}(), predicate{}("Id"), originalPrd{}(), functional{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [klabel{}("String2Int"), functional{}(), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(511,21,511,91)"), function{}(), productionID{}("1383519982")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(352,18,352,131)"), function{}(), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1880078449")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), smtlib{}("distinct"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(280,19,280,91)"), function{}(), left{}(), productionID{}("2038522556")]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [klabel{}("signExtendBitRangeInt"), functional{}(), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,18,365,118)"), function{}(), productionID{}("800088638")]
+  symbol LblinitTCell{}(SortMap{}) : SortTCell{} [functional{}(), originalPrd{}(), function{}(), noThread{}(), initializer{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}(), functional{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [klabel{}("lengthString"), functional{}(), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(498,18,498,72)"), function{}(), productionID{}("1899600175")]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortK{}) : SortK{} [klabel{}("Map:lookup"), functional{}(), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(108,16,108,104)"), function{}(), symbol'Kywd'{}(), productionID{}("943573036")]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), predicate{}("String"), originalPrd{}(), functional{}()]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(SortId{}) : SortString{} [klabel{}("Id2String"), functional{}(), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(703,21,703,77)"), function{}(), productionID{}("116669570")]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("xor"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(274,19,274,102)"), function{}(), left{}(), productionID{}("2109839984")]
+  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("mod"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(346,18,346,93)"), function{}(), left{}(), productionID{}("1865859824")]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,18,120,108)"), function{}(), latex{}("{#1}-_{\\it Map}{#2}"), productionID{}("735937428")]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}(), functional{}()]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [klabel{}("substrString"), functional{}(), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(502,21,502,87)"), function{}(), productionID{}("684566052")]
+  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,18,358,128)"), function{}(), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("504807594")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [klabel{}("updateMap"), functional{}(), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,79)"), function{}(), productionID{}("1604247316")]
+  symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("or"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(276,19,276,104)"), function{}(), left{}(), productionID{}("508512860")]
+  symbol Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(SortK{}, SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortK{} [klabel{}("List:get"), functional{}(), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,16,240,94)"), function{}(), symbol'Kywd'{}(), productionID{}("1309335839")]
+  symbol Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), strict{}(""), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(), productionID{}("284686302")]
+  symbol Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [klabel{}("notBool_"), functional{}(), boolOperation{}(), smtlib{}("not"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,19,271,162)"), function{}(), symbol'Kywd'{}(), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), productionID{}("459718907")]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [klabel{}("keys"), functional{}(), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(131,18,131,74)"), function{}(), productionID{}("788625466")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [klabel{}("List:range"), functional{}(), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(243,19,243,98)"), function{}(), symbol'Kywd'{}(), productionID{}("596470015")]
+  symbol Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), strict{}(""), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(), productionID{}("1940445711")]
+  symbol Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(SortStmt{}, SortStmt{}) : SortStmt{} [functional{}(), format{}("%1%n%2"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(45,20,45,68)"), left{}(), productionID{}("808417649")]
+  symbol Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("=>"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,105)"), function{}(), left{}(), productionID{}("925973605")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,79)"), function{}(), productionID{}("2059572982")]
+  symbol Lbl'-LT-'state'-GT-'{}(SortMap{}) : SortStateCell{} [functional{}(), format{}("%1%i%n%2%d%n%3"), constructor{}(), contentStartLine{}("84"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("17"), cell{}(), originalPrd{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), color{}("red"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(84,17,87,21)")]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(529,19,529,70)"), function{}(), productionID{}("2113604623")]
+  symbol LblisStateCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCell"), originalPrd{}(), functional{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortK{} [klabel{}("Set:choice"), functional{}(), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(184,16,184,90)"), function{}(), productionID{}("839998248")]
+  symbol Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}() : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [klabel{}("sizeList"), functional{}(), smtlib{}("smt_seq_len"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(249,18,249,109)"), function{}(), productionID{}("1481818223")]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(351,18,351,131)"), function{}(), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("704106237")]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortK{}, SortK{}) : SortMap{} [klabel{}("_|->_"), functional{}(), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(102,18,102,124)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}\\mapsto{#2}"), productionID{}("52514534")]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(SortK{}, SortList{}) : SortBool{} [klabel{}("_inList_"), functional{}(), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(246,19,246,85)"), function{}(), productionID{}("1267105885")]
+  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("*"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,18,339,143)"), function{}(), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1237912220")]
+  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), smtlib{}(">"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(385,19,385,133)"), function{}(), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1834361038")]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [klabel{}("directionalityChar"), functional{}(), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(532,21,532,86)"), function{}(), productionID{}("379303133")]
+  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("div"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(342,18,342,146)"), function{}(), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("757708014")]
+  hooked-symbol LblSetItem{}(SortK{}) : SortSet{} [klabel{}("SetItem"), functional{}(), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(166,18,166,96)"), function{}(), symbol'Kywd'{}(), productionID{}("1358343316")]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [klabel{}("rfindChar"), functional{}(), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(506,18,506,90)"), function{}(), productionID{}("1473981203")]
+  symbol LblinitStateCell{}() : SortStateCell{} [functional{}(), originalPrd{}(), function{}(), noThread{}(), initializer{}()]
+  symbol Lbl'Stop'Map{}() : SortMap{} [klabel{}(".Map"), functional{}(), constructor{}(), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(97,18,97,116)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{Map}"), productionID{}("102174918")]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("int_min"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(359,18,359,90)"), function{}(), productionID{}("332873513")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("intersectSet"), functional{}(), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(169,18,169,76)"), function{}(), productionID{}("1824837049")]
+  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [functional{}(), smtlib{}("<"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,133)"), function{}(), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("1541525668")]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}(), functional{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("Set:difference"), functional{}(), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(172,18,172,134)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}-_{\\it Set}{#2}"), productionID{}("672746064")]
+  symbol Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [klabel{}("findString"), functional{}(), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(503,18,503,85)"), function{}(), productionID{}("352367347")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(178,19,178,73)"), function{}(), productionID{}("442199874")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [klabel{}("removeAll"), functional{}(), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,18,128,79)"), function{}(), productionID{}("1752461090")]
+  symbol Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}(), functional{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}() : SortBlock{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(38,20,38,26)"), productionID{}("1860491691")]
+  symbol LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(SortInt{}) : SortId{} [klabel{}("freshId"), freshGenerator{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(705,17,705,58)"), function{}(), productionID{}("554348863")]
+  symbol Lbl'-LT-'T'-GT-'-fragment{}(SortKCellOpt{}, SortStateCellOpt{}) : SortTCellFragment{} [cellFragment{}("TCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), smtlib{}("="), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,84)"), function{}(), left{}(), productionID{}("1179792105")]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("-"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,18,349,140)"), function{}(), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("304354378")]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}(), functional{}()]
+  symbol LblisPgm{}(SortK{}) : SortBool{} [function{}(), predicate{}("Pgm"), originalPrd{}(), functional{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("int_max"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(360,18,360,90)"), function{}(), productionID{}("90567568")]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), format{}("%1%i%n%2%d%n%3"), constructor{}(), contentStartLine{}("84"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("17"), cell{}(), originalPrd{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), maincell{}(), color{}("green"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(84,17,87,21)")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [klabel{}("_andBool_"), functional{}(), boolOperation{}(), smtlib{}("and"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(272,19,272,175)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(), productionID{}("1041109062")]
+  symbol LblisAExp{}(SortK{}) : SortBool{} [function{}(), predicate{}("AExp"), originalPrd{}(), functional{}()]
+  symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("_Set_"), idem{}(), functional{}(), element{}("SetItem"), format{}("%1%n%2"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".Set"), comm{}(), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(159,18,159,164)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("1342346098")]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [klabel{}("String2Base"), functional{}(), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(514,21,514,92)"), function{}(), productionID{}("462526099")]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [klabel{}("FloatFormat"), functional{}(), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(509,21,509,113)"), function{}(), productionID{}("1552326679")]
+  symbol Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(SortBExp{}, SortBlock{}, SortBlock{}) : SortStmt{} [functional{}(), strict{}("1"), format{}("%1 %2%3%4 %5 %6 %7"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), colors{}("yellow, white, white, yellow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), productionID{}("1350751778")]
+  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), smtlib{}("^"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,18,336,151)"), function{}(), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), left{}(), productionID{}("479920916")]
+  symbol Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(SortK{}, SortK{}) : SortBool{} [functional{}(), notEqualEqualK{}(), smtlib{}("distinct"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(728,19,728,132)"), function{}(), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), productionID{}("1367937032")]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), predicate{}("Float"), originalPrd{}(), functional{}()]
+  symbol Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(SortStmt{}) : SortBlock{} [functional{}(), format{}("%1%i%n%2%d%n%3"), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(39,20,39,70)"), productionID{}("1515403487")]
+  symbol LblisBlock{}(SortK{}) : SortBool{} [function{}(), predicate{}("Block"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(SortK{}, SortMap{}) : SortBool{} [functional{}(), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,19,134,77)"), function{}(), productionID{}("1095273238")]
 
 // generated axioms
-  axiom{R} \exists{R} (Val:KCell{}, \equals{KCell{}, R} (Val:KCell{}, LblinitKCell{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, Lbl'Stop'Set{}())) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblInt2String{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EBADF'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, LblgetKLabel{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:BExp{}, \equals{BExp{}, R} (Val:BExp{}, Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(K0:BExp{}))) [] // functional
-  axiom{}\implies{BExp{}} (\and{BExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:BExp{}), Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(Y0:BExp{})), Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(\and{BExp{}} (X0:BExp{}, Y0:BExp{}))) [] // no confusion same constructor
-  axiom{}\not{BExp{}} (\and{BExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:BExp{}), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{}))) [] // no confusion different constructors
-  axiom{}\not{BExp{}} (\and{BExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:BExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:BExp{}, Y1:BExp{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisKResult{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblchrChar{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EOF'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:String{}, K1:String{}, K2:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Stream{}, \equals{Stream{}, R} (Val:Stream{}, Lbl'Hash'buffer{}(K0:K{}))) [] // functional
-  axiom{}\implies{Stream{}} (\and{Stream{}} (Lbl'Hash'buffer{}(X0:K{}), Lbl'Hash'buffer{}(Y0:K{})), Lbl'Hash'buffer{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Pgm{}, \equals{Pgm{}, R} (Val:Pgm{}, Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(K0:Ids{}, K1:Stmt{}))) [] // functional
-  axiom{}\implies{Pgm{}} (\and{Pgm{}} (Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(X0:Ids{}, X1:Stmt{}), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Y0:Ids{}, Y1:Stmt{})), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(\and{Ids{}} (X0:Ids{}, Y0:Ids{}), \and{Stmt{}} (X1:Stmt{}, Y1:Stmt{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:K{}, K1:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EACCES'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, LblListItem{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisStateCellOpt{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, LblintersectSet{}(K0:Set{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisKCellOpt{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'unknownIOError{}(Y0:Int{}))) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Stmt{}, \equals{Stmt{}, R} (Val:Stmt{}, Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(K0:Id{}, K1:AExp{}))) [] // functional
-  axiom{}\implies{Stmt{}} (\and{Stmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:Id{}, X1:AExp{}), Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(Y0:Id{}, Y1:AExp{})), Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(\and{Id{}} (X0:Id{}, Y0:Id{}), \and{AExp{}} (X1:AExp{}, Y1:AExp{}))) [] // no confusion same constructor
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:Id{}, X1:AExp{}), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(Y0:BExp{}, Y1:Block{}))) [] // no confusion different constructors
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:Id{}, X1:AExp{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:Stmt{}, Y1:Stmt{}))) [] // no confusion different constructors
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:Id{}, X1:AExp{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:BExp{}, Y1:Block{}, Y2:Block{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'unknownIOError{}(K0:Int{}))) [] // functional
-  axiom{}\implies{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'unknownIOError{}(Y0:Int{})), Lbl'Hash'unknownIOError{}(\and{Int{}} (X0:Int{}, Y0:Int{}))) [] // no confusion same constructor
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'unknownIOError{}(X0:Int{}), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisBool{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:Map{}, K1:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, LblremoveAll{}(K0:Map{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:TCell{}, \equals{TCell{}, R} (Val:TCell{}, Lbl'-LT-'T'-GT-'{}(K0:KCell{}, K1:StateCell{}))) [] // functional
-  axiom{}\implies{TCell{}} (\and{TCell{}} (Lbl'-LT-'T'-GT-'{}(X0:KCell{}, X1:StateCell{}), Lbl'-LT-'T'-GT-'{}(Y0:KCell{}, Y1:StateCell{})), Lbl'-LT-'T'-GT-'{}(\and{KCell{}} (X0:KCell{}, Y0:KCell{}), \and{StateCell{}} (X1:StateCell{}, Y1:StateCell{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisTCell{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblSet'Coln'in{}(K0:K{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Hash'stdout'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Hash'isConcrete{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, Lbl'Hash'argv{}())) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblsrandInt{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisIds{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblrandInt{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisStmt{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblMap'Coln'choice{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:BExp{}, \equals{BExp{}, R} (Val:BExp{}, Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:AExp{}, K1:AExp{}))) [] // functional
-  axiom{}\implies{BExp{}} (\and{BExp{}} (Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{})), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{AExp{}} (X0:AExp{}, Y0:AExp{}), \and{AExp{}} (X1:AExp{}, Y1:AExp{}))) [] // no confusion same constructor
-  axiom{}\not{BExp{}} (\and{BExp{}} (Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:BExp{}, Y1:BExp{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \equals{Map{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:Map{},K2:Map{}),K3:Map{}),Lbl'Unds'Map'Unds'{}(K1:Map{},Lbl'Unds'Map'Unds'{}(K2:Map{},K3:Map{}))) [] // associativity
-  axiom{R} \equals{Map{}, R} (Lbl'Unds'Map'Unds'{}(K1:Map{},K2:Map{}),Lbl'Unds'Map'Unds'{}(K2:Map{},K1:Map{})) [] // commutativity
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'Unds'Map'Unds'{}(K0:Map{}, K1:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \equals{List{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:List{},K2:List{}),K3:List{}),Lbl'Unds'List'Unds'{}(K1:List{},Lbl'Unds'List'Unds'{}(K2:List{},K3:List{}))) [] // associativity
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, Lbl'Unds'List'Unds'{}(K0:List{}, K1:List{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblSet'Coln'choice{}(K0:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisBExp{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EPERM'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(K0:Int{}, K1:Int{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:String{}, K1:String{}, K2:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:K{}, Y1:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:Int{}, Y1:String{}, Y2:String{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:AExp{}, \equals{AExp{}, R} (Val:AExp{}, Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(K0:Int{}))) [] // functional
-  axiom{}\implies{AExp{}} (\and{AExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:Int{}), Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(Y0:Int{})), Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(\and{Int{}} (X0:Int{}, Y0:Int{}))) [] // no confusion same constructor
-  axiom{}\not{AExp{}} (\and{AExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:Int{}), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{}))) [] // no confusion different constructors
-  axiom{}\not{AExp{}} (\and{AExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:Int{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbllog2Int{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lblsize{}(K0:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:Stmt{}, \equals{Stmt{}, R} (Val:Stmt{}, Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(K0:BExp{}, K1:Block{}))) [] // functional
-  axiom{}\implies{Stmt{}} (\and{Stmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:BExp{}, X1:Block{}), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(Y0:BExp{}, Y1:Block{})), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(\and{BExp{}} (X0:BExp{}, Y0:BExp{}), \and{Block{}} (X1:Block{}, Y1:Block{}))) [] // no confusion same constructor
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:BExp{}, X1:Block{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:Stmt{}, Y1:Stmt{}))) [] // no confusion different constructors
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:BExp{}, X1:Block{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:BExp{}, Y1:Block{}, Y2:Block{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:BExp{}, \equals{BExp{}, R} (Val:BExp{}, Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(K0:BExp{}, K1:BExp{}))) [] // functional
-  axiom{}\implies{BExp{}} (\and{BExp{}} (Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(X0:BExp{}, X1:BExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:BExp{}, Y1:BExp{})), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(\and{BExp{}} (X0:BExp{}, Y0:BExp{}), \and{BExp{}} (X1:BExp{}, Y1:BExp{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblfindChar{}(K0:String{}, K1:String{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EDOM'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisK{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'inList'Unds'{}(K0:K{}, K1:List{}))) [] // functional
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, Lbl'Stop'List{}())) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(K0:String{}, K1:String{}, K2:String{}, K3:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisMap{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:StateCellOpt{}, \equals{StateCellOpt{}, R} (Val:StateCellOpt{}, LblnoStateCell{}())) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisTCellFragment{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:K{}, Y1:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:Int{}, Y1:String{}, Y2:String{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(K0:Int{}))) [] // functional
-  axiom{R, S0} \exists{R} (Val:S0, \equals{S0, R} (Val:S0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{S0}(K0:Bool{}, K1:S0, K2:S0))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EIO'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:Map{}, K1:K{}, K2:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblString2Base{}(K0:String{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisId{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LbllengthString{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:TCell{}, \equals{TCell{}, R} (Val:TCell{}, LblinitTCell{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisSet{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsEqls'Int'Unds'{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Id{}, \equals{Id{}, R} (Val:Id{}, LblfreshId{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, LblupdateMap{}(K0:Map{}, K1:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblrfindChar{}(K0:String{}, K1:String{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblMap'Coln'lookup{}(K0:Map{}, K1:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisString{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, Lblvalues{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, Lbl'Hash'sort{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:Map{}, K1:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisInt{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblfindString{}(K0:String{}, K1:String{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Ids{}, \equals{Ids{}, R} (Val:Ids{}, Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(K0:Id{}, K1:Ids{}))) [] // functional
-  axiom{}\implies{Ids{}} (\and{Ids{}} (Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(X0:Id{}, X1:Ids{}), Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(Y0:Id{}, Y1:Ids{})), Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(\and{Id{}} (X0:Id{}, Y0:Id{}), \and{Ids{}} (X1:Ids{}, Y1:Ids{}))) [] // no confusion same constructor
-  axiom{}\not{Ids{}} (\and{Ids{}} (Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(X0:Id{}, X1:Ids{}), Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsQuotRBraUnds'Ids{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisStream{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Float{}, \equals{Float{}, R} (Val:Float{}, LblString2Float{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Hash'stderr'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisCell{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:Id{}, \equals{Id{}, R} (Val:Id{}, LblString2Id{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(K0:K{}, K1:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:K{}, Y1:K{})), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}), \and{K{}} (X1:K{}, Y1:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:Int{}, Y1:String{}, Y2:String{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(K0:Int{}, K1:String{}, K2:String{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(Y0:Int{}, Y1:String{}, Y2:String{})), Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(\and{Int{}} (X0:Int{}, Y0:Int{}), \and{String{}} (X1:String{}, Y1:String{}), \and{String{}} (X2:String{}, Y2:String{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblList'Coln'get{}(K0:List{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:AExp{}, \equals{AExp{}, R} (Val:AExp{}, Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:AExp{}, K1:AExp{}))) [] // functional
-  axiom{}\implies{AExp{}} (\and{AExp{}} (Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{})), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{AExp{}} (X0:AExp{}, Y0:AExp{}), \and{AExp{}} (X1:AExp{}, Y1:AExp{}))) [] // no confusion same constructor
-  axiom{}\not{AExp{}} (\and{AExp{}} (Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblsizeMap{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblId2String{}(K0:Id{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{})), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblnotBool'Unds'{}(K0:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:List{}, \equals{List{}, R} (Val:List{}, LblList'Coln'range{}(K0:List{}, K1:Int{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:AExp{}, \equals{AExp{}, R} (Val:AExp{}, Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:AExp{}, K1:AExp{}))) [] // functional
-  axiom{}\implies{AExp{}} (\and{AExp{}} (Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:AExp{}, Y1:AExp{})), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{AExp{}} (X0:AExp{}, Y0:AExp{}), \and{AExp{}} (X1:AExp{}, Y1:AExp{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Ids{}, \equals{Ids{}, R} (Val:Ids{}, Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsQuotRBraUnds'Ids{}())) [] // functional
-  axiom{R} \exists{R} (Val:Stmt{}, \equals{Stmt{}, R} (Val:Stmt{}, Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(K0:Stmt{}, K1:Stmt{}))) [] // functional
-  axiom{}\implies{Stmt{}} (\and{Stmt{}} (Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:Stmt{}, X1:Stmt{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:Stmt{}, Y1:Stmt{})), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(\and{Stmt{}} (X0:Stmt{}, Y0:Stmt{}), \and{Stmt{}} (X1:Stmt{}, Y1:Stmt{}))) [] // no confusion same constructor
-  axiom{}\not{Stmt{}} (\and{Stmt{}} (Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:Stmt{}, X1:Stmt{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:BExp{}, Y1:Block{}, Y2:Block{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{})), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:Map{}, K1:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblrfindString{}(K0:String{}, K1:String{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:StateCell{}, \equals{StateCell{}, R} (Val:StateCell{}, Lbl'-LT-'state'-GT-'{}(K0:Map{}))) [] // functional
-  axiom{}\implies{StateCell{}} (\and{StateCell{}} (Lbl'-LT-'state'-GT-'{}(X0:Map{}), Lbl'-LT-'state'-GT-'{}(Y0:Map{})), Lbl'-LT-'state'-GT-'{}(\and{Map{}} (X0:Map{}, Y0:Map{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblFloat2String{}(K0:Float{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:String{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisStateCell{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [] // functional
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:K{}, K1:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:K{}, \equals{K{}, R} (Val:K{}, LblMap'Coln'lookupOrDefault{}(K0:Map{}, K1:K{}, K2:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'noparse'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisList{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EINTR'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblcategoryChar{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblBase2String{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, LblSetItem{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:StateCell{}, \equals{StateCell{}, R} (Val:StateCell{}, LblinitStateCell{}())) [] // functional
-  axiom{R} \exists{R} (Val:Map{}, \equals{Map{}, R} (Val:Map{}, Lbl'Stop'Map{}())) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, Lblkeys{}(K0:Map{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisKItem{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, LblSet'Coln'difference{}(K0:Set{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Hash'open'LParUndsRParUnds'K-IO'UndsUnds'String{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblString2Int{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:Set{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LbldirectionalityChar{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblsizeList{}(K0:List{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisKConfigVar{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{}\not{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Block{}, \equals{Block{}, R} (Val:Block{}, Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}())) [] // functional
-  axiom{}\not{Block{}} (\and{Block{}} (Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}(), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Y0:Stmt{}))) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Hash'stdin'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{R} \exists{R} (Val:TCellFragment{}, \equals{TCellFragment{}, R} (Val:TCellFragment{}, Lbl'-LT-'T'-GT-'-fragment{}(K0:KCellOpt{}, K1:StateCellOpt{}))) [] // functional
-  axiom{}\implies{TCellFragment{}} (\and{TCellFragment{}} (Lbl'-LT-'T'-GT-'-fragment{}(X0:KCellOpt{}, X1:StateCellOpt{}), Lbl'-LT-'T'-GT-'-fragment{}(Y0:KCellOpt{}, Y1:StateCellOpt{})), Lbl'-LT-'T'-GT-'-fragment{}(\and{KCellOpt{}} (X0:KCellOpt{}, Y0:KCellOpt{}), \and{StateCellOpt{}} (X1:StateCellOpt{}, Y1:StateCellOpt{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:KCellOpt{}, \equals{KCellOpt{}, R} (Val:KCellOpt{}, LblnoKCell{}())) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisKCell{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblFloatFormat{}(K0:Float{}, K1:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisPgm{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}(), Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:String{}, \equals{String{}, R} (Val:String{}, LblsubstrString{}(K0:String{}, K1:Int{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:KCell{}, \equals{KCell{}, R} (Val:KCell{}, Lbl'-LT-'k'-GT-'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KCell{}} (\and{KCell{}} (Lbl'-LT-'k'-GT-'{}(X0:K{}), Lbl'-LT-'k'-GT-'{}(Y0:K{})), Lbl'-LT-'k'-GT-'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblabsInt{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'andBool'Unds'{}(K0:Bool{}, K1:Bool{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisAExp{}(K0:K{}))) [] // functional
-  axiom{R} \equals{Set{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:Set{},K2:Set{}),K3:Set{}),Lbl'Unds'Set'Unds'{}(K1:Set{},Lbl'Unds'Set'Unds'{}(K2:Set{},K3:Set{}))) [] // associativity
-  axiom{R} \equals{Set{}, R} (Lbl'Unds'Set'Unds'{}(K1:Set{},K2:Set{}),Lbl'Unds'Set'Unds'{}(K2:Set{},K1:Set{})) [] // commutativity
-  axiom{R} \equals{Set{}, R} (Lbl'Unds'Set'Unds'{}(K:Set{},K:Set{}),K:Set{}) [] // idempotency
-  axiom{R} \exists{R} (Val:Set{}, \equals{Set{}, R} (Val:Set{}, Lbl'Unds'Set'Unds'{}(K0:Set{}, K1:Set{}))) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblfreshInt{}(K0:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Stmt{}, \equals{Stmt{}, R} (Val:Stmt{}, Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(K0:BExp{}, K1:Block{}, K2:Block{}))) [] // functional
-  axiom{}\implies{Stmt{}} (\and{Stmt{}} (Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(X0:BExp{}, X1:Block{}, X2:Block{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:BExp{}, Y1:Block{}, Y2:Block{})), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(\and{BExp{}} (X0:BExp{}, Y0:BExp{}), \and{Block{}} (X1:Block{}, Y1:Block{}), \and{Block{}} (X2:Block{}, Y2:Block{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, Lbl'UndsXor-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:Int{}, K1:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:KItem{}, \equals{KItem{}, R} (Val:KItem{}, Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(K0:K{}))) [] // functional
-  axiom{}\implies{KItem{}} (\and{KItem{}} (Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(X0:K{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:K{})), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(\and{K{}} (X0:K{}, Y0:K{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblbitRangeInt{}(K0:Int{}, K1:Int{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EROFS'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EROFS'Unds'K-IO'Unds'{}(), Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EROFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EROFS'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblordChar{}(K0:String{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(K0:K{}, K1:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisIOError{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisFloat{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{}\not{IOError{}} (\and{IOError{}} (Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}(), Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // no confusion different constructors
-  axiom{R} \exists{R} (Val:IOError{}, \equals{IOError{}, R} (Val:IOError{}, Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}())) [] // functional
-  axiom{R} \exists{R} (Val:Int{}, \equals{Int{}, R} (Val:Int{}, LblsignExtendBitRangeInt{}(K0:Int{}, K1:Int{}, K2:Int{}))) [] // functional
-  axiom{R} \exists{R} (Val:Block{}, \equals{Block{}, R} (Val:Block{}, Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(K0:Stmt{}))) [] // functional
-  axiom{}\implies{Block{}} (\and{Block{}} (Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(X0:Stmt{}), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Y0:Stmt{})), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(\and{Stmt{}} (X0:Stmt{}, Y0:Stmt{}))) [] // no confusion same constructor
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, LblisBlock{}(K0:K{}))) [] // functional
-  axiom{R} \exists{R} (Val:Bool{}, \equals{Bool{}, R} (Val:Bool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(K0:K{}, K1:Map{}))) [] // functional
-  axiom{} \or{KItem{}} (\exists{KItem{}} (Val:Int{}, inj{Int{}, KItem{}} (Val:Int{})), \or{KItem{}} (\exists{KItem{}} (Val:Pgm{}, inj{Pgm{}, KItem{}} (Val:Pgm{})), \or{KItem{}} (\exists{KItem{}} (Val:KCell{}, inj{KCell{}, KItem{}} (Val:KCell{})), \or{KItem{}} (\exists{KItem{}} (Val:StateCellOpt{}, inj{StateCellOpt{}, KItem{}} (Val:StateCellOpt{})), \or{KItem{}} (\exists{KItem{}} (Val:Set{}, inj{Set{}, KItem{}} (Val:Set{})), \or{KItem{}} (\exists{KItem{}} (Val:AExp{}, inj{AExp{}, KItem{}} (Val:AExp{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (Val:Map{}, inj{Map{}, KItem{}} (Val:Map{})), \or{KItem{}} (\exists{KItem{}} (Val:TCell{}, inj{TCell{}, KItem{}} (Val:TCell{})), \or{KItem{}} (\exists{KItem{}} (Val:List{}, inj{List{}, KItem{}} (Val:List{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (Val:IOError{}, inj{IOError{}, KItem{}} (Val:IOError{})), \or{KItem{}} (\exists{KItem{}} (Val:TCellFragment{}, inj{TCellFragment{}, KItem{}} (Val:TCellFragment{})), \or{KItem{}} (\exists{KItem{}} (Val:StateCell{}, inj{StateCell{}, KItem{}} (Val:StateCell{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, \exists{KItem{}} (X1:K{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:K{}, X1:K{}))), \or{KItem{}} (\exists{KItem{}} (X0:Int{}, \exists{KItem{}} (X1:String{}, \exists{KItem{}} (X2:String{}, Lbl'Hash'systemResult'LParUndsCommUndsCommUndsRParUnds'K-IO'UndsUnds'Int'Unds'String'Unds'String{}(X0:Int{}, X1:String{}, X2:String{})))), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (Val:Cell{}, inj{Cell{}, KItem{}} (Val:Cell{})), \or{KItem{}} (\exists{KItem{}} (Val:Bool{}, inj{Bool{}, KItem{}} (Val:Bool{})), \or{KItem{}} (\exists{KItem{}} (Val:Float{}, inj{Float{}, KItem{}} (Val:Float{})), \or{KItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), \or{KItem{}} (\exists{KItem{}} (Val:Ids{}, inj{Ids{}, KItem{}} (Val:Ids{})), \or{KItem{}} (\exists{KItem{}} (Val:Id{}, inj{Id{}, KItem{}} (Val:Id{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (Val:Stmt{}, inj{Stmt{}, KItem{}} (Val:Stmt{})), \or{KItem{}} (\exists{KItem{}} (Val:BExp{}, inj{BExp{}, KItem{}} (Val:BExp{})), \or{KItem{}} (\exists{KItem{}} (Val:KCellOpt{}, inj{KCellOpt{}, KItem{}} (Val:KCellOpt{})), \or{KItem{}} (\exists{KItem{}} (X0:K{}, Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(X0:K{})), \or{KItem{}} (\exists{KItem{}} (Val:String{}, inj{String{}, KItem{}} (Val:String{})), \or{KItem{}} (\exists{KItem{}} (Val:KResult{}, inj{KResult{}, KItem{}} (Val:KResult{})), \or{KItem{}} (\exists{KItem{}} (Val:Stream{}, inj{Stream{}, KItem{}} (Val:Stream{})), \or{KItem{}} (\exists{KItem{}} (Val:Block{}, inj{Block{}, KItem{}} (Val:Block{})), \bottom{KItem{}}()))))))))))))))))))))))))))))))))))) [] // no junk
-  axiom{} \or{List{}} (\exists{List{}} (X0:List{}, \exists{List{}} (X1:List{}, Lbl'Unds'List'Unds'{}(X0:List{}, X1:List{}))), \or{List{}} (Lbl'Stop'List{}(), \bottom{List{}}())) [] // no junk
-  axiom{} \or{TCellFragment{}} (\exists{TCellFragment{}} (X0:KCellOpt{}, \exists{TCellFragment{}} (X1:StateCellOpt{}, Lbl'-LT-'T'-GT-'-fragment{}(X0:KCellOpt{}, X1:StateCellOpt{}))), \bottom{TCellFragment{}}()) [] // no junk
-  axiom{} \or{String{}} (\top{String{}}(), \bottom{String{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{StateCell{}} (\exists{StateCell{}} (X0:Map{}, Lbl'-LT-'state'-GT-'{}(X0:Map{})), \bottom{StateCell{}}()) [] // no junk
-  axiom{} \or{KConfigVar{}} (\top{KConfigVar{}}(), \bottom{KConfigVar{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{TCell{}} (\exists{TCell{}} (X0:KCell{}, \exists{TCell{}} (X1:StateCell{}, Lbl'-LT-'T'-GT-'{}(X0:KCell{}, X1:StateCell{}))), \bottom{TCell{}}()) [] // no junk
-  axiom{} \or{Ids{}} (\exists{Ids{}} (X0:Id{}, \exists{Ids{}} (X1:Ids{}, Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(X0:Id{}, X1:Ids{}))), \or{Ids{}} (Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsQuotRBraUnds'Ids{}(), \bottom{Ids{}}())) [] // no junk
-  axiom{} \or{BExp{}} (\exists{BExp{}} (X0:BExp{}, Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:BExp{})), \or{BExp{}} (\exists{BExp{}} (X0:AExp{}, \exists{BExp{}} (X1:AExp{}, Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}))), \or{BExp{}} (\exists{BExp{}} (X0:BExp{}, \exists{BExp{}} (X1:BExp{}, Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(X0:BExp{}, X1:BExp{}))), \or{BExp{}} (\exists{BExp{}} (Val:Bool{}, inj{Bool{}, BExp{}} (Val:Bool{})), \bottom{BExp{}}())))) [] // no junk
-  axiom{} \or{StateCellOpt{}} (LblnoStateCell{}(), \or{StateCellOpt{}} (\exists{StateCellOpt{}} (Val:StateCell{}, inj{StateCell{}, StateCellOpt{}} (Val:StateCell{})), \bottom{StateCellOpt{}}())) [] // no junk
-  axiom{} \or{Id{}} (\top{Id{}}(), \bottom{Id{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{Stream{}} (\exists{Stream{}} (X0:K{}, Lbl'Hash'buffer{}(X0:K{})), \bottom{Stream{}}()) [] // no junk
-  axiom{} \or{Cell{}} (\exists{Cell{}} (Val:KCell{}, inj{KCell{}, Cell{}} (Val:KCell{})), \or{Cell{}} (\exists{Cell{}} (Val:TCell{}, inj{TCell{}, Cell{}} (Val:TCell{})), \or{Cell{}} (\exists{Cell{}} (Val:StateCell{}, inj{StateCell{}, Cell{}} (Val:StateCell{})), \bottom{Cell{}}()))) [] // no junk
-  axiom{} \or{Bool{}} (\top{Bool{}}(), \bottom{Bool{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{KCell{}} (\exists{KCell{}} (X0:K{}, Lbl'-LT-'k'-GT-'{}(X0:K{})), \bottom{KCell{}}()) [] // no junk
-  axiom{} \or{K{}} (\exists{K{}} (Val:KItem{}, inj{KItem{}, K{}} (Val:KItem{})), \bottom{K{}}()) [] // no junk
-  axiom{} \or{KResult{}} (\exists{KResult{}} (Val:Int{}, inj{Int{}, KResult{}} (Val:Int{})), \or{KResult{}} (\exists{KResult{}} (Val:Bool{}, inj{Bool{}, KResult{}} (Val:Bool{})), \bottom{KResult{}}())) [] // no junk
-  axiom{} \or{Map{}} (\exists{Map{}} (X0:Map{}, \exists{Map{}} (X1:Map{}, Lbl'Unds'Map'Unds'{}(X0:Map{}, X1:Map{}))), \or{Map{}} (Lbl'Stop'Map{}(), \bottom{Map{}}())) [] // no junk
-  axiom{} \or{KCellOpt{}} (\exists{KCellOpt{}} (Val:KCell{}, inj{KCell{}, KCellOpt{}} (Val:KCell{})), \or{KCellOpt{}} (LblnoKCell{}(), \bottom{KCellOpt{}}())) [] // no junk
-  axiom{} \or{Stmt{}} (\exists{Stmt{}} (X0:Id{}, \exists{Stmt{}} (X1:AExp{}, Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:Id{}, X1:AExp{}))), \or{Stmt{}} (\exists{Stmt{}} (Val:Block{}, inj{Block{}, Stmt{}} (Val:Block{})), \or{Stmt{}} (\exists{Stmt{}} (X0:BExp{}, \exists{Stmt{}} (X1:Block{}, Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:BExp{}, X1:Block{}))), \or{Stmt{}} (\exists{Stmt{}} (X0:Stmt{}, \exists{Stmt{}} (X1:Stmt{}, Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:Stmt{}, X1:Stmt{}))), \or{Stmt{}} (\exists{Stmt{}} (X0:BExp{}, \exists{Stmt{}} (X1:Block{}, \exists{Stmt{}} (X2:Block{}, Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(X0:BExp{}, X1:Block{}, X2:Block{})))), \bottom{Stmt{}}()))))) [] // no junk
-  axiom{} \or{Int{}} (\top{Int{}}(), \bottom{Int{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{Float{}} (\top{Float{}}(), \bottom{Float{}}()) [] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{Pgm{}} (\exists{Pgm{}} (X0:Ids{}, \exists{Pgm{}} (X1:Stmt{}, Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(X0:Ids{}, X1:Stmt{}))), \bottom{Pgm{}}()) [] // no junk
-  axiom{} \or{Block{}} (Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}(), \or{Block{}} (\exists{Block{}} (X0:Stmt{}, Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(X0:Stmt{})), \bottom{Block{}}())) [] // no junk
-  axiom{} \or{Set{}} (Lbl'Stop'Set{}(), \or{Set{}} (\exists{Set{}} (X0:Set{}, \exists{Set{}} (X1:Set{}, Lbl'Unds'Set'Unds'{}(X0:Set{}, X1:Set{}))), \bottom{Set{}}())) [] // no junk
-  axiom{} \or{IOError{}} (Lbl'Hash'EBADF'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ESPIPE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EOVERFLOW'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENFILE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENETUNREACH'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EOF'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EXDEV'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EADDRNOTAVAIL'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EACCES'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOPROTOOPT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EAGAIN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENETDOWN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EISCONN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EPIPE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ECONNABORTED'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ESRCH'Unds'K-IO'Unds'{}(), \or{IOError{}} (\exists{IOError{}} (X0:Int{}, Lbl'Hash'unknownIOError{}(X0:Int{})), \or{IOError{}} (Lbl'Hash'EOPNOTSUPP'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOSPC'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EDEADLK'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ECONNREFUSED'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EPROTOTYPE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EAFNOSUPPORT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENXIO'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EWOULDBLOCK'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'E2BIG'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENETRESET'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EPERM'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOSYS'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EALREADY'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EHOSTDOWN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOTSOCK'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EDOM'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOBUFS'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ETIMEDOUT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ETOOMANYREFS'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EDESTADDRREQ'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOTTY'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ECONNRESET'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EMFILE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EIO'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOEXEC'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EPFNOSUPPORT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ESHUTDOWN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EINVAL'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EMLINK'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EISDIR'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EFBIG'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOTCONN'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENODEV'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EEXIST'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ELOOP'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOTEMPTY'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EHOSTUNREACH'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'noparse'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EINTR'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EMSGSIZE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOENT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOLCK'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EFAULT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ERANGE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EBUSY'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EINPROGRESS'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOMEM'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENOTDIR'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ENAMETOOLONG'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EADDRINUSE'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EROFS'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'EPROTONOSUPPORT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ESOCKTNOSUPPORT'Unds'K-IO'Unds'{}(), \or{IOError{}} (Lbl'Hash'ECHILD'Unds'K-IO'Unds'{}(), \bottom{IOError{}}()))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) [] // no junk
-  axiom{} \or{AExp{}} (\exists{AExp{}} (Val:Id{}, inj{Id{}, AExp{}} (Val:Id{})), \or{AExp{}} (\exists{AExp{}} (Val:Int{}, inj{Int{}, AExp{}} (Val:Int{})), \or{AExp{}} (\exists{AExp{}} (X0:Int{}, Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:Int{})), \or{AExp{}} (\exists{AExp{}} (X0:AExp{}, \exists{AExp{}} (X1:AExp{}, Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}))), \or{AExp{}} (\exists{AExp{}} (X0:AExp{}, \exists{AExp{}} (X1:AExp{}, Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:AExp{}, X1:AExp{}))), \bottom{AExp{}}()))))) [] // no junk
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, LblinitKCell{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBExp{}, \equals{SortBExp{}, R} (Val:SortBExp{}, Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(K0:SortBExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortBExp{}} (\and{SortBExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:SortBExp{}), Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(Y0:SortBExp{})), Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(\and{SortBExp{}} (X0:SortBExp{}, Y0:SortBExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortBExp{}} (\and{SortBExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:SortBExp{}), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortBExp{}} (\and{SortBExp{}} (Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:SortBExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:SortBExp{}, Y1:SortBExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKResult{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblchrChar'LParUndsRParUnds'STRING'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFloat{}, \equals{SortFloat{}, R} (Val:SortFloat{}, LblString2Float'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortPgm{}, \equals{SortPgm{}, R} (Val:SortPgm{}, Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(K0:SortIds{}, K1:SortStmt{}))) [functional{}()] // functional
+  axiom{}\implies{SortPgm{}} (\and{SortPgm{}} (Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(X0:SortIds{}, X1:SortStmt{}), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Y0:SortIds{}, Y1:SortStmt{})), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(\and{SortIds{}} (X0:SortIds{}, Y0:SortIds{}), \and{SortStmt{}} (X1:SortStmt{}, Y1:SortStmt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbllog2Int'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStateCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblordChar'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStmt{}, \equals{SortStmt{}, R} (Val:SortStmt{}, Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(K0:SortId{}, K1:SortAExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:SortId{}, X1:SortAExp{}), Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(Y0:SortId{}, Y1:SortAExp{})), Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(\and{SortId{}} (X0:SortId{}, Y0:SortId{}), \and{SortAExp{}} (X1:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:SortId{}, X1:SortAExp{}), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:SortId{}, X1:SortAExp{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:SortStmt{}, Y1:SortStmt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:SortId{}, X1:SortAExp{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{}, Y2:SortBlock{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCell{}, \equals{SortTCell{}, R} (Val:SortTCell{}, Lbl'-LT-'T'-GT-'{}(K0:SortKCell{}, K1:SortStateCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCell{}} (\and{SortTCell{}} (Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortStateCell{}), Lbl'-LT-'T'-GT-'{}(Y0:SortKCell{}, Y1:SortStateCell{})), Lbl'-LT-'T'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortStateCell{}} (X1:SortStateCell{}, Y1:SortStateCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisTCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortK{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIds{}, \equals{SortIds{}, R} (Val:SortIds{}, Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids'QuotRBraUnds'Ids{}())) [functional{}()] // functional
+  axiom{}\not{SortIds{}} (\and{SortIds{}} (Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids'QuotRBraUnds'Ids{}(), Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(Y0:SortId{}, Y1:SortIds{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIds{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStmt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBExp{}, \equals{SortBExp{}, R} (Val:SortBExp{}, Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:SortAExp{}, K1:SortAExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortBExp{}} (\and{SortBExp{}} (Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{})), Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{SortAExp{}} (X0:SortAExp{}, Y0:SortAExp{}), \and{SortAExp{}} (X1:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortBExp{}} (\and{SortBExp{}} (Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:SortBExp{}, Y1:SortBExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'Map'Unds'{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(K0:SortString{}, K1:SortString{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBase2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortIds{}, \equals{SortIds{}, R} (Val:SortIds{}, Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(K0:SortId{}, K1:SortIds{}))) [functional{}()] // functional
+  axiom{}\implies{SortIds{}} (\and{SortIds{}} (Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(X0:SortId{}, X1:SortIds{}), Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(Y0:SortId{}, Y1:SortIds{})), Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(\and{SortId{}} (X0:SortId{}, Y0:SortId{}), \and{SortIds{}} (X1:SortIds{}, Y1:SortIds{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortAExp{}, \equals{SortAExp{}, R} (Val:SortAExp{}, Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortAExp{}} (\and{SortAExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:SortInt{}), Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(Y0:SortInt{})), Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortAExp{}} (\and{SortAExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:SortInt{}), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortAExp{}} (\and{SortAExp{}} (Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:SortInt{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStmt{}, \equals{SortStmt{}, R} (Val:SortStmt{}, Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(K0:SortBExp{}, K1:SortBlock{}))) [functional{}()] // functional
+  axiom{}\implies{SortStmt{}} (\and{SortStmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{})), Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(\and{SortBExp{}} (X0:SortBExp{}, Y0:SortBExp{}), \and{SortBlock{}} (X1:SortBlock{}, Y1:SortBlock{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:SortStmt{}, Y1:SortStmt{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{}, Y2:SortBlock{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBExp{}, \equals{SortBExp{}, R} (Val:SortBExp{}, Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(K0:SortBExp{}, K1:SortBExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortBExp{}} (\and{SortBExp{}} (Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(X0:SortBExp{}, X1:SortBExp{}), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(Y0:SortBExp{}, Y1:SortBExp{})), Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(\and{SortBExp{}} (X0:SortBExp{}, Y0:SortBExp{}), \and{SortBExp{}} (X1:SortBExp{}, Y1:SortBExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblcategoryChar'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(K0:SortString{}, K1:SortString{}, K2:SortString{}, K3:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, LblnoStateCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisTCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortS0} \exists{R} (Val:SortS0, \equals{SortS0, R} (Val:SortS0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(K0:SortBool{}, K1:SortS0, K2:SortS0))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(K0:SortString{}, K1:SortString{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblString2Int'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCell{}, \equals{SortTCell{}, R} (Val:SortTCell{}, LblinitTCell{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, LblMap'Coln'lookup{}(K0:SortMap{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(Y0:SortK{}, Y1:SortK{})), Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}), \and{SortK{}} (X1:SortK{}, Y1:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, LblList'Coln'get{}(K0:SortList{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortAExp{}, \equals{SortAExp{}, R} (Val:SortAExp{}, Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:SortAExp{}, K1:SortAExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortAExp{}} (\and{SortAExp{}} (Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{})), Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{SortAExp{}} (X0:SortAExp{}, Y0:SortAExp{}), \and{SortAExp{}} (X1:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortAExp{}} (\and{SortAExp{}} (Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblList'Coln'range{}(K0:SortList{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortAExp{}, \equals{SortAExp{}, R} (Val:SortAExp{}, Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(K0:SortAExp{}, K1:SortAExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortAExp{}} (\and{SortAExp{}} (Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(Y0:SortAExp{}, Y1:SortAExp{})), Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(\and{SortAExp{}} (X0:SortAExp{}, Y0:SortAExp{}), \and{SortAExp{}} (X1:SortAExp{}, Y1:SortAExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortStmt{}, \equals{SortStmt{}, R} (Val:SortStmt{}, Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(K0:SortStmt{}, K1:SortStmt{}))) [functional{}()] // functional
+  axiom{}\implies{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:SortStmt{}, X1:SortStmt{}), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(Y0:SortStmt{}, Y1:SortStmt{})), Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(\and{SortStmt{}} (X0:SortStmt{}, Y0:SortStmt{}), \and{SortStmt{}} (X1:SortStmt{}, Y1:SortStmt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortStmt{}} (\and{SortStmt{}} (Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:SortStmt{}, X1:SortStmt{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{}, Y2:SortBlock{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCell{}, \equals{SortStateCell{}, R} (Val:SortStateCell{}, Lbl'-LT-'state'-GT-'{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{}\implies{SortStateCell{}} (\and{SortStateCell{}} (Lbl'-LT-'state'-GT-'{}(X0:SortMap{}), Lbl'-LT-'state'-GT-'{}(Y0:SortMap{})), Lbl'-LT-'state'-GT-'{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStateCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(K0:SortK{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LbldirectionalityChar'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(K0:SortString{}, K1:SortString{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCell{}, \equals{SortStateCell{}, R} (Val:SortStateCell{}, LblinitStateCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(K0:SortString{}, K1:SortString{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBlock{}, \equals{SortBlock{}, R} (Val:SortBlock{}, Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortBlock{}} (\and{SortBlock{}} (Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}(), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Y0:SortStmt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCellFragment{}, \equals{SortTCellFragment{}, R} (Val:SortTCellFragment{}, Lbl'-LT-'T'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortStateCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCellFragment{}} (\and{SortTCellFragment{}} (Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}), Lbl'-LT-'T'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortStateCellOpt{})), Lbl'-LT-'T'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortStateCellOpt{}} (X1:SortStateCellOpt{}, Y1:SortStateCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisPgm{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisAExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblString2Base'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int{}(K0:SortString{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Float'Unds'String{}(K0:SortFloat{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStmt{}, \equals{SortStmt{}, R} (Val:SortStmt{}, Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(K0:SortBExp{}, K1:SortBlock{}, K2:SortBlock{}))) [functional{}()] // functional
+  axiom{}\implies{SortStmt{}} (\and{SortStmt{}} (Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}, X2:SortBlock{}), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(Y0:SortBExp{}, Y1:SortBlock{}, Y2:SortBlock{})), Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(\and{SortBExp{}} (X0:SortBExp{}, Y0:SortBExp{}), \and{SortBlock{}} (X1:SortBlock{}, Y1:SortBlock{}), \and{SortBlock{}} (X2:SortBlock{}, Y2:SortBlock{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsXor-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBlock{}, \equals{SortBlock{}, R} (Val:SortBlock{}, Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(K0:SortStmt{}))) [functional{}()] // functional
+  axiom{}\implies{SortBlock{}} (\and{SortBlock{}} (Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(X0:SortStmt{}), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Y0:SortStmt{})), Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(\and{SortStmt{}} (X0:SortStmt{}, Y0:SortStmt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBlock{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(K0:SortK{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortPgm{}, inj{SortPgm{}, SortKItem{}} (Val:SortPgm{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortKItem{}} (Val:SortStateCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortAExp{}, inj{SortAExp{}, SortKItem{}} (Val:SortAExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCell{}, inj{SortTCell{}, SortKItem{}} (Val:SortTCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortKItem{}} (Val:SortTCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortKItem{}} (Val:SortStateCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(X0:SortK{}, X1:SortK{}))), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIds{}, inj{SortIds{}, SortKItem{}} (Val:SortIds{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStmt{}, inj{SortStmt{}, SortKItem{}} (Val:SortStmt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBExp{}, inj{SortBExp{}, SortKItem{}} (Val:SortBExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBlock{}, inj{SortBlock{}, SortKItem{}} (Val:SortBlock{})), \bottom{SortKItem{}}())))))))))))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortList{}} (\exists{SortList{}} (X0:SortList{}, \exists{SortList{}} (X1:SortList{}, Lbl'Unds'List'Unds'{}(X0:SortList{}, X1:SortList{}))), \or{SortList{}} (Lbl'Stop'List{}(), \bottom{SortList{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortTCellFragment{}} (\exists{SortTCellFragment{}} (X0:SortKCellOpt{}, \exists{SortTCellFragment{}} (X1:SortStateCellOpt{}, Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}))), \bottom{SortTCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortStateCell{}} (\exists{SortStateCell{}} (X0:SortMap{}, Lbl'-LT-'state'-GT-'{}(X0:SortMap{})), \bottom{SortStateCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortTCell{}} (\exists{SortTCell{}} (X0:SortKCell{}, \exists{SortTCell{}} (X1:SortStateCell{}, Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortStateCell{}))), \bottom{SortTCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortIds{}} (Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids'QuotRBraUnds'Ids{}(), \or{SortIds{}} (\exists{SortIds{}} (X0:SortId{}, \exists{SortIds{}} (X1:SortIds{}, Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(X0:SortId{}, X1:SortIds{}))), \bottom{SortIds{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortBExp{}} (\exists{SortBExp{}} (X0:SortBExp{}, Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(X0:SortBExp{})), \or{SortBExp{}} (\exists{SortBExp{}} (X0:SortAExp{}, \exists{SortBExp{}} (X1:SortAExp{}, Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}))), \or{SortBExp{}} (\exists{SortBExp{}} (X0:SortBExp{}, \exists{SortBExp{}} (X1:SortBExp{}, Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(X0:SortBExp{}, X1:SortBExp{}))), \or{SortBExp{}} (\exists{SortBExp{}} (Val:SortBool{}, inj{SortBool{}, SortBExp{}} (Val:SortBool{})), \bottom{SortBExp{}}())))) [constructor{}()] // no junk
+  axiom{} \or{SortStateCellOpt{}} (LblnoStateCell{}(), \or{SortStateCellOpt{}} (\exists{SortStateCellOpt{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortStateCellOpt{}} (Val:SortStateCell{})), \bottom{SortStateCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortTCell{}, inj{SortTCell{}, SortCell{}} (Val:SortTCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortCell{}} (Val:SortStateCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \bottom{SortK{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortInt{}, inj{SortInt{}, SortKResult{}} (Val:SortInt{})), \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortBool{}, inj{SortBool{}, SortKResult{}} (Val:SortBool{})), \bottom{SortKResult{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortMap{}} (\exists{SortMap{}} (X0:SortMap{}, \exists{SortMap{}} (X1:SortMap{}, Lbl'Unds'Map'Unds'{}(X0:SortMap{}, X1:SortMap{}))), \or{SortMap{}} (Lbl'Stop'Map{}(), \bottom{SortMap{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \or{SortKCellOpt{}} (LblnoKCell{}(), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortStmt{}} (\exists{SortStmt{}} (X0:SortId{}, \exists{SortStmt{}} (X1:SortAExp{}, Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(X0:SortId{}, X1:SortAExp{}))), \or{SortStmt{}} (\exists{SortStmt{}} (Val:SortBlock{}, inj{SortBlock{}, SortStmt{}} (Val:SortBlock{})), \or{SortStmt{}} (\exists{SortStmt{}} (X0:SortBExp{}, \exists{SortStmt{}} (X1:SortBlock{}, Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}))), \or{SortStmt{}} (\exists{SortStmt{}} (X0:SortStmt{}, \exists{SortStmt{}} (X1:SortStmt{}, Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(X0:SortStmt{}, X1:SortStmt{}))), \or{SortStmt{}} (\exists{SortStmt{}} (X0:SortBExp{}, \exists{SortStmt{}} (X1:SortBlock{}, \exists{SortStmt{}} (X2:SortBlock{}, Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(X0:SortBExp{}, X1:SortBlock{}, X2:SortBlock{})))), \bottom{SortStmt{}}()))))) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortPgm{}} (\exists{SortPgm{}} (X0:SortIds{}, \exists{SortPgm{}} (X1:SortStmt{}, Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(X0:SortIds{}, X1:SortStmt{}))), \bottom{SortPgm{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortBlock{}} (Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}(), \or{SortBlock{}} (\exists{SortBlock{}} (X0:SortStmt{}, Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(X0:SortStmt{})), \bottom{SortBlock{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortSet{}} (Lbl'Stop'Set{}(), \or{SortSet{}} (\exists{SortSet{}} (X0:SortSet{}, \exists{SortSet{}} (X1:SortSet{}, Lbl'Unds'Set'Unds'{}(X0:SortSet{}, X1:SortSet{}))), \bottom{SortSet{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortAExp{}} (\exists{SortAExp{}} (Val:SortId{}, inj{SortId{}, SortAExp{}} (Val:SortId{})), \or{SortAExp{}} (\exists{SortAExp{}} (Val:SortInt{}, inj{SortInt{}, SortAExp{}} (Val:SortInt{})), \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortInt{}, Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(X0:SortInt{})), \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortAExp{}, \exists{SortAExp{}} (X1:SortAExp{}, Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}))), \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortAExp{}, \exists{SortAExp{}} (X1:SortAExp{}, Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}))), \bottom{SortAExp{}}()))))) [constructor{}()] // no junk
 
 // rules
-// rule `_=/=String__STRING__String_String`(S1,S2)=>`notBool_`(`_==String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(523) org.kframework.attributes.Location(Location(523,8,523,65)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}))),
-      \top{R}()))
-  []
-
-// rule `_andBool_`(_4,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(288) org.kframework.attributes.Location(Location(288,8,288,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andBool'Unds'{}(Var'Unds'4:Bool{},\dv{Bool{}}("false")),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_10,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(733) org.kframework.attributes.Location(Location(733,8,733,64)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        LblnotBool'Unds'{}(VarC:Bool{}),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{K{},R} (
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{K{}}(VarC:Bool{},Var'Unds'10:K{},VarB2:K{}),
-        VarB2:K{}),
-      \top{R}()))
-  []
-
 // rule isIds(inj{Ids,K}(Ids))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisIds{}(inj{Ids{}, K{}}(VarIds:Ids{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisIds{}(inj{SortIds{}, SortK{}}(VarIds:SortIds{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `#stdout_K-IO_`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(860) org.kframework.attributes.Location(Location(860,8,860,20)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_<=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(536) org.kframework.attributes.Location(Location(536,8,536,63)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Int{},R} (
-        Lbl'Hash'stdout'Unds'K-IO'Unds'{}(),
-        \dv{Int{}}("1")),
+      \equals{SortBool{},R} (
+        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}))),
       \top{R}()))
-  []
-
-// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKConfigVar:KConfigVar{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKConfigVar{}(inj{KConfigVar{}, K{}}(VarKConfigVar:KConfigVar{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKConfigVar{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
+  [contentStartLine{}("536"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(536,8,536,63)")]
 
 // rule isKItem(inj{KItem,K}(KItem))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{KItem{}, K{}}(VarKItem:KItem{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortKItem{}, SortK{}}(VarKItem:SortKItem{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -3300,1104 +560,75 @@ module IMP
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisBExp{}(inj{BExp{}, K{}}(VarBExp:BExp{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisBExp{}(inj{SortBExp{}, SortK{}}(VarBExp:SortBExp{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule freshInt(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(395) org.kframework.attributes.Location(Location(395,8,395,28)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(296) org.kframework.attributes.Location(Location(296,8,296,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Int{},R} (
-        LblfreshInt{}(VarI:Int{}),
-        VarI:Int{}),
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
       \top{R}()))
-  []
+  [contentStartLine{}("296"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(296,8,296,38)")]
 
 // rule isKCell(inj{KCell,K}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKCell{}(inj{KCell{}, K{}}(VarKCell:KCell{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(285) org.kframework.attributes.Location(Location(285,8,285,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `findChar(_,_,_)_STRING__String_String_Int`(_16,#token("\"\"","String"),_17)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(541) org.kframework.attributes.Location(Location(541,8,541,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andBool'Unds'{}(\dv{Bool{}}("true"),VarB:Bool{}),
-        VarB:Bool{}),
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'16:SortString{},\dv{SortString{}}("\"\""),Var'Unds'17:SortInt{}),
+        \dv{SortInt{}}("-1")),
       \top{R}()))
-  []
+  [contentStartLine{}("541"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(541,8,541,32)")]
+
+// rule `<T>`(`<k>`(inj{Block,KItem}(`{}_IMP-SYNTAX_`(.KList))~>DotVar1),DotVar0)=>`<T>`(`<k>`(DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(150) org.kframework.attributes.Location(Location(150,8,150,15)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}()),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar1:SortK{}),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("150"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(150,8,150,15)"), structural{}()]
 
 // rule isKItem(inj{Ids,K}(Ids))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Ids{}, K{}}(VarIds:Ids{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortIds{}, SortK{}}(VarIds:SortIds{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isIds(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `_orBool__BOOL__Bool_Bool`(_3,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(301) org.kframework.attributes.Location(Location(301,8,301,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
+    \top{R}(),
     \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarIds:Ids{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisIds{}(inj{Ids{}, K{}}(VarIds:Ids{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisIds{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'3:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
       \top{R}()))
-  []
+  [contentStartLine{}("301"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(301,8,301,34)")]
 
 // rule isFloat(inj{Float,K}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisFloat{}(inj{Float{}, K{}}(VarFloat:Float{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(inj{Bool,BExp}(#token("false","Bool")),_23,S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(179) org.kframework.attributes.Location(Location(179,8,179,32)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(inj{Bool{}, BExp{}}(\dv{Bool{}}("false")),Var'Unds'23:Block{},VarS:Block{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Block{}, KItem{}}(VarS:Block{}),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isAExp(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisAExp{}(inj{Int{}, K{}}(VarInt:Int{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX__BExp_Block_Block1_`(inj{Block,K}(K1),inj{Block,K}(K2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(HOLE,K1,K2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [colors(yellow, white, white, yellow) cool() format(%1 %2%3%4 %5 %6 %7) org.kframework.attributes.Location(Location(42,20,43,123)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(2092801316) strict(1)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(inj{Block{}, K{}}(VarK1:Block{}),inj{Block{}, K{}}(VarK2:Block{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarHOLE:BExp{},VarK1:Block{},VarK2:Block{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1076984738) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{KCellOpt,K}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{KCellOpt{}, K{}}(VarKCellOpt:KCellOpt{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1076984738) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_=/=K__K-EQUAL__K_K`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(726) org.kframework.attributes.Location(Location(726,8,726,45)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(VarK1:K{},VarK2:K{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:K{},VarK2:K{}))),
-      \top{R}()))
-  []
-
-// rule isTCell(inj{TCell,K}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisTCell{}(inj{TCell{}, K{}}(VarTCell:TCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{List{}, K{}}(VarList:List{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX__BExp_BExp1_`(inj{BExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(36,20,36,76)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1534755892) strict(1)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(VarHOLE:BExp{},VarK1:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(inj{BExp{}, K{}}(VarK1:BExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule isSet(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisSet{}(inj{Set{}, K{}}(VarSet:Set{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX__BExp0_`(.KList)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() org.kframework.attributes.Location(Location(35,20,35,67)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(194481424) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(VarHOLE:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{KCell,K}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{KCell{}, K{}}(VarKCell:KCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isAExp(inj{AExp,K}(AExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisAExp{}(inj{AExp{}, K{}}(VarAExp:AExp{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCellOpt:KCellOpt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKCellOpt{}(inj{KCellOpt{}, K{}}(VarKCellOpt:KCellOpt{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCell:KCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKCellOpt{}(inj{KCell{}, K{}}(VarKCell:KCell{}))))),
-        \bottom{R}()))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKCellOpt{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isCell(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisCell{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX__BExp0_`(.KList)~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() org.kframework.attributes.Location(Location(35,20,35,67)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(194481424) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(VarHOLE:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(X,inj{Int,AExp}(I)))~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),_22),DotVar2)))=>`<T>`(`<k>`(DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),inj{Int,K}(I)),DotVar2))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(156) org.kframework.attributes.Location(Location(156,8,156,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarX:Id{},inj{Int{}, AExp{}}(VarI:Int{}))),VarDotVar1:K{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{Id{}, K{}}(VarX:Id{}),Var'Unds'22:K{}),VarDotVar2:Map{}))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar1:K{}),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{Id{}, K{}}(VarX:Id{}),inj{Int{}, K{}}(VarI:Int{})),VarDotVar2:Map{}))))))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(970535245) seqstrict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(303) org.kframework.attributes.Location(Location(303,8,303,32)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:Bool{},\dv{Bool{}}("false")),
-        VarB:Bool{}),
-      \top{R}()))
-  []
-
-// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(308) org.kframework.attributes.Location(Location(308,8,308,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:Bool{},\dv{Bool{}}("false")),
-        VarK:Bool{}),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{Id,K}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Id{}, K{}}(VarId:Id{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isStateCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCell:StateCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStateCellOpt{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCellOpt:StateCellOpt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStateCellOpt{}(inj{StateCellOpt{}, K{}}(VarStateCellOpt:StateCellOpt{}))))),
-        \bottom{R}()))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStateCellOpt{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `_modInt__INT__Int_Int`(I1,I2)=>`_%Int__INT__Int_Int`(`_+Int__INT__Int_Int`(`_%Int__INT__Int_Int`(I1,absInt(I2)),absInt(I2)),absInt(I2)) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(374) org.kframework.attributes.Location(Location(374,5,377,23)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:Int{},\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},LblabsInt{}(VarI2:Int{})),LblabsInt{}(VarI2:Int{})),LblabsInt{}(VarI2:Int{}))),
-      \top{R}()))
-  []
-
-// rule isKConfigVar(inj{KConfigVar,K}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKConfigVar{}(inj{KConfigVar{}, K{}}(VarKConfigVar:KConfigVar{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(970535245) seqstrict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(substrString(Source,#token("0","Int"),findString(Source,ToReplace,#token("0","Int"))),Replacement),substrString(Source,`_+Int__INT__Int_Int`(findString(Source,ToReplace,#token("0","Int")),lengthString(ToReplace)),lengthString(Source))) requires `_>=Int__INT__Int_Int`(findString(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(550) org.kframework.attributes.Location(Location(550,8,552,66)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0")),\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{String{},R} (
-        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:String{},VarToReplace:String{},VarReplacement:String{}),
-        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString{}(VarSource:String{},\dv{Int{}}("0"),LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0"))),VarReplacement:String{}),LblsubstrString{}(VarSource:String{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0")),LbllengthString{}(VarToReplace:String{})),LbllengthString{}(VarSource:String{})))),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{KResult,K}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{KResult{}, K{}}(VarKResult:KResult{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(290) org.kframework.attributes.Location(Location(290,8,290,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("true"),VarK:Bool{}),
-        VarK:Bool{}),
-      \top{R}()))
-  []
-
-// rule isBlock(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBlock:Block{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisBlock{}(inj{Block{}, K{}}(VarBlock:Block{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisBlock{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisK{}(VarK:K{}),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule findChar(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int_`(findString(S1,substrString(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),findChar(S1,substrString(S2,#token("1","Int"),lengthString(S2)),I),`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int_`(findChar(S1,substrString(S2,#token("1","Int"),lengthString(S2)),I),#token("-1","Int")),findString(S1,substrString(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT__Int_Int`(findString(S1,substrString(S2,#token("0","Int"),#token("1","Int")),I),findChar(S1,substrString(S2,#token("1","Int"),lengthString(S2)),I)))) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(540) org.kframework.attributes.Location(Location(540,8,540,431)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:String{},\dv{String{}}("\"\"")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        LblfindChar{}(VarS1:String{},VarS2:String{},VarI:Int{}),
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{Int{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("0"),\dv{Int{}}("1")),VarI:Int{}),\dv{Int{}}("-1")),LblfindChar{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("1"),LbllengthString{}(VarS2:String{})),VarI:Int{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{Int{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("1"),LbllengthString{}(VarS2:String{})),VarI:Int{}),\dv{Int{}}("-1")),LblfindString{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("0"),\dv{Int{}}("1")),VarI:Int{}),LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("0"),\dv{Int{}}("1")),VarI:Int{}),LblfindChar{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("1"),LbllengthString{}(VarS2:String{})),VarI:Int{}))))),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_+Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(118) org.kframework.attributes.Location(Location(118,8,118,29)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{Int{}, AExp{}}(VarI1:Int{}),inj{Int{}, AExp{}}(VarI2:Int{}))),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Int{}, KItem{}}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(380) org.kframework.attributes.Location(Location(380,8,380,57)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        VarI2:Int{}),
-      \top{R}()))
-  []
-
-// rule isKResult(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKResult{}(inj{Bool{}, K{}}(VarBool:Bool{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_==String__STRING__String_String`(S1,S2)=>`_==K_`(inj{String,K}(S1),inj{String,K}(S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(524) org.kframework.attributes.Location(Location(524,8,524,49)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}),
-        Lbl'UndsEqlsEqls'K'Unds'{}(inj{String{}, K{}}(VarS1:String{}),inj{String{}, K{}}(VarS2:String{}))),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(inj{Bool,BExp}(#token("true","Bool")),S,_21))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(178) org.kframework.attributes.Location(Location(178,8,178,32)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(inj{Bool{}, BExp{}}(\dv{Bool{}}("true")),VarS:Block{},Var'Unds'21:Block{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Block{}, KItem{}}(VarS:Block{}),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_divInt__INT__Int_Int`(I1,I2)=>`_/Int__INT__Int_Int`(`_-Int__INT__Int_Int`(I1,`_modInt__INT__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(371) org.kframework.attributes.Location(Location(371,8,372,23)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:Int{},\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{})),VarI2:Int{})),
-      \top{R}()))
-  []
-
-// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(291) org.kframework.attributes.Location(Location(291,8,291,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:Bool{},\dv{Bool{}}("true")),
-        VarK:Bool{}),
-      \top{R}()))
-  []
-
-// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>`_+Int__INT__Int_Int`(#token("1","Int"),`countAllOccurrences(_,_)_STRING__String_String`(substrString(Source,`_+Int__INT__Int_Int`(findString(Source,ToCount,#token("0","Int")),lengthString(ToCount)),lengthString(Source)),ToCount)) requires `_>=Int__INT__Int_Int`(findString(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(547) org.kframework.attributes.Location(Location(547,8,548,60)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToCount:String{},\dv{Int{}}("0")),\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:String{},VarToCount:String{}),
-        Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString{}(VarSource:String{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToCount:String{},\dv{Int{}}("0")),LbllengthString{}(VarToCount:String{})),LbllengthString{}(VarSource:String{})),VarToCount:String{}))),
-      \top{R}()))
-  []
-
-// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool"),_2)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(292) org.kframework.attributes.Location(Location(292,8,292,36)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("false"),Var'Unds'2:Bool{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{BExp,K}(BExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{BExp{}, K{}}(VarBExp:BExp{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_dividesInt__INT__Int_Int`(I1,I2)=>`_==Int_`(`_%Int__INT__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(392) org.kframework.attributes.Location(Location(392,8,392,58)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:Int{},VarI1:Int{}),\dv{Int{}}("0"))),
-      \top{R}()))
-  []
-
-// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(286) org.kframework.attributes.Location(Location(286,8,286,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andBool'Unds'{}(VarB:Bool{},\dv{Bool{}}("true")),
-        VarB:Bool{}),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`-__IMP-SYNTAX__Int`(I1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_-Int__INT__Int_Int`(#token("0","Int"),I1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(119) org.kframework.attributes.Location(Location(119,8,119,25)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(VarI1:Int{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Int{}, KItem{}}(Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("0"),VarI1:Int{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_>=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(538) org.kframework.attributes.Location(Location(538,8,538,63)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}),
-        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}))),
-      \top{R}()))
-  []
-
-// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_11)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(732) org.kframework.attributes.Location(Location(732,8,732,56)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        VarC:Bool{},
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{K{},R} (
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{K{}}(VarC:Bool{},VarB1:K{},Var'Unds'11:K{}),
-        VarB1:K{}),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1076984738) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarIOError:IOError{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisIOError{}(inj{IOError{}, K{}}(VarIOError:IOError{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisIOError{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isBExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBExp:BExp{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisBExp{}(inj{BExp{}, K{}}(VarBExp:BExp{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBool:Bool{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisBExp{}(inj{Bool{}, K{}}(VarBool:Bool{}))))),
-        \bottom{R}()))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisBExp{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(310) org.kframework.attributes.Location(Location(310,8,310,36)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("true"),VarB:Bool{}),
-        VarB:Bool{}),
-      \top{R}()))
-  []
-
-// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarMap:Map{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisMap{}(inj{Map{}, K{}}(VarMap:Map{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisMap{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX__Ids_Stmt`(`.List{"_,__IMP-SYNTAX_"}_Ids`(.KList),S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(202) org.kframework.attributes.Location(Location(202,8,202,24)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Pgm{}, KItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsQuotRBraUnds'Ids{}(),VarS:Stmt{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(VarS:Stmt{}),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Block{}, K{}}(VarBlock:Block{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,_16)=>Source requires `_<Int__INT__Int_Int`(findString(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(553) org.kframework.attributes.Location(Location(553,8,554,57)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0")),\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{String{},R} (
-        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:String{},VarToReplace:String{},Var'Unds'16:String{}),
-        VarSource:String{}),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(HOLE,K1,K2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX__BExp_Block_Block1_`(inj{Block,K}(K1),inj{Block,K}(K2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [colors(yellow, white, white, yellow) format(%1 %2%3%4 %5 %6 %7) heat() org.kframework.attributes.Location(Location(42,20,43,123)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(2092801316) strict(1)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarHOLE:BExp{},VarK1:Block{},VarK2:Block{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(inj{Block{}, K{}}(VarK1:Block{}),inj{Block{}, K{}}(VarK2:Block{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,K}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{KCell{},R} (
-        LblinitKCell{}(VarInit:Map{}),
-        Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarInit:Map{},inj{KConfigVar{}, K{}}(\dv{KConfigVar{}}("$PGM"))))),
-      \top{R}()))
-  []
-
-// rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStream:Stream{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStream{}(inj{Stream{}, K{}}(VarStream:Stream{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStream{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule bitRangeInt(I,IDX,LEN)=>`_modInt__INT__Int_Int`(`_>>Int__INT__Int_Int`(I,IDX),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(367) org.kframework.attributes.Location(Location(367,8,367,70)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Int{},R} (
-        LblbitRangeInt{}(VarI:Int{},VarIDX:Int{},VarLEN:Int{}),
-        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI:Int{},VarIDX:Int{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("1"),VarLEN:Int{}))),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX__BExp_BExp1_`(inj{BExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(36,20,36,76)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1534755892) strict(1)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarHOLE:BExp{}),kseq{}(Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(inj{BExp{}, K{}}(VarK1:BExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(VarHOLE:BExp{},VarK1:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_/Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(117) org.kframework.attributes.Location(Location(117,8,117,51)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{} \and{TCell{}} (
-    \equals{Bool{},TCell{}}(
-        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:Int{},\dv{Int{}}("0")),
-        \dv{Bool{}}("true")), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{Int{}, AExp{}}(VarI1:Int{}),inj{Int{}, AExp{}}(VarI2:Int{}))),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Int{}, KItem{}}(Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{Float,K}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Float{}, K{}}(VarFloat:Float{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_andBool_`(#token("false","Bool"),_9)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(287) org.kframework.attributes.Location(Location(287,8,287,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andBool'Unds'{}(\dv{Bool{}}("false"),Var'Unds'9:Bool{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule signExtendBitRangeInt(I,IDX,LEN)=>`_-Int__INT__Int_Int`(`_modInt__INT__Int_Int`(`_+Int__INT__Int_Int`(bitRangeInt(I,IDX,LEN),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(369) org.kframework.attributes.Location(Location(369,8,369,149)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Int{},R} (
-        LblsignExtendBitRangeInt{}(VarI:Int{},VarIDX:Int{},VarLEN:Int{}),
-        Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblbitRangeInt{}(VarI:Int{},VarIDX:Int{},VarLEN:Int{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:Int{},\dv{Int{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("1"),VarLEN:Int{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{Int{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:Int{},\dv{Int{}}("1"))))),
-      \top{R}()))
-  []
-
-// rule isStateCellOpt(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStateCellOpt{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_=/=Int__INT__Int_Int`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(391) org.kframework.attributes.Location(Location(391,8,391,53)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:Int{},VarI2:Int{}))),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Block,KItem}(`{}_IMP-SYNTAX_`(.KList))~>DotVar1),DotVar0)=>`<T>`(`<k>`(DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(148) org.kframework.attributes.Location(Location(148,8,148,15)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Block{}, KItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}()),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar1:K{}),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{Cell,K}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Cell{}, K{}}(VarCell:Cell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{Stmt,K}(Stmt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Stmt{}, K{}}(VarStmt:Stmt{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCell:KCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKCell{}(inj{KCell{}, K{}}(VarKCell:KCell{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKCell{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isStmt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBlock:Block{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStmt{}(inj{Block{}, K{}}(VarBlock:Block{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStmt:Stmt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStmt{}(inj{Stmt{}, K{}}(VarStmt:Stmt{}))))),
-        \bottom{R}()))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStmt{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`while(_)__IMP-SYNTAX__BExp_Block`(B,S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(B,`{_}_IMP-SYNTAX__Stmt`(`___IMP-SYNTAX__Stmt_Stmt`(inj{Block,Stmt}(S),`while(_)__IMP-SYNTAX__BExp_Block`(B,S))),`{}_IMP-SYNTAX_`(.KList)))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(185) org.kframework.attributes.Location(Location(185,8,185,53)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(VarB:BExp{},VarS:Block{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarB:BExp{},Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(inj{Block{}, Stmt{}}(VarS:Block{}),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(VarB:BExp{},VarS:Block{}))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}())),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(297) org.kframework.attributes.Location(Location(297,8,297,38)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:Bool{},VarB:Bool{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isAExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarInt:Int{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisAExp{}(inj{Int{}, K{}}(VarInt:Int{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarAExp:AExp{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisAExp{}(inj{AExp{}, K{}}(VarAExp:AExp{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarId:Id{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisAExp{}(inj{Id{}, K{}}(VarId:Id{}))))),
-        \bottom{R}())))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisAExp{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX__Id_AExp0_`(inj{Id,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) format(%1 %2 %3%4) heat() org.kframework.attributes.Location(Location(41,20,41,90)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1719072416) strict(2)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarK0:Id{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(inj{Id{}, K{}}(VarK0:Id{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarInt:Int{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKResult{}(inj{Int{}, K{}}(VarInt:Int{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBool:Bool{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKResult{}(inj{Bool{}, K{}}(VarBool:Bool{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKResult:KResult{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKResult{}(inj{KResult{}, K{}}(VarKResult:KResult{}))))),
-        \bottom{R}())))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKResult{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_<=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(536) org.kframework.attributes.Location(Location(536,8,536,63)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}),
-        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:String{},VarS1:String{}))),
-      \top{R}()))
-  []
-
-// rule isCell(inj{TCell,K}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisCell{}(inj{TCell{}, K{}}(VarTCell:TCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_==Int_`(I1,I2)=>`_==K_`(inj{Int,K}(I1),inj{Int,K}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(390) org.kframework.attributes.Location(Location(390,8,390,40)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:Int{},VarI2:Int{}),
-        Lbl'UndsEqlsEqls'K'Unds'{}(inj{Int{}, K{}}(VarI1:Int{}),inj{Int{}, K{}}(VarI2:Int{}))),
-      \top{R}()))
-  []
-
-// rule isStateCell(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStateCell{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKCellOpt(inj{KCellOpt,K}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKCellOpt{}(inj{KCellOpt{}, K{}}(VarKCellOpt:KCellOpt{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule freshId(I)=>`String2Id`(`_+String__STRING__String_String`(#token("\"_\"","String"),`Int2String`(I))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(708) org.kframework.attributes.Location(Location(708,8,708,62)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Id{},R} (
-        LblfreshId{}(VarI:Int{}),
-        LblString2Id{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(\dv{String{}}("\"_\""),LblInt2String{}(VarI:Int{})))),
-      \top{R}()))
-  []
-
-// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCell:StateCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisCell{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarCell:Cell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisCell{}(inj{Cell{}, K{}}(VarCell:Cell{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCell:KCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisCell{}(inj{KCell{}, K{}}(VarKCell:KCell{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarTCell:TCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisCell{}(inj{TCell{}, K{}}(VarTCell:TCell{}))))),
-        \bottom{R}()))))),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisCell{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarSet:Set{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisSet{}(inj{Set{}, K{}}(VarSet:Set{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisSet{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(295) org.kframework.attributes.Location(Location(295,8,295,38)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("false"),VarB:Bool{}),
-        VarB:Bool{}),
-      \top{R}()))
-  []
-
-// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarFloat:Float{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisFloat{}(inj{Float{}, K{}}(VarFloat:Float{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisFloat{}(VarK:K{}),
-        \dv{Bool{}}("false")),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{AExp,K}(AExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{AExp{}, K{}}(VarAExp:AExp{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isPgm(inj{Pgm,K}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisPgm{}(inj{Pgm{}, K{}}(VarPgm:Pgm{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(315) org.kframework.attributes.Location(Location(315,8,315,57)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:Bool{},VarB2:Bool{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:Bool{},VarB2:Bool{}))),
+      \equals{SortBool{},R} (
+        LblisFloat{}(inj{SortFloat{}, SortK{}}(VarFloat:SortFloat{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -4406,376 +637,393 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarList:List{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisList{}(inj{List{}, K{}}(VarList:List{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarList:SortList{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisList{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule `<T>`(`<k>`(inj{Stmt,KItem}(`___IMP-SYNTAX__Stmt_Stmt`(S1,S2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S1)~>inj{Stmt,KItem}(S2)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(169) org.kframework.attributes.Location(Location(169,8,169,35)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(VarS1:Stmt{},VarS2:Stmt{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(VarS1:Stmt{}),kseq{}(inj{Stmt{}, KItem{}}(VarS2:Stmt{}),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_andThenBool__BOOL__Bool_Bool`(_0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(293) org.kframework.attributes.Location(Location(293,8,293,36)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isAExp(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:Bool{},\dv{Bool{}}("false")),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisAExp{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires isKResult(inj{AExp,K}(K0)) ensures #token("true","Bool") [color(pink) heat() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(970535245) seqstrict()]
-  axiom{} \and{TCell{}} (
-    \equals{Bool{},TCell{}}(
-        LblisKResult{}(inj{AExp{}, K{}}(VarK0:AExp{})),
-        \dv{Bool{}}("true")), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKItem(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,K}(K1),inj{Bool,K}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(733) org.kframework.attributes.Location(Location(733,8,733,43)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Set{}, K{}}(VarSet:Set{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:SortBool{},VarK2:SortBool{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(inj{SortBool{}, SortK{}}(VarK1:SortBool{}),inj{SortBool{}, SortK{}}(VarK2:SortBool{}))),
       \top{R}()))
-  []
+  [contentStartLine{}("733"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(733,8,733,43)")]
 
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(`_<=Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(127) org.kframework.attributes.Location(Location(127,8,127,31)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{Int{}, AExp{}}(VarI1:Int{}),inj{Int{}, AExp{}}(VarI2:Int{}))),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Bool{}, KItem{}}(Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1810923540) seqstrict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), seqstrict{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), latex{}("{#1}\\leq{#2}"), productionID{}("1810923540")]
 
-// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(298) org.kframework.attributes.Location(Location(298,8,298,57)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isKItem(inj{KCellOpt,K}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:Bool{},VarB2:Bool{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:Bool{},VarB2:Bool{}))),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortKCellOpt{}, SortK{}}(VarKCellOpt:SortKCellOpt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isKItem(inj{IOError,K}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isTCell(inj{TCell,K}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{IOError{}, K{}}(VarIOError:IOError{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisTCell{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isInt(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isKItem(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisInt{}(inj{Int{}, K{}}(VarInt:Int{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortList{}, SortK{}}(VarList:SortList{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_1)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(311) org.kframework.attributes.Location(Location(311,8,311,40)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'1:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("311"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,8,311,40)")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBool:Bool{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisBool{}(inj{Bool{}, K{}}(VarBool:Bool{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKConfigVar:SortKConfigVar{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKConfigVar{}(inj{SortKConfigVar{}, SortK{}}(VarKConfigVar:SortKConfigVar{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisBool{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1006751649) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX__Id_AExp0_`(inj{Id,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) format(%1 %2 %3%4) heat() org.kframework.attributes.Location(Location(41,20,41,90)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(417557780) strict(2)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(inj{SortId{}, SortK{}}(VarK0:SortId{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}("2"), format{}("%1 %2 %3%4"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), productionID{}("417557780")]
 
-// rule isAExp(inj{Id,K}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(545) org.kframework.attributes.Location(Location(545,8,546,59)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        \dv{SortInt{}}("0")),
+      \top{R}()))
+  [contentStartLine{}("545"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(545,8,546,59)")]
+
+// rule isSet(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisAExp{}(inj{Id{}, K{}}(VarId:Id{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisSet{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isKItem(inj{String,K}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,_12,_13,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(561) org.kframework.attributes.Location(Location(561,8,561,49)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{String{}, K{}}(VarString:String{})),
-        \dv{Bool{}}("true")),
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},Var'Unds'12:SortString{},Var'Unds'13:SortString{},\dv{SortInt{}}("0")),
+        VarSource:SortString{}),
       \top{R}()))
-  []
+  [contentStartLine{}("561"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(561,8,561,49)")]
 
-// rule isKItem(inj{Pgm,K}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isKItem(inj{KCell,K}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Pgm{}, K{}}(VarPgm:Pgm{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isKItem(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(313) org.kframework.attributes.Location(Location(313,8,313,45)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Map{}, K{}}(VarMap:Map{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
       \top{R}()))
-  []
+  [contentStartLine{}("313"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(313,8,313,45)")]
 
-// rule isStmt(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isAExp(inj{AExp,K}(AExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisStmt{}(inj{Block{}, K{}}(VarBlock:Block{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisAExp{}(inj{SortAExp{}, SortK{}}(VarAExp:SortAExp{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isKItem(inj{TCellFragment,K}(TCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isCell(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{TCellFragment{}, K{}}(VarTCellFragment:TCellFragment{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisCell{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isKItem(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Bool{}, K{}}(VarBool:Bool{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isKResult(inj{KResult,K}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKResult{}(inj{KResult{}, K{}}(VarKResult:KResult{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule findChar(_17,#token("\"\"","String"),_18)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(541) org.kframework.attributes.Location(Location(541,8,541,32)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Int{},R} (
-        LblfindChar{}(Var'Unds'17:String{},\dv{String{}}("\"\""),Var'Unds'18:Int{}),
-        \dv{Int{}}("-1")),
-      \top{R}()))
-  []
-
-// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule isBExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarId:Id{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisId{}(inj{Id{}, K{}}(VarId:Id{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBExp:SortBExp{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisBExp{}(inj{SortBExp{}, SortK{}}(VarBExp:SortBExp{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBool:SortBool{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisBExp{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
+        \bottom{R}()))),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBExp{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `bitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN)=>`_modInt__INT__Int_Int`(`_>>Int__INT__Int_Int`(I,IDX),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(367) org.kframework.attributes.Location(Location(367,8,367,70)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
+      \top{R}()))
+  [contentStartLine{}("367"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(367,8,367,70)")]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1940445711) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(), productionID{}("1940445711")]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(284686302) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(), productionID{}("284686302")]
+
+// rule isKItem(inj{Id,K}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortId{}, SortK{}}(VarId:SortId{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX__BExp_BExp1_`(inj{BExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(36,20,36,76)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1932332324) strict(1)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(inj{SortBExp{}, SortK{}}(VarK1:SortBExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}("1"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), left{}(), productionID{}("1932332324")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool"),_6)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(292) org.kframework.attributes.Location(Location(292,8,292,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'6:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("292"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,8,292,36)")]
+
+// rule `<T>`(`<k>`(inj{Id,KItem}(X)~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),I),DotVar2)))=>`<T>`(`<k>`(I~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),I),DotVar2))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(112) org.kframework.attributes.Location(Location(112,8,112,60)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),VarDotVar1:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortK{}}(VarX:SortId{}),VarI:SortK{}),VarDotVar2:SortMap{}))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(append{}(VarI:SortK{},VarDotVar1:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortK{}}(VarX:SortId{}),VarI:SortK{}),VarDotVar2:SortMap{}))))))
+  [contentStartLine{}("112"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(112,8,112,60)")]
+
+// rule isKConfigVar(inj{KConfigVar,K}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(inj{SortKConfigVar{}, SortK{}}(VarKConfigVar:SortKConfigVar{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{KResult,K}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortKResult{}, SortK{}}(VarKResult:SortKResult{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisK{}(VarK:SortK{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(310) org.kframework.attributes.Location(Location(310,8,310,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("310"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(310,8,310,36)")]
+
+// rule `<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX__Ids_Stmt`(`.List{"_,__IMP-SYNTAX__Id_Ids"}_Ids`(.KList),S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(204) org.kframework.attributes.Location(Location(204,8,204,24)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids'QuotRBraUnds'Ids{}(),VarS:SortStmt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("204"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,8,204,24)"), structural{}()]
+
+// rule isKResult(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(`_<=Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(129) org.kframework.attributes.Location(Location(129,8,129,31)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("129"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,8,129,31)")]
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX__BExp_BExp1_`(inj{BExp,K}(K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(HOLE,K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(36,20,36,76)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1932332324) strict(1)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'{}(inj{SortBExp{}, SortK{}}(VarK1:SortBExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), left{}(), productionID{}("1932332324")]
+
+// rule `<T>`(`<k>`(inj{Pgm,K}(`int_;__IMP-SYNTAX__Ids_Stmt`(`_,__IMP-SYNTAX__Id_Ids`(X,Xs),_22))),`<state>`(`_Map_`(Rho,`.Map`(.KList))))=>`<T>`(`<k>`(inj{Pgm,K}(`int_;__IMP-SYNTAX__Ids_Stmt`(Xs,_22))),`<state>`(`_Map_`(Rho,`_|->_`(inj{Id,K}(X),inj{Int,K}(#token("0","Int")))))) requires `notBool_`(`Set:in`(inj{Id,K}(X),`keys(_)_MAP__Map`(Rho))) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(202) org.kframework.attributes.Location(Location(202,8,203,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{} \and{SortTCell{}} (
+    \equals{SortBool{},SortTCell{}}(
+        LblnotBool'Unds'{}(LblSet'Coln'in{}(inj{SortId{}, SortK{}}(VarX:SortId{}),Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(VarRho:SortMap{}))),
+        \dv{SortBool{}}("true")), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(inj{SortPgm{}, SortK{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'UndsUnds'Id'Unds'Ids{}(VarX:SortId{},VarXs:SortIds{}),Var'Unds'22:SortStmt{}))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'Stop'Map{}()))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(inj{SortPgm{}, SortK{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(VarXs:SortIds{},Var'Unds'22:SortStmt{}))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortK{}}(VarX:SortId{}),inj{SortInt{}, SortK{}}(\dv{SortInt{}}("0")))))))))
+  [contentStartLine{}("202"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(202,8,203,38)")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_10)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(737) org.kframework.attributes.Location(Location(737,8,737,56)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},VarB1:SortK{},Var'Unds'10:SortK{}),
+        VarB1:SortK{}),
+      \top{R}()))
+  [contentStartLine{}("737"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(737,8,737,56)")]
+
+// rule `_>String__STRING__String_String`(S1,S2)=>`_<String__STRING__String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(537) org.kframework.attributes.Location(Location(537,8,537,52)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+      \top{R}()))
+  [contentStartLine{}("537"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(537,8,537,52)")]
+
+// rule isIds(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarIds:SortIds{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisIds{}(inj{SortIds{}, SortK{}}(VarIds:SortIds{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisId{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisIds{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX__Id_AExp0_`(inj{Id,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() format(%1 %2 %3%4) org.kframework.attributes.Location(Location(41,20,41,90)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1719072416) strict(2)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(inj{Id{}, K{}}(VarK0:Id{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarK0:Id{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
+// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX__BExp0_`(.KList)~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() org.kframework.attributes.Location(Location(35,20,35,67)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1581078471) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(VarHOLE:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), productionID{}("1581078471")]
 
-// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(282) org.kframework.attributes.Location(Location(282,8,282,29)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isKItem(inj{BExp,K}(BExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblnotBool'Unds'{}(\dv{Bool{}}("true")),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortBExp{}, SortK{}}(VarBExp:SortBExp{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1006751649) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_orBool__BOOL__Bool_Bool`(_7,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(301) org.kframework.attributes.Location(Location(301,8,301,34)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'7:Bool{},\dv{Bool{}}("true")),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isBlock(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisBlock{}(inj{Block{}, K{}}(VarBlock:Block{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_impliesBool__BOOL__Bool_Bool`(_8,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(312) org.kframework.attributes.Location(Location(312,8,312,39)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'8:Bool{},\dv{Bool{}}("true")),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Pgm,K}(`int_;__IMP-SYNTAX__Ids_Stmt`(`_,__IMP-SYNTAX_`(X,Xs),_20))),`<state>`(`_Map_`(Rho,`.Map`(.KList))))=>`<T>`(`<k>`(inj{Pgm,K}(`int_;__IMP-SYNTAX__Ids_Stmt`(Xs,_20))),`<state>`(`_Map_`(Rho,`_|->_`(inj{Id,K}(X),inj{Int,K}(#token("0","Int")))))) requires `notBool_`(`Set:in`(inj{Id,K}(X),keys(Rho))) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(200) org.kframework.attributes.Location(Location(200,8,201,38)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{} \and{TCell{}} (
-    \equals{Bool{},TCell{}}(
-        LblnotBool'Unds'{}(LblSet'Coln'in{}(inj{Id{}, K{}}(VarX:Id{}),Lblkeys{}(VarRho:Map{}))),
-        \dv{Bool{}}("true")), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(inj{Pgm{}, K{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'{}(VarX:Id{},VarXs:Ids{}),Var'Unds'20:Stmt{}))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:Map{},Lbl'Stop'Map{}()))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(inj{Pgm{}, K{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt{}(VarXs:Ids{},Var'Unds'20:Stmt{}))),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:Map{},Lbl'UndsPipe'-'-GT-Unds'{}(inj{Id{}, K{}}(VarX:Id{}),inj{Int{}, K{}}(\dv{Int{}}("0")))))))))
-  []
-
-// rule `<T>`(`<k>`(inj{Block,KItem}(`{_}_IMP-SYNTAX__Stmt`(S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(149) org.kframework.attributes.Location(Location(149,8,149,16)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Block{}, KItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(VarS:Stmt{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Stmt{}, KItem{}}(VarS:Stmt{}),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isStream(inj{Stream,K}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStream{}(inj{Stream{}, K{}}(VarStream:Stream{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isList(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisList{}(inj{List{}, K{}}(VarList:List{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,_14,_15,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(561) org.kframework.attributes.Location(Location(561,8,561,49)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{String{},R} (
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:String{},Var'Unds'14:String{},Var'Unds'15:String{},\dv{Int{}}("0")),
-        VarSource:String{}),
-      \top{R}()))
-  []
-
-// rule isStmt(inj{Stmt,K}(Stmt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStmt{}(inj{Stmt{}, K{}}(VarStmt:Stmt{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(283) org.kframework.attributes.Location(Location(283,8,283,29)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblnotBool'Unds'{}(\dv{Bool{}}("false")),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `#stdin_K-IO_`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(859) org.kframework.attributes.Location(Location(859,8,859,19)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Int{},R} (
-        Lbl'Hash'stdin'Unds'K-IO'Unds'{}(),
-        \dv{Int{}}("0")),
-      \top{R}()))
-  []
-
-// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(substrString(Source,#token("0","Int"),findString(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING__String_String_String_Int`(substrString(Source,`_+Int__INT__Int_Int`(findString(Source,ToReplace,#token("0","Int")),lengthString(ToReplace)),lengthString(Source)),ToReplace,Replacement,`_-Int__INT__Int_Int`(Count,#token("1","Int")))) requires `_>Int__INT__Int_Int`(Count,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(557) org.kframework.attributes.Location(Location(557,8,560,30)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarCount:Int{},\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{String{},R} (
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:String{},VarToReplace:String{},VarReplacement:String{},VarCount:Int{}),
-        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString{}(VarSource:String{},\dv{Int{}}("0"),LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0"))),VarReplacement:String{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString{}(VarSource:String{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToReplace:String{},\dv{Int{}}("0")),LbllengthString{}(VarToReplace:String{})),LbllengthString{}(VarSource:String{})),VarToReplace:String{},VarReplacement:String{},Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarCount:Int{},\dv{Int{}}("1"))))),
-      \top{R}()))
-  []
-
-// rule isKItem(inj{Stream,K}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Stream{}, K{}}(VarStream:Stream{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(970535245) seqstrict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
   []
 
 // rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
@@ -4783,67 +1031,823 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarString:String{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisString{}(inj{String{}, K{}}(VarString:String{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarString:SortString{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisString{}(inj{SortString{}, SortK{}}(VarString:SortString{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisString{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisString{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule isBExp(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(inj{Bool,BExp}(#token("true","Bool")),S,_19))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(180) org.kframework.attributes.Location(Location(180,8,180,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),VarS:SortBlock{},Var'Unds'19:SortBlock{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("180"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(180,8,180,32)")]
+
+// rule `_dividesInt__INT__Int_Int`(I1,I2)=>`_==Int__INT__Int_Int`(`_%Int__INT__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(392) org.kframework.attributes.Location(Location(392,8,392,58)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisBExp{}(inj{Bool{}, K{}}(VarBool:Bool{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
       \top{R}()))
-  []
+  [contentStartLine{}("392"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,8,392,58)")]
 
-// rule `replaceAll(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING__String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(562) org.kframework.attributes.Location(Location(562,8,562,154)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(307) org.kframework.attributes.Location(Location(307,8,307,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{String{},R} (
-        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:String{},VarToReplace:String{},VarReplacement:String{}),
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:String{},VarToReplace:String{},VarReplacement:String{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:String{},VarToReplace:String{}))),
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
       \top{R}()))
-  []
+  [contentStartLine{}("307"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(307,8,307,37)")]
 
-// rule initTCell(Init)=>`<T>`(initKCell(Init),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`-__IMP-SYNTAX__Int`(I1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_-Int__INT__Int_Int`(#token("0","Int"),I1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(121) org.kframework.attributes.Location(Location(121,8,121,25)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'UndsUnds'Int{}(VarI1:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("0"),VarI1:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("121"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(121,8,121,25)")]
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarId:SortId{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisId{}(inj{SortId{}, SortK{}}(VarId:SortId{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisId{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKItem(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{TCell{},R} (
-        LblinitTCell{}(VarInit:Map{}),
-        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(VarInit:Map{}),LblinitStateCell{}())),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
+
+// rule isBlock(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBlock:SortBlock{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisBlock{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBlock{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,_18)=>Source requires `_<Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(553) org.kframework.attributes.Location(Location(553,8,554,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},Var'Unds'18:SortString{}),
+        VarSource:SortString{}),
+      \top{R}()))
+  [contentStartLine{}("553"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(553,8,554,57)")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(286) org.kframework.attributes.Location(Location(286,8,286,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("286"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,8,286,37)")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_11,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(738) org.kframework.attributes.Location(Location(738,8,738,64)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},Var'Unds'11:SortK{},VarB2:SortK{}),
+        VarB2:SortK{}),
+      \top{R}()))
+  [contentStartLine{}("738"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(738,8,738,64)")]
+
+// rule isStateCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCell:SortStateCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisStateCellOpt{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCellOpt:SortStateCellOpt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisStateCellOpt{}(inj{SortStateCellOpt{}, SortK{}}(VarStateCellOpt:SortStateCellOpt{}))))),
+        \bottom{R}()))),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(303) org.kframework.attributes.Location(Location(303,8,303,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("303"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(303,8,303,32)")]
+
+// rule isTCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarTCellFragment:SortTCellFragment{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisTCellFragment{}(inj{SortTCellFragment{}, SortK{}}(VarTCellFragment:SortTCellFragment{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(302) org.kframework.attributes.Location(Location(302,8,302,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("302"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(302,8,302,32)")]
+
+// rule isKItem(inj{Float,K}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortFloat{}, SortK{}}(VarFloat:SortFloat{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_=/=String__STRING__String_String`(S1,S2)=>`notBool_`(`_==String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(523) org.kframework.attributes.Location(Location(523,8,523,65)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [contentStartLine{}("523"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(523,8,523,65)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool"),_2)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(305) org.kframework.attributes.Location(Location(305,8,305,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("305"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(305,8,305,33)")]
+
+// rule isStateCellOpt(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `freshId(_)_ID-SYNTAX__Int`(I)=>`String2Id(_)_ID-SYNTAX__String`(`_+String__STRING__String_String`(#token("\"_\"","String"),`Int2String(_)_STRING__Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(713) org.kframework.attributes.Location(Location(713,8,713,62)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortId{},R} (
+        LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(VarI:SortInt{}),
+        LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(\dv{SortString{}}("\"_\""),LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{})))),
+      \top{R}()))
+  [contentStartLine{}("713"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(713,8,713,62)")]
+
+// rule isKItem(inj{Cell,K}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Stmt,K}(Stmt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortStmt{}, SortK{}}(VarStmt:SortStmt{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_+Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(120) org.kframework.attributes.Location(Location(120,8,120,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("120"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,8,120,29)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(_14,#token("\"\"","String"),_15)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(543) org.kframework.attributes.Location(Location(543,8,543,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'14:SortString{},\dv{SortString{}}("\"\""),Var'Unds'15:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [contentStartLine{}("543"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(543,8,543,33)")]
+
+// rule `_andBool_`(#token("false","Bool"),_4)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(287) org.kframework.attributes.Location(Location(287,8,287,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("false"),Var'Unds'4:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("287"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(287,8,287,37)")]
+
+// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarInt:SortInt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKResult{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBool:SortBool{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKResult{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKResult:SortKResult{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKResult{}(inj{SortKResult{}, SortK{}}(VarKResult:SortKResult{}))))),
+        \bottom{R}())))),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isAExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarInt:SortInt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisAExp{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarAExp:SortAExp{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisAExp{}(inj{SortAExp{}, SortK{}}(VarAExp:SortAExp{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarId:SortId{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisAExp{}(inj{SortId{}, SortK{}}(VarId:SortId{}))))),
+        \bottom{R}())))),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisAExp{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_modInt__INT__Int_Int`(I1,I2)=>`_%Int__INT__Int_Int`(`_+Int__INT__Int_Int`(`_%Int__INT__Int_Int`(I1,`absInt(_)_INT__Int`(I2)),`absInt(_)_INT__Int`(I2)),`absInt(_)_INT__Int`(I2)) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(374) org.kframework.attributes.Location(Location(374,5,377,23)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{}))),
+      \top{R}()))
+  [contentStartLine{}("374"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("5"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(374,5,377,23)")]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Int,KItem}(`_/Int__INT__Int_Int`(I1,I2))~>DotVar1),DotVar0) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(119) org.kframework.attributes.Location(Location(119,8,119,51)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{} \and{SortTCell{}} (
+    \equals{SortBool{},SortTCell{}}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("119"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(119,8,119,51)")]
+
+// rule isKItem(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `freshInt(_)_INT__Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(395) org.kframework.attributes.Location(Location(395,8,395,28)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI:SortInt{}),
+        VarI:SortInt{}),
+      \top{R}()))
+  [contentStartLine{}("395"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,8,395,28)")]
+
+// rule isCell(inj{TCell,K}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(297) org.kframework.attributes.Location(Location(297,8,297,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("297"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(297,8,297,38)")]
+
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`while(_)__IMP-SYNTAX__BExp_Block`(B,S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(B,`{_}_IMP-SYNTAX__Stmt`(`___IMP-SYNTAX__Stmt_Stmt`(inj{Block,Stmt}(S),`while(_)__IMP-SYNTAX__BExp_Block`(B,S))),`{}_IMP-SYNTAX_`(.KList)))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(187) org.kframework.attributes.Location(Location(187,8,187,53)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(VarB:SortBExp{},VarS:SortBlock{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarB:SortBExp{},Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(VarS:SortBlock{}),Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block{}(VarB:SortBExp{},VarS:SortBlock{}))),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'{}())),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("187"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(187,8,187,53)"), structural{}()]
+
+// rule isStateCell(inj{StateCell,K}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCellOpt(inj{KCellOpt,K}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(inj{SortKCellOpt{}, SortK{}}(VarKCellOpt:SortKCellOpt{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(284686302) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(), productionID{}("284686302")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_8,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(312) org.kframework.attributes.Location(Location(312,8,312,39)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'8:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("312"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(312,8,312,39)")]
 
 // rule initStateCell(.KList)=>`<state>`(`.Map`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{StateCell{},R} (
+      \equals{SortStateCell{},R} (
         LblinitStateCell{}(),
         Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}())),
       \top{R}()))
-  []
+  [initializer{}()]
 
-// rule rfindChar(_12,#token("\"\"","String"),_13)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(543) org.kframework.attributes.Location(Location(543,8,543,33)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isKItem(inj{AExp,K}(AExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Int{},R} (
-        LblrfindChar{}(Var'Unds'12:String{},\dv{String{}}("\"\""),Var'Unds'13:Int{}),
-        \dv{Int{}}("-1")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortAExp{}, SortK{}}(VarAExp:SortAExp{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool"),_5)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(300) org.kframework.attributes.Location(Location(300,8,300,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'5:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("300"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(300,8,300,34)")]
+
+// rule isPgm(inj{Pgm,K}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisPgm{}(inj{SortPgm{}, SortK{}}(VarPgm:SortPgm{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT__Int_Int`(`rfindString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(542) org.kframework.attributes.Location(Location(542,8,542,182)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("\"\"")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))),
+      \top{R}()))
+  [contentStartLine{}("542"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(542,8,542,182)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(295) org.kframework.attributes.Location(Location(295,8,295,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("295"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(295,8,295,38)")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarMap:SortMap{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisMap{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(inj{Bool,BExp}(T)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(`notBool_`(T))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(130) org.kframework.attributes.Location(Location(130,8,130,24)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(inj{SortBool{}, SortBExp{}}(VarT:SortBool{}))),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(LblnotBool'Unds'{}(VarT:SortBool{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("130"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(130,8,130,24)")]
+
+// rule isKItem(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_=/=K__K-EQUAL__K_K`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(731) org.kframework.attributes.Location(Location(731,8,731,45)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'K'UndsUnds'K-EQUAL'UndsUnds'K'Unds'K{}(VarK1:SortK{},VarK2:SortK{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
+      \top{R}()))
+  [contentStartLine{}("731"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(731,8,731,45)")]
+
+// rule isAExp(inj{Id,K}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisAExp{}(inj{SortId{}, SortK{}}(VarId:SortId{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{String,K}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortString{}, SortK{}}(VarString:SortString{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Pgm,K}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortPgm{}, SortK{}}(VarPgm:SortPgm{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isStmt(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStmt{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_>=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(538) org.kframework.attributes.Location(Location(538,8,538,63)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [contentStartLine{}("538"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(538,8,538,63)")]
+
+// rule isKItem(inj{TCellFragment,K}(TCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortTCellFragment{}, SortK{}}(VarTCellFragment:SortTCellFragment{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKResult(inj{KResult,K}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(inj{SortKResult{}, SortK{}}(VarKResult:SortKResult{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_==String__STRING__String_String`(S1,S2)=>`_==K_`(inj{String,K}(S1),inj{String,K}(S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(524) org.kframework.attributes.Location(Location(524,8,524,49)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(inj{SortString{}, SortK{}}(VarS1:SortString{}),inj{SortString{}, SortK{}}(VarS2:SortString{}))),
+      \top{R}()))
+  [contentStartLine{}("524"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(524,8,524,49)")]
+
+// rule isTCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarTCell:SortTCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisTCell{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1940445711) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(), productionID{}("1940445711")]
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(315) org.kframework.attributes.Location(Location(315,8,315,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [contentStartLine{}("315"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,8,315,57)")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(282) org.kframework.attributes.Location(Location(282,8,282,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("282"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(282,8,282,29)")]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1940445711) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(), productionID{}("1940445711")]
+
+// rule isStateCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCell:SortStateCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisStateCell{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(285) org.kframework.attributes.Location(Location(285,8,285,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("285"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(285,8,285,37)")]
+
+// rule isBlock(inj{Block,K}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBlock{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(inj{Bool,BExp}(#token("true","Bool")),B))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(B)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(131) org.kframework.attributes.Location(Location(131,8,131,22)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),VarB:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarB:SortBExp{}),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("131"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(131,8,131,22)")]
+
+// rule `<T>`(`<k>`(inj{Block,KItem}(`{_}_IMP-SYNTAX__Stmt`(S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(151) org.kframework.attributes.Location(Location(151,8,151,16)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt{}(VarS:SortStmt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("151"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(151,8,151,16)"), structural{}()]
+
+// rule `_andBool_`(_7,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(288) org.kframework.attributes.Location(Location(288,8,288,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'7:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("288"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(288,8,288,37)")]
+
+// rule isList(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isStmt(inj{Stmt,K}(Stmt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStmt{}(inj{SortStmt{}, SortK{}}(VarStmt:SortStmt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -4852,255 +1856,363 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCell:StateCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStmt:SortStmt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortStmt{}, SortK{}}(VarStmt:SortStmt{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarSet:Set{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Set{}, K{}}(VarSet:Set{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCell:SortStateCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarInt:Int{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Int{}, K{}}(VarInt:Int{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarPgm:SortPgm{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortPgm{}, SortK{}}(VarPgm:SortPgm{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarTCell:TCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{TCell{}, K{}}(VarTCell:TCell{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCellOpt:SortKCellOpt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortKCellOpt{}, SortK{}}(VarKCellOpt:SortKCellOpt{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarAExp:AExp{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{AExp{}, K{}}(VarAExp:AExp{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarIds:Ids{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Ids{}, K{}}(VarIds:Ids{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarSet:SortSet{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarTCellFragment:TCellFragment{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{TCellFragment{}, K{}}(VarTCellFragment:TCellFragment{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarInt:SortInt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarId:Id{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Id{}, K{}}(VarId:Id{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCellOpt:SortStateCellOpt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortStateCellOpt{}, SortK{}}(VarStateCellOpt:SortStateCellOpt{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStmt:Stmt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Stmt{}, K{}}(VarStmt:Stmt{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarTCell:SortTCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarPgm:Pgm{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Pgm{}, K{}}(VarPgm:Pgm{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarFloat:SortFloat{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortFloat{}, SortK{}}(VarFloat:SortFloat{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCellOpt:KCellOpt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{KCellOpt{}, K{}}(VarKCellOpt:KCellOpt{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarMap:SortMap{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKCell:KCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{KCell{}, K{}}(VarKCell:KCell{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarList:SortList{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortList{}, SortK{}}(VarList:SortList{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCellOpt:StateCellOpt{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{StateCellOpt{}, K{}}(VarStateCellOpt:StateCellOpt{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarCell:SortCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStream:Stream{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Stream{}, K{}}(VarStream:Stream{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarAExp:SortAExp{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortAExp{}, SortK{}}(VarAExp:SortAExp{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarFloat:Float{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Float{}, K{}}(VarFloat:Float{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarIds:SortIds{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortIds{}, SortK{}}(VarIds:SortIds{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarMap:Map{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Map{}, K{}}(VarMap:Map{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBlock:SortBlock{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarList:List{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{List{}, K{}}(VarList:List{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarTCellFragment:SortTCellFragment{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortTCellFragment{}, SortK{}}(VarTCellFragment:SortTCellFragment{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarCell:Cell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Cell{}, K{}}(VarCell:Cell{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarString:SortString{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortString{}, SortK{}}(VarString:SortString{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBlock:Block{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Block{}, K{}}(VarBlock:Block{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarId:SortId{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortId{}, SortK{}}(VarId:SortId{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarIOError:IOError{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{IOError{}, K{}}(VarIOError:IOError{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKResult:SortKResult{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortKResult{}, SortK{}}(VarKResult:SortKResult{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarString:String{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{String{}, K{}}(VarString:String{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBExp:SortBExp{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortBExp{}, SortK{}}(VarBExp:SortBExp{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKResult:KResult{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{KResult{}, K{}}(VarKResult:KResult{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBool:SortBool{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBExp:BExp{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{BExp{}, K{}}(VarBExp:BExp{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarBool:Bool{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{Bool{}, K{}}(VarBool:Bool{}))))),
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarKItem:KItem{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisKItem{}(inj{KItem{}, K{}}(VarKItem:KItem{}))))),
-        \bottom{R}())))))))))))))))))))))))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKItem:SortKItem{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortKItem{}, SortK{}}(VarKItem:SortKItem{}))))),
+        \bottom{R}())))))))))))))))))))))))),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1006751649) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1810923540) seqstrict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), seqstrict{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), latex{}("{#1}\\leq{#2}"), productionID{}("1810923540")]
 
-// rule isString(inj{String,K}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `findChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT__Int_Int`(`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)))) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(540) org.kframework.attributes.Location(Location(540,8,540,431)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("\"\"")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))))),
+      \top{R}()))
+  [contentStartLine{}("540"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(540,8,540,431)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>`_+Int__INT__Int_Int`(#token("1","Int"),`countAllOccurrences(_,_)_STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING__String`(ToCount)),`lengthString(_)_STRING__String`(Source)),ToCount)) requires `_>=Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(547) org.kframework.attributes.Location(Location(547,8,548,60)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToCount:SortString{}))),
+      \top{R}()))
+  [contentStartLine{}("547"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(547,8,548,60)")]
+
+// rule isBExp(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisString{}(inj{String{}, K{}}(VarString:String{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisBExp{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isMap(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisMap{}(inj{Map{}, K{}}(VarMap:Map{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
+// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX__Id_AExp0_`(inj{Id,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() format(%1 %2 %3%4) org.kframework.attributes.Location(Location(41,20,41,90)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(417557780) strict(2)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'{}(inj{SortId{}, SortK{}}(VarK0:SortId{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}("2"), format{}("%1 %2 %3%4"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), productionID{}("417557780")]
 
-// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_3)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(311) org.kframework.attributes.Location(Location(311,8,311,40)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("false"),Var'Unds'3:Bool{}),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(296) org.kframework.attributes.Location(Location(296,8,296,38)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:Bool{},\dv{Bool{}}("false")),
-        VarB:Bool{}),
-      \top{R}()))
-  []
-
-// rule isTCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarTCellFragment:TCellFragment{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisTCellFragment{}(inj{TCellFragment{}, K{}}(VarTCellFragment:TCellFragment{}))))),
-        \bottom{R}())),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCellOpt:SortKCellOpt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKCellOpt{}(inj{SortKCellOpt{}, SortK{}}(VarKCellOpt:SortKCellOpt{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKCellOpt{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
+        \bottom{R}()))),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisTCellFragment{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
-
-// rule isKItem(inj{StateCellOpt,K}(StateCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{StateCellOpt{}, K{}}(VarStateCellOpt:StateCellOpt{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
+  [owise{}()]
 
 // rule isPgm(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarPgm:Pgm{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisPgm{}(inj{Pgm{}, K{}}(VarPgm:Pgm{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarPgm:SortPgm{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisPgm{}(inj{SortPgm{}, SortK{}}(VarPgm:SortPgm{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisPgm{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisPgm{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(290) org.kframework.attributes.Location(Location(290,8,290,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("290"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,8,290,37)")]
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1940445711) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(), productionID{}("1940445711")]
+
+// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(380) org.kframework.attributes.Location(Location(380,8,380,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI2:SortInt{}),
+      \top{R}()))
+  [contentStartLine{}("380"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(380,8,380,57)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(298) org.kframework.attributes.Location(Location(298,8,298,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [contentStartLine{}("298"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(298,8,298,57)")]
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1810923540) seqstrict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), seqstrict{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), latex{}("{#1}\\leq{#2}"), productionID{}("1810923540")]
+
+// rule isString(inj{String,K}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(inj{SortString{}, SortK{}}(VarString:SortString{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_divInt__INT__Int_Int`(I1,I2)=>`_/Int__INT__Int_Int`(`_-Int__INT__Int_Int`(I1,`_modInt__INT__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(371) org.kframework.attributes.Location(Location(371,8,372,23)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
+      \top{R}()))
+  [contentStartLine{}("371"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(371,8,372,23)")]
+
+// rule isMap(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(284686302) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{SortAExp{}, SortK{}}(VarK1:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(), productionID{}("284686302")]
+
+// rule initTCell(Init)=>`<T>`(initKCell(Init),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortTCell{},R} (
+        LblinitTCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitStateCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN)=>`_-Int__INT__Int_Int`(`_modInt__INT__Int_Int`(`_+Int__INT__Int_Int`(`bitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(369) org.kframework.attributes.Location(Location(369,8,369,149)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [contentStartLine{}("369"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(369,8,369,149)")]
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING__String_String_String_Int`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source)),ToReplace,Replacement,`_-Int__INT__Int_Int`(Count,#token("1","Int")))) requires `_>Int__INT__Int_Int`(Count,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(557) org.kframework.attributes.Location(Location(557,8,560,30)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},VarCount:SortInt{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [contentStartLine{}("557"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(557,8,560,30)")]
+
+// rule isKItem(inj{StateCellOpt,K}(StateCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortStateCellOpt{}, SortK{}}(VarStateCellOpt:SortStateCellOpt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -5108,25 +2220,19 @@ module IMP
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisId{}(inj{Id{}, K{}}(VarId:Id{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisId{}(inj{SortId{}, SortK{}}(VarId:SortId{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(inj{Bool,BExp}(#token("false","Bool")),_19))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(#token("false","Bool"))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(130) org.kframework.attributes.Location(Location(130,8,130,27)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(inj{Bool{}, BExp{}}(\dv{Bool{}}("false")),Var'Unds'19:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Bool{}, KItem{}}(\dv{Bool{}}("false")),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
   []
 
 // rule isKItem(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{Int{}, K{}}(VarInt:Int{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -5134,67 +2240,47 @@ module IMP
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisTCellFragment{}(inj{TCellFragment{}, K{}}(VarTCellFragment:TCellFragment{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(inj{SortTCellFragment{}, SortK{}}(VarTCellFragment:SortTCellFragment{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isTCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(284686302) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(), productionID{}("284686302")]
+
+// rule `_=/=Int__INT__Int_Int`(I1,I2)=>`notBool_`(`_==Int__INT__Int_Int`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(391) org.kframework.attributes.Location(Location(391,8,391,53)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
+    \top{R}(),
     \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarTCell:TCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisTCell{}(inj{TCell{}, K{}}(VarTCell:TCell{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisTCell{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}))),
       \top{R}()))
-  []
+  [contentStartLine{}("391"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(391,8,391,53)")]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source))) requires `_>=Int__INT__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(550) org.kframework.attributes.Location(Location(550,8,552,66)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})))),
+      \top{R}()))
+  [contentStartLine{}("550"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(550,8,552,66)")]
 
 // rule isCell(inj{KCell,K}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisCell{}(inj{KCell{}, K{}}(VarKCell:KCell{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_>String__STRING__String_String`(S1,S2)=>`_<String__STRING__String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(537) org.kframework.attributes.Location(Location(537,8,537,52)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:String{},VarS2:String{}),
-        Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:String{},VarS1:String{})),
-      \top{R}()))
-  []
-
-// rule isStateCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarStateCell:StateCell{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisStateCell{}(inj{StateCell{}, K{}}(VarStateCell:StateCell{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisStateCell{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -5202,9 +2288,9 @@ module IMP
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisStateCellOpt{}(inj{StateCellOpt{}, K{}}(VarStateCellOpt:StateCellOpt{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(inj{SortStateCellOpt{}, SortK{}}(VarStateCellOpt:SortStateCellOpt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
@@ -5212,235 +2298,330 @@ module IMP
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKCellOpt{}(inj{KCell{}, K{}}(VarKCell:KCell{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isIOError(inj{IOError,K}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBool:SortBool{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisBool{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(inj{Bool,BExp}(#token("false","Bool")),_20,S))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(181) org.kframework.attributes.Location(Location(181,8,181,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")),Var'Unds'20:SortBlock{},VarS:SortBlock{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("181"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(181,8,181,32)")]
+
+// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,K}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisIOError{}(inj{IOError{}, K{}}(VarIOError:IOError{})),
-        \dv{Bool{}}("true")),
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortK{}}(\dv{SortKConfigVar{}}("$PGM"))))),
       \top{R}()))
-  []
+  [initializer{}()]
+
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX__Id_AExp`(X,inj{Int,AExp}(I)))~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),_23),DotVar2)))=>`<T>`(`<k>`(DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),inj{Int,K}(I)),DotVar2))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(158) org.kframework.attributes.Location(Location(158,8,158,73)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp{}(VarX:SortId{},inj{SortInt{}, SortAExp{}}(VarI:SortInt{}))),VarDotVar1:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortK{}}(VarX:SortId{}),Var'Unds'23:SortK{}),VarDotVar2:SortMap{}))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar1:SortK{}),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortK{}}(VarX:SortId{}),inj{SortInt{}, SortK{}}(VarI:SortInt{})),VarDotVar2:SortMap{}))))))
+  [contentStartLine{}("158"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(158,8,158,73)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(283) org.kframework.attributes.Location(Location(283,8,283,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("283"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,8,283,29)")]
 
 // rule isBool(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisBool{}(inj{Bool{}, K{}}(VarBool:Bool{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisBool{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(inj{Bool,BExp}(#token("true","Bool")),B))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(B)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(129) org.kframework.attributes.Location(Location(129,8,129,22)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(inj{Bool{}, BExp{}}(\dv{Bool{}}("true")),VarB:BExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(VarB:BExp{}),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX__AExp_AExp`(HOLE,K1))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX__AExp_AExp1_`(inj{AExp,K}(K1))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() left() org.kframework.attributes.Location(Location(30,20,30,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1076984738) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarHOLE:AExp{},VarK1:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'{}(inj{AExp{}, K{}}(VarK1:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}))))
-  []
-
-// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(302) org.kframework.attributes.Location(Location(302,8,302,32)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(308) org.kframework.attributes.Location(Location(308,8,308,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("false"),VarB:Bool{}),
-        VarB:Bool{}),
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
       \top{R}()))
-  []
+  [contentStartLine{}("308"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(308,8,308,37)")]
 
-// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(313) org.kframework.attributes.Location(Location(313,8,313,45)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
-    \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:Bool{},\dv{Bool{}}("false")),
-        LblnotBool'Unds'{}(VarB:Bool{})),
-      \top{R}()))
-  []
-
-// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int__INT__Int_Int`(findString(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(545) org.kframework.attributes.Location(Location(545,8,546,59)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(LblfindString{}(VarSource:String{},VarToCount:String{},\dv{Int{}}("0")),\dv{Int{}}("0")),
-        \dv{Bool{}}("true")),
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStateCell:SortStateCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisCell{}(inj{SortStateCell{}, SortK{}}(VarStateCell:SortStateCell{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarCell:SortCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisCell{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarTCell:SortTCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisCell{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{}))))),
+        \bottom{R}()))))),
+      \top{R}()),
     \and{R} (
-      \equals{Int{},R} (
-        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:String{},VarToCount:String{}),
-        \dv{Int{}}("0")),
+      \equals{SortBool{},R} (
+        LblisCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
 // rule isCell(inj{Cell,K}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisCell{}(inj{Cell{}, K{}}(VarCell:Cell{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisCell{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `#stderr_K-IO_`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(861) org.kframework.attributes.Location(Location(861,8,861,20)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX__BExp0_`(.KList)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) heat() org.kframework.attributes.Location(Location(35,20,35,67)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1581078471) strict()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(VarHOLE:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp0'Unds'{}(),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}(""), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), productionID{}("1581078471")]
+
+// rule `<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX__BExp_Block_Block1_`(inj{Block,K}(K1),inj{Block,K}(K2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(HOLE,K1,K2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [colors(yellow, white, white, yellow) cool() format(%1 %2%3%4 %5 %6 %7) org.kframework.attributes.Location(Location(42,20,43,123)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1350751778) strict(1)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(inj{SortBlock{}, SortK{}}(VarK1:SortBlock{}),inj{SortBlock{}, SortK{}}(VarK2:SortBlock{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [strict{}("1"), format{}("%1 %2%3%4 %5 %6 %7"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), cool{}(), colors{}("yellow, white, white, yellow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), productionID{}("1350751778")]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarFloat:SortFloat{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisFloat{}(inj{SortFloat{}, SortK{}}(VarFloat:SortFloat{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(293) org.kframework.attributes.Location(Location(293,8,293,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Int{},R} (
-        Lbl'Hash'stderr'Unds'K-IO'Unds'{}(),
-        \dv{Int{}}("2")),
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [contentStartLine{}("293"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(293,8,293,36)")]
 
-// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,K}(K1),inj{Bool,K}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(728) org.kframework.attributes.Location(Location(728,8,728,43)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`___IMP-SYNTAX__Stmt_Stmt`(S1,S2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Stmt,KItem}(S1)~>inj{Stmt,KItem}(S2)~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(171) org.kframework.attributes.Location(Location(171,8,171,35)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K) structural()]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt{}(VarS1:SortStmt{},VarS2:SortStmt{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS1:SortStmt{}),kseq{}(inj{SortStmt{}, SortKItem{}}(VarS2:SortStmt{}),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("171"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(171,8,171,35)"), structural{}()]
+
+// rule `<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX__BExp_Block_Block`(HOLE,K1,K2))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX__BExp_Block_Block1_`(inj{Block,K}(K1),inj{Block,K}(K2))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [colors(yellow, white, white, yellow) format(%1 %2%3%4 %5 %6 %7) heat() org.kframework.attributes.Location(Location(42,20,43,123)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1350751778) strict(1)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'{}(inj{SortBlock{}, SortK{}}(VarK1:SortBlock{}),inj{SortBlock{}, SortK{}}(VarK2:SortBlock{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [strict{}("1"), format{}("%1 %2%3%4 %5 %6 %7"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), colors{}("yellow, white, white, yellow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), productionID{}("1350751778")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarSet:SortSet{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisSet{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `replaceAll(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING__String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(562) org.kframework.attributes.Location(Location(562,8,562,154)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:Bool{},VarK2:Bool{}),
-        Lbl'UndsEqlsEqls'K'Unds'{}(inj{Bool{}, K{}}(VarK1:Bool{}),inj{Bool{}, K{}}(VarK2:Bool{}))),
+      \equals{SortString{},R} (
+        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{}))),
       \top{R}()))
-  []
+  [contentStartLine{}("562"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(562,8,562,154)")]
 
-// rule `<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX__BExp`(inj{Bool,BExp}(T)))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(`notBool_`(T))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(128) org.kframework.attributes.Location(Location(128,8,128,24)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{BExp{}, KItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp{}(inj{Bool{}, BExp{}}(VarT:Bool{}))),VarDotVar1:K{})),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Bool{}, KItem{}}(LblnotBool'Unds'{}(VarT:Bool{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(379) org.kframework.attributes.Location(Location(379,8,379,57)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:Int{},VarI2:Int{}),
-        VarI1:Int{}),
-      \top{R}()))
-  []
-
-// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool"),_6)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(300) org.kframework.attributes.Location(Location(300,8,300,34)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(291) org.kframework.attributes.Location(Location(291,8,291,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("true"),Var'Unds'6:Bool{}),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+        VarK:SortBool{}),
       \top{R}()))
-  []
+  [contentStartLine{}("291"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(291,8,291,37)")]
 
-// rule `_orElseBool__BOOL__Bool_Bool`(_5,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(306) org.kframework.attributes.Location(Location(306,8,306,33)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule isKResult(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'5:Bool{},\dv{Bool{}}("true")),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKResult{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(307) org.kframework.attributes.Location(Location(307,8,307,37)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0) requires isKResult(inj{AExp,K}(K0)) ensures #token("true","Bool") [color(pink) heat() latex({#1}\leq{#2}) org.kframework.attributes.Location(Location(34,20,34,91)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) productionID(1810923540) seqstrict()]
+  axiom{} \and{SortTCell{}} (
+    \equals{SortBool{},SortTCell{}}(
+        LblisKResult{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),
+        \dv{SortBool{}}("true")), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{SortAExp{}, SortK{}}(VarK0:SortAExp{})),VarDotVar1:SortK{}))),VarDotVar0:SortStateCell{}))))
+  [heat{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), color{}("pink"), seqstrict{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), latex{}("{#1}\\leq{#2}"), productionID{}("1810923540")]
+
+// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(379) org.kframework.attributes.Location(Location(379,8,379,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI1:SortInt{}),
+      \top{R}()))
+  [contentStartLine{}("379"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(379,8,379,57)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_9,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(306) org.kframework.attributes.Location(Location(306,8,306,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("false"),VarK:Bool{}),
-        VarK:Bool{}),
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'9:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
       \top{R}()))
-  []
+  [contentStartLine{}("306"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,8,306,33)")]
 
-// rule rfindChar(S1,S2,I)=>`maxInt(_,_)_INT__Int_Int`(rfindString(S1,substrString(S2,#token("0","Int"),#token("1","Int")),I),rfindChar(S1,substrString(S2,#token("1","Int"),lengthString(S2)),I)) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(542) org.kframework.attributes.Location(Location(542,8,542,182)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
-  axiom{R} \implies{R} (
-    \equals{Bool{},R}(
-        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:String{},\dv{String{}}("\"\"")),
-        \dv{Bool{}}("true")),
-    \and{R} (
-      \equals{Int{},R} (
-        LblrfindChar{}(VarS1:String{},VarS2:String{},VarI:Int{}),
-        LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(LblrfindString{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("0"),\dv{Int{}}("1")),VarI:Int{}),LblrfindChar{}(VarS1:String{},LblsubstrString{}(VarS2:String{},\dv{Int{}}("1"),LbllengthString{}(VarS2:String{})),VarI:Int{}))),
-      \top{R}()))
-  []
+// rule `<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX__BExp_BExp`(inj{Bool,BExp}(#token("false","Bool")),_21))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{Bool,KItem}(#token("false","Bool"))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(132) org.kframework.attributes.Location(Location(132,8,132,27)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortTCell{}} (
+    \top{SortTCell{}}(), \and{SortTCell{}} (
+    \top{SortTCell{}}(), \rewrites{SortTCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")),Var'Unds'21:SortBExp{})),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(\dv{SortBool{}}("false")),VarDotVar1:SortK{})),VarDotVar0:SortStateCell{}))))
+  [contentStartLine{}("132"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,8,132,27)")]
 
 // rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \ceil{Bool{},R} (
-            \exists{Bool{}} (VarInt:Int{}, 
-              \and{Bool{}} (
-                \top{Bool{}}(),
-                LblisInt{}(inj{Int{}, K{}}(VarInt:Int{}))))),
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarInt:SortInt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisInt{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisInt{}(VarK:K{}),
-        \dv{Bool{}}("false")),
+      \equals{SortBool{},R} (
+        LblisInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
       \top{R}()))
-  []
+  [owise{}()]
 
-// rule `#open(_)_K-IO__String`(S)=>`#open(_,_)_K-IO__String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(853) org.kframework.attributes.Location(Location(853,8,853,48)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `_==Int__INT__Int_Int`(I1,I2)=>`_==K_`(inj{Int,K}(I1),inj{Int,K}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(390) org.kframework.attributes.Location(Location(390,8,390,40)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Int{},R} (
-        Lbl'Hash'open'LParUndsRParUnds'K-IO'UndsUnds'String{}(VarS:String{}),
-        Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'UndsUnds'String'Unds'String{}(VarS:String{},\dv{String{}}("\"r+\""))),
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(inj{SortInt{}, SortK{}}(VarI1:SortInt{}),inj{SortInt{}, SortK{}}(VarI2:SortInt{}))),
       \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX__AExp_AExp0_`(inj{AExp,K}(K0))~>DotVar1),DotVar0)=>`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX__AExp_AExp`(K0,HOLE))~>DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [color(pink) cool() left() org.kframework.attributes.Location(Location(31,20,31,73)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) productionID(1006751649) strict()]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(VarHOLE:AExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'{}(inj{AExp{}, K{}}(VarK0:AExp{})),VarDotVar1:K{}))),VarDotVar0:StateCell{}),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{AExp{}, KItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp{}(VarK0:AExp{},VarHOLE:AExp{})),VarDotVar1:K{})),VarDotVar0:StateCell{}))))
-  []
-
-// rule isKResult(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        LblisKResult{}(inj{Int{}, K{}}(VarInt:Int{})),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool"),_1)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(305) org.kframework.attributes.Location(Location(305,8,305,33)) org.kframework.attributes.Source(Source(/home/theo/builds/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{Bool{},R} (
-        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{Bool{}}("true"),Var'Unds'1:Bool{}),
-        \dv{Bool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<T>`(`<k>`(inj{Id,KItem}(X)~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),I),DotVar2)))=>`<T>`(`<k>`(I~>DotVar1),`<state>`(`_Map_`(`_|->_`(inj{Id,K}(X),I),DotVar2))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(110) org.kframework.attributes.Location(Location(110,8,110,60)) org.kframework.attributes.Source(Source(/home/theo/builds/kore-to-llvm/test/./imp.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
-  axiom{} \and{TCell{}} (
-    \top{TCell{}}(), \and{TCell{}} (
-    \top{TCell{}}(), \rewrites{TCell{}}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{Id{}, KItem{}}(VarX:Id{}),VarDotVar1:K{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{Id{}, K{}}(VarX:Id{}),VarI:K{}),VarDotVar2:Map{}))),Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(append{}(VarI:K{},VarDotVar1:K{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{Id{}, K{}}(VarX:Id{}),VarI:K{}),VarDotVar2:Map{}))))))
-  []
+  [contentStartLine{}("390"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(390,8,390,40)")]
 
 // rule isKItem(inj{TCell,K}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{Bool{},R} (
-        LblisKItem{}(inj{TCell{}, K{}}(VarTCell:TCell{})),
-        \dv{Bool{}}("true")),
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortTCell{}, SortK{}}(VarTCell:SortTCell{})),
+        \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-endmodule []
+// rule isStmt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBlock:SortBlock{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisStmt{}(inj{SortBlock{}, SortK{}}(VarBlock:SortBlock{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarStmt:SortStmt{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisStmt{}(inj{SortStmt{}, SortK{}}(VarStmt:SortStmt{}))))),
+        \bottom{R}()))),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStmt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(61,1,205,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/tests/regression-new/imp-kore/./imp.k)")]

--- a/test/imp.ll
+++ b/test/imp.ll
@@ -1,3 +1,5 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
 
 %mpz = type { i32, i32, i64* }
 %blockheader = type { i64 }
@@ -149,14 +151,14 @@ entry:
   %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %1 = bitcast i8* %malloccall to { %blockheader, [0 x i64], i1 }*
   %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %1, i64 0, i32 0
-  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  store %blockheader { i64 4503608217305214 }, %blockheader* %inj
   %2 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %1, i64 0, i32 2
   store i1 %VarK1, i1* %2
   %3 = bitcast { %blockheader, [0 x i64], i1 }* %1 to %block*
   %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %4 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], i1 }*
   %inj2 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %4, i64 0, i32 0
-  store %blockheader { i64 4503603922337918 }, %blockheader* %inj2
+  store %blockheader { i64 4503608217305214 }, %blockheader* %inj2
   %5 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %4, i64 0, i32 2
   store i1 %VarK2, i1* %5
   %6 = bitcast { %blockheader, [0 x i64], i1 }* %4 to %block*
@@ -685,7 +687,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  store %blockheader { i64 4503608217305214 }, %blockheader* %inj
   %4 = alloca i1
   %5 = call i1 @hook_INT_le(i1* %4, %mpz* %VarI1, %mpz* %VarI2)
   br i1 %5, label %notstuck, label %stuck
@@ -1615,7 +1617,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  store %blockheader { i64 4503608217305214 }, %blockheader* %inj
   %hook_BOOL_not = xor i1 %VarT, true
   %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
   store i1 %hook_BOOL_not, i1* %4
@@ -3374,7 +3376,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  store %blockheader { i64 4503608217305214 }, %blockheader* %inj
   %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
   store i1 false, i1* %4
   %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*

--- a/test/imp.ll
+++ b/test/imp.ll
@@ -1,0 +1,3441 @@
+
+%mpz = type { i32, i32, i64* }
+%blockheader = type { i64 }
+%block = type { %blockheader, [0 x i64*] }
+%map = type { i64, i8*, i8* }
+
+@int_-1 = global %mpz { i32 1, i32 -1, i64* getelementptr inbounds ([1 x i64], [1 x i64]* @int_-1_limbs, i32 0, i32 0) }
+@int_-1_limbs = global [1 x i64] [i64 1]
+@int_0 = global %mpz { i32 0, i32 0, i64* getelementptr inbounds ([0 x i64], [0 x i64]* @int_0_limbs, i32 0, i32 0) }
+@int_0_limbs = global [0 x i64] zeroinitializer
+@int_1 = global %mpz { i32 1, i32 1, i64* getelementptr inbounds ([1 x i64], [1 x i64]* @int_1_limbs, i32 0, i32 0) }
+@int_1_limbs = global [1 x i64] [i64 1]
+@"token_\22_\22" = global { %blockheader, [3 x i8] } { %blockheader { i64 3 }, [3 x i8] c"\22_\22" }
+@"token_$PGM" = global { %blockheader, [4 x i8] } { %blockheader { i64 4 }, [4 x i8] c"$PGM" }
+
+define %block* @apply_rule_0(%block* %K2) {
+entry:
+  ret %block* %K2
+}
+
+; Function Attrs: noreturn
+declare void @abort() #0
+
+define %block* @apply_rule_1(%block* %K1, %block* %K2, %block* %K3) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %1 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %K1, %block** %1
+  %2 = alloca %block*
+  %3 = call i1 @"eval_append{SortK{},SortK{}}"(%block** %2, %block* %K2, %block* %K3)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %4, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %6
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare noalias i8* @malloc(i64)
+
+declare i1 @"eval_append{SortK{},SortK{}}"(%block**, %block*, %block*)
+
+define i1 @apply_rule_2() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_3(%block* %VarS1, %block* %VarS2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_STRING_lt(i1* %0, %block* %VarS2, %block* %VarS1)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  %hook_BOOL_not = xor i1 %2, true
+  ret i1 %hook_BOOL_not
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_lt(i1*, %block*, %block*)
+
+define i1 @apply_rule_4() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_5() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_6(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_7() {
+entry:
+  ret i1 true
+}
+
+define %mpz* @apply_rule_8() {
+entry:
+  ret %mpz* @int_-1
+}
+
+define %block* @apply_rule_9(%block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %2 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %VarDotVar1, %block** %2
+  %3 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %3, %block** %4
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %6
+}
+
+define i1 @apply_rule_10() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_11() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_12() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_13() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_14() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_15(i1 %VarK1, i1 %VarK2) {
+entry:
+  %0 = alloca i1
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall to { %blockheader, [0 x i64], i1 }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %1, i64 0, i32 0
+  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  %2 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %1, i64 0, i32 2
+  store i1 %VarK1, i1* %2
+  %3 = bitcast { %blockheader, [0 x i64], i1 }* %1 to %block*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], i1 }*
+  %inj2 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %4, i64 0, i32 0
+  store %blockheader { i64 4503603922337918 }, %blockheader* %inj2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %4, i64 0, i32 2
+  store i1 %VarK2, i1* %5
+  %6 = bitcast { %blockheader, [0 x i64], i1 }* %4 to %block*
+  %7 = call i1 @hook_KEQUAL_eq(i1* %0, %block* %3, %block* %6)
+  br i1 %7, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %8 = load i1, i1* %0
+  ret i1 %8
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_KEQUAL_eq(i1*, %block*, %block*)
+
+define %block* @apply_rule_16(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612585 }, %blockheader* %"Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarK1, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define i1 @apply_rule_17() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_18() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_19() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_20() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_21() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_22(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355912 }, %blockheader* %"Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp0'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356036 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK0, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define %mpz* @apply_rule_23() {
+entry:
+  ret %mpz* @int_0
+}
+
+define i1 @apply_rule_24() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_25(%block* %VarSource) {
+entry:
+  ret %block* %VarSource
+}
+
+define i1 @apply_rule_26() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_27(i1 %VarB) {
+entry:
+  %hook_BOOL_not = xor i1 %VarB, true
+  ret i1 %hook_BOOL_not
+}
+
+define i1 @apply_rule_28() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_29() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_30() {
+entry:
+  ret i1 false
+}
+
+define %mpz* @apply_rule_31(%mpz* %VarI, %mpz* %VarLEN, %mpz* %VarIDX) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %2 = call i1 @hook_INT_shr(%mpz* %1, %mpz* %VarI, %mpz* %VarIDX)
+  br i1 %2, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall2 to %mpz*
+  %4 = call i1 @hook_INT_shl(%mpz* %3, %mpz* @int_1, %mpz* %VarLEN)
+  br i1 %4, label %notstuck3, label %stuck
+
+notstuck3:                                        ; preds = %notstuck
+  %5 = call i1 @hook_INT_emod(%mpz* %0, %mpz* %1, %mpz* %3)
+  br i1 %5, label %notstuck4, label %stuck
+
+notstuck4:                                        ; preds = %notstuck3
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck3, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_shr(%mpz*, %mpz*, %mpz*)
+
+declare i1 @hook_INT_shl(%mpz*, %mpz*, %mpz*)
+
+declare i1 @hook_INT_emod(%mpz*, %mpz*, %mpz*)
+
+define %block* @apply_rule_32(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612601 }, %blockheader* %"Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarK1, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define %block* @apply_rule_33(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612603 }, %blockheader* %"Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarK1, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define i1 @apply_rule_34() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_35(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355911 }, %blockheader* %"Lbl'Hash'freezer'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp1'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define i1 @apply_rule_36() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_37(%block* %VarX, %block* %VarI, %block* %VarDotVar1, %map %VarDotVar2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %2 = alloca %block*
+  %3 = call i1 @"eval_append{SortK{},SortK{}}"(%block** %2, %block* %VarI, %block* %VarDotVar1)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %4, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %6, %block** %7
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %map }* getelementptr ({ %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %map }*
+  %"Lbl'-LT-'state'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %8, i64 0, i32 0
+  store %blockheader { i64 844442110001154 }, %blockheader* %"Lbl'-LT-'state'-GT-'"
+  %9 = alloca %map
+  %10 = alloca %map
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %11 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %11, i64 0, i32 0
+  store %blockheader { i64 562958543356036 }, %blockheader* %inj
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %11, i64 0, i32 2
+  store %block* %VarX, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %11 to %block*
+  %14 = call i1 @hook_MAP_element(%map* %10, %block* %13, %block* %VarI)
+  br i1 %14, label %notstuck4, label %stuck
+
+notstuck4:                                        ; preds = %notstuck
+  %15 = load %map, %map* %10
+  %16 = alloca %map
+  store %map %15, %map* %16
+  %17 = alloca %map
+  store %map %VarDotVar2, %map* %17
+  %18 = call i1 @hook_MAP_concat(%map* %9, %map* %16, %map* %17)
+  br i1 %18, label %notstuck5, label %stuck
+
+notstuck5:                                        ; preds = %notstuck4
+  %19 = load %map, %map* %9
+  %20 = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %8, i64 0, i32 2
+  store %map %19, %map* %20
+  %21 = bitcast { %blockheader, [0 x i64], %map }* %8 to %block*
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %21, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+
+stuck:                                            ; preds = %notstuck4, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_MAP_element(%map*, %block*, %block*)
+
+declare i1 @hook_MAP_concat(%map*, %map*, %map*)
+
+define i1 @apply_rule_38() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_39() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_40() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_41(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define %block* @apply_rule_42(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarS) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarS, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_43() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_44(%mpz* %VarI1, %mpz* %VarI2, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  %4 = alloca i1
+  %5 = call i1 @hook_INT_le(i1* %4, %mpz* %VarI1, %mpz* %VarI2)
+  br i1 %5, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %6 = load i1, i1* %4
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %6, i1* %7
+  %8 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %16
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_le(i1*, %mpz*, %mpz*)
+
+define %block* @apply_rule_45(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612586 }, %blockheader* %"Lbl'UndsAndAndUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'BExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarK1, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define %block* @apply_rule_46(%block* %VarX, %map %VarRho, %block* %VarXs, %block* %"Var'Unds'22") {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 562958543356040 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 281487861612621 }, %blockheader* %"Lblint'UndsSClnUndsUnds'IMP-SYNTAX'UndsUnds'Ids'Unds'Stmt"
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %3, i64 0, i32 2
+  store %block* %VarXs, %block** %4
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %3, i64 0, i32 3
+  store %block* %"Var'Unds'22", %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %3 to %block*
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %6, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %map }* getelementptr ({ %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* null, i32 1) to i64))
+  %12 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %map }*
+  %"Lbl'-LT-'state'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %12, i64 0, i32 0
+  store %blockheader { i64 844442110001154 }, %blockheader* %"Lbl'-LT-'state'-GT-'"
+  %13 = alloca %map
+  %14 = alloca %map
+  store %map %VarRho, %map* %14
+  %15 = alloca %map
+  %malloccall5 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %16 = bitcast i8* %malloccall5 to { %blockheader, [0 x i64], %block* }*
+  %inj6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %16, i64 0, i32 0
+  store %blockheader { i64 562958543356036 }, %blockheader* %inj6
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %16, i64 0, i32 2
+  store %block* %VarX, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block* }* %16 to %block*
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %19 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %mpz* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %19, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj8
+  %20 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %19, i64 0, i32 2
+  store %mpz* @int_0, %mpz** %20
+  %21 = bitcast { %blockheader, [0 x i64], %mpz* }* %19 to %block*
+  %22 = call i1 @hook_MAP_element(%map* %15, %block* %18, %block* %21)
+  br i1 %22, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %23 = load %map, %map* %15
+  %24 = alloca %map
+  store %map %23, %map* %24
+  %25 = call i1 @hook_MAP_concat(%map* %13, %map* %14, %map* %24)
+  br i1 %25, label %notstuck9, label %stuck
+
+notstuck9:                                        ; preds = %notstuck
+  %26 = load %map, %map* %13
+  %27 = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %12, i64 0, i32 2
+  store %map %26, %map* %27
+  %28 = bitcast { %blockheader, [0 x i64], %map }* %12 to %block*
+  %29 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %28, %block** %29
+  %30 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %30
+
+stuck:                                            ; preds = %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+define %block* @apply_rule_47(%block* %VarB1) {
+entry:
+  ret %block* %VarB1
+}
+
+define i1 @apply_rule_48(%block* %VarS1, %block* %VarS2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_STRING_lt(i1* %0, %block* %VarS2, %block* %VarS1)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  ret i1 %2
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_49() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_50(%block* %VarHOLE, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 562958543355907 }, %blockheader* %"Lbl'BangUndsUnds'IMP-SYNTAX'UndsUnds'BExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block* }* %4 to %block*
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %6, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %16
+}
+
+define i1 @apply_rule_51() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_52() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_53(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarS) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356026 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarS, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_54(%mpz* %VarI1, %mpz* %VarI2) {
+entry:
+  %0 = alloca i1
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall to %mpz*
+  %2 = call i1 @hook_INT_tmod(%mpz* %1, %mpz* %VarI2, %mpz* %VarI1)
+  br i1 %2, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %3 = call i1 @hook_INT_eq(i1* %0, %mpz* %1, %mpz* @int_0)
+  br i1 %3, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %4 = load i1, i1* %0
+  ret i1 %4
+
+stuck:                                            ; preds = %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_tmod(%mpz*, %mpz*, %mpz*)
+
+declare i1 @hook_INT_eq(i1*, %mpz*, %mpz*)
+
+define i1 @apply_rule_55(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define %block* @apply_rule_56(%mpz* %VarI1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %mpz* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to %mpz*
+  %5 = call i1 @hook_INT_sub(%mpz* %4, %mpz* @int_0, %mpz* %VarI1)
+  br i1 %5, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 2
+  store %mpz* %4, %mpz** %6
+  %7 = bitcast { %blockheader, [0 x i64], %mpz* }* %3 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %15
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_sub(%mpz*, %mpz*, %mpz*)
+
+define i1 @apply_rule_57() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_58() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_59() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_60(%block* %VarSource) {
+entry:
+  ret %block* %VarSource
+}
+
+define i1 @apply_rule_61(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define %block* @apply_rule_62(%block* %VarB2) {
+entry:
+  ret %block* %VarB2
+}
+
+define i1 @apply_rule_63() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_64(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_65() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_66(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_67() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_68(%block* %VarS1, %block* %VarS2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_STRING_eq(i1* %0, %block* %VarS1, %block* %VarS2)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  %hook_BOOL_not = xor i1 %2, true
+  ret i1 %hook_BOOL_not
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_eq(i1*, %block*, %block*)
+
+define i1 @apply_rule_69() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_70() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_71(%mpz* %VarI) {
+entry:
+  %0 = alloca %block*
+  %1 = alloca %block*
+  %2 = alloca %block*
+  %3 = call i1 @hook_STRING_int2string(%block** %2, %mpz* %VarI)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %2
+  %5 = call i1 @hook_STRING_concat(%block** %1, %block* bitcast ({ %blockheader, [3 x i8] }* @"token_\22_\22" to %block*), %block* %4)
+  br i1 %5, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %6 = load %block*, %block** %1
+  %7 = call i1 @hook_STRING_string2token(%block** %0, %block* %6)
+  br i1 %7, label %notstuck2, label %stuck
+
+notstuck2:                                        ; preds = %notstuck1
+  %8 = load %block*, %block** %0
+  ret %block* %8
+
+stuck:                                            ; preds = %notstuck1, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_int2string(%block**, %mpz*)
+
+declare i1 @hook_STRING_concat(%block**, %block*, %block*)
+
+declare i1 @hook_STRING_string2token(%block**, %block*)
+
+define i1 @apply_rule_72() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_73() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_74(%mpz* %VarI1, %mpz* %VarI2, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %mpz* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to %mpz*
+  %5 = call i1 @hook_INT_add(%mpz* %4, %mpz* %VarI1, %mpz* %VarI2)
+  br i1 %5, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 2
+  store %mpz* %4, %mpz** %6
+  %7 = bitcast { %blockheader, [0 x i64], %mpz* }* %3 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %15
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_add(%mpz*, %mpz*, %mpz*)
+
+define %mpz* @apply_rule_75() {
+entry:
+  ret %mpz* @int_-1
+}
+
+define i1 @apply_rule_76() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_77() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_78() {
+entry:
+  ret i1 false
+}
+
+define %mpz* @apply_rule_79(%mpz* %VarI1, %mpz* %VarI2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to %mpz*
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to %mpz*
+  %4 = call i1 @hook_INT_abs(%mpz* %3, %mpz* %VarI2)
+  br i1 %4, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %5 = call i1 @hook_INT_tmod(%mpz* %2, %mpz* %VarI1, %mpz* %3)
+  br i1 %5, label %notstuck4, label %stuck
+
+notstuck4:                                        ; preds = %notstuck
+  %malloccall5 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %6 = bitcast i8* %malloccall5 to %mpz*
+  %7 = call i1 @hook_INT_abs(%mpz* %6, %mpz* %VarI2)
+  br i1 %7, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck4
+  %8 = call i1 @hook_INT_add(%mpz* %1, %mpz* %2, %mpz* %6)
+  br i1 %8, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck6
+  %malloccall8 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall8 to %mpz*
+  %10 = call i1 @hook_INT_abs(%mpz* %9, %mpz* %VarI2)
+  br i1 %10, label %notstuck9, label %stuck
+
+notstuck9:                                        ; preds = %notstuck7
+  %11 = call i1 @hook_INT_tmod(%mpz* %0, %mpz* %1, %mpz* %9)
+  br i1 %11, label %notstuck10, label %stuck
+
+notstuck10:                                       ; preds = %notstuck9
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck9, %notstuck7, %notstuck6, %notstuck4, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_abs(%mpz*, %mpz*)
+
+define %block* @apply_rule_80(%mpz* %VarI1, %mpz* %VarI2, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %mpz* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to %mpz*
+  %5 = call i1 @hook_INT_tdiv(%mpz* %4, %mpz* %VarI1, %mpz* %VarI2)
+  br i1 %5, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 2
+  store %mpz* %4, %mpz** %6
+  %7 = bitcast { %blockheader, [0 x i64], %mpz* }* %3 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %15
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_tdiv(%mpz*, %mpz*, %mpz*)
+
+define i1 @apply_rule_81() {
+entry:
+  ret i1 true
+}
+
+define %mpz* @apply_rule_82(%mpz* %VarI) {
+entry:
+  ret %mpz* %VarI
+}
+
+define i1 @apply_rule_83() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_84() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_85(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarB, %block* %VarS) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block*, %block* }*
+  %"Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 4222141830529097 }, %blockheader* %"Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarB, %block** %5
+  %malloccall5 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %6 = bitcast i8* %malloccall5 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %6, i64 0, i32 0
+  store %blockheader { i64 562958543355921 }, %blockheader* %"Lbl'LBraUndsRBraUnds'IMP-SYNTAX'UndsUnds'Stmt"
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612604 }, %blockheader* %"Lbl'UndsUndsUnds'IMP-SYNTAX'UndsUnds'Stmt'Unds'Stmt"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543356026 }, %blockheader* %inj8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %VarS, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %10, %block** %11
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %12 = bitcast i8* %malloccall9 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %12, i64 0, i32 0
+  store %blockheader { i64 281487861612659 }, %blockheader* %"Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block"
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %12, i64 0, i32 2
+  store %block* %VarB, %block** %13
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %12, i64 0, i32 3
+  store %block* %VarS, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %12 to %block*
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %15, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %18 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %6, i64 0, i32 2
+  store %block* %17, %block** %18
+  %19 = bitcast { %blockheader, [0 x i64], %block* }* %6 to %block*
+  %20 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 3
+  store %block* %19, %block** %20
+  %21 = inttoptr i64 68719476737 to %block*
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 4
+  store %block* %21, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block*, %block* }* %4 to %block*
+  %24 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %23, %block** %24
+  %25 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %26 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %25, %block** %26
+  %27 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %27
+  %28 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %29 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %28, %block** %29
+  %30 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %31 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %30, %block** %31
+  %32 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %32
+  %33 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %33
+}
+
+define i1 @apply_rule_86() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_87() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_88(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612603 }, %blockheader* %"Lbl'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarK0, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarHOLE, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define i1 @apply_rule_89() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_90() {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %map }* getelementptr ({ %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %map }*
+  %"Lbl'-LT-'state'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %0, i64 0, i32 0
+  store %blockheader { i64 844442110001154 }, %blockheader* %"Lbl'-LT-'state'-GT-'"
+  %1 = alloca %map
+  %2 = call i1 @hook_MAP_unit(%map* %1)
+  br i1 %2, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %3 = load %map, %map* %1
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %0, i64 0, i32 2
+  store %map %3, %map* %4
+  %5 = bitcast { %blockheader, [0 x i64], %map }* %0 to %block*
+  ret %block* %5
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_MAP_unit(%map*)
+
+define i1 @apply_rule_91() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_92() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_93() {
+entry:
+  ret i1 true
+}
+
+define %mpz* @apply_rule_94(%mpz* %VarI, %block* %VarS1, %block* %VarS2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %2 = alloca %block*
+  %3 = call i1 @hook_STRING_substr(%block** %2, %block* %VarS2, %mpz* @int_0, %mpz* @int_1)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %2
+  %5 = call i1 @hook_STRING_rfind(%mpz* %1, %block* %VarS1, %block* %4, %mpz* %VarI)
+  br i1 %5, label %notstuck2, label %stuck
+
+notstuck2:                                        ; preds = %notstuck
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %6 = bitcast i8* %malloccall3 to %mpz*
+  %7 = alloca %block*
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall4 to %mpz*
+  %9 = call i1 @hook_STRING_length(%mpz* %8, %block* %VarS2)
+  br i1 %9, label %notstuck5, label %stuck
+
+notstuck5:                                        ; preds = %notstuck2
+  %10 = call i1 @hook_STRING_substr(%block** %7, %block* %VarS2, %mpz* @int_1, %mpz* %8)
+  br i1 %10, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck5
+  %11 = load %block*, %block** %7
+  %12 = call i1 @hook_STRING_rfindChar(%mpz* %6, %block* %VarS1, %block* %11, %mpz* %VarI)
+  br i1 %12, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck6
+  %13 = call i1 @hook_INT_max(%mpz* %0, %mpz* %1, %mpz* %6)
+  br i1 %13, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck7
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck7, %notstuck6, %notstuck5, %notstuck2, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_substr(%block**, %block*, %mpz*, %mpz*)
+
+declare i1 @hook_STRING_rfind(%mpz*, %block*, %block*, %mpz*)
+
+declare i1 @hook_STRING_length(%mpz*, %block*)
+
+declare i1 @hook_STRING_rfindChar(%mpz*, %block*, %block*, %mpz*)
+
+declare i1 @hook_INT_max(%mpz*, %mpz*, %mpz*)
+
+define i1 @apply_rule_95(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_96() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_97() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_98(%block* %VarDotVar0, %block* %VarDotVar1, i1 %VarT) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  %hook_BOOL_not = xor i1 %VarT, true
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %hook_BOOL_not, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_99() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_100() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_101(%block* %VarK1, %block* %VarK2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_KEQUAL_eq(i1* %0, %block* %VarK1, %block* %VarK2)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  %hook_BOOL_not = xor i1 %2, true
+  ret i1 %hook_BOOL_not
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_102() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_103() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_104() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_105() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_106() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_107(%block* %VarS1, %block* %VarS2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_STRING_lt(i1* %0, %block* %VarS1, %block* %VarS2)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  %hook_BOOL_not = xor i1 %2, true
+  ret i1 %hook_BOOL_not
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_108() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_109() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_110() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_111(%block* %VarS1, %block* %VarS2) {
+entry:
+  %0 = alloca i1
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543356041 }, %blockheader* %inj
+  %2 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %VarS1, %block** %2
+  %3 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %inj2 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 562958543356041 }, %blockheader* %inj2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %4, i64 0, i32 2
+  store %block* %VarS2, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block* }* %4 to %block*
+  %7 = call i1 @hook_KEQUAL_eq(i1* %0, %block* %3, %block* %6)
+  br i1 %7, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %8 = load i1, i1* %0
+  ret i1 %8
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_112() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_113(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612601 }, %blockheader* %"Lbl'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarK0, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarHOLE, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define i1 @apply_rule_114(i1 %VarB1, i1 %VarB2) {
+entry:
+  %hook_BOOL_eq = icmp eq i1 %VarB1, %VarB2
+  %hook_BOOL_not = xor i1 %hook_BOOL_eq, true
+  ret i1 %hook_BOOL_not
+}
+
+define i1 @apply_rule_115() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_116(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355914 }, %blockheader* %"Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define i1 @apply_rule_117() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_118(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_119() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_120(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarB) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarB, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define %block* @apply_rule_121(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarS) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarS, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_122() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_123() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_124() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_125() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_126(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612585 }, %blockheader* %"Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarK0, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarHOLE, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define %mpz* @apply_rule_127(%mpz* %VarI, %block* %VarS1, %block* %VarS2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %1 = alloca i1
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall1 to %mpz*
+  %3 = alloca %block*
+  %4 = call i1 @hook_STRING_substr(%block** %3, %block* %VarS2, %mpz* @int_0, %mpz* @int_1)
+  br i1 %4, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %5 = load %block*, %block** %3
+  %6 = call i1 @hook_STRING_find(%mpz* %2, %block* %VarS1, %block* %5, %mpz* %VarI)
+  br i1 %6, label %notstuck2, label %stuck
+
+notstuck2:                                        ; preds = %notstuck
+  %7 = call i1 @hook_INT_eq(i1* %1, %mpz* %2, %mpz* @int_-1)
+  br i1 %7, label %notstuck3, label %stuck
+
+notstuck3:                                        ; preds = %notstuck2
+  %8 = load i1, i1* %1
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall4 to %mpz*
+  %10 = alloca %block*
+  %malloccall5 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %11 = bitcast i8* %malloccall5 to %mpz*
+  %12 = call i1 @hook_STRING_length(%mpz* %11, %block* %VarS2)
+  br i1 %12, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck3
+  %13 = call i1 @hook_STRING_substr(%block** %10, %block* %VarS2, %mpz* @int_1, %mpz* %11)
+  br i1 %13, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck6
+  %14 = load %block*, %block** %10
+  %15 = call i1 @hook_STRING_findChar(%mpz* %9, %block* %VarS1, %block* %14, %mpz* %VarI)
+  br i1 %15, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck7
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %16 = bitcast i8* %malloccall9 to %mpz*
+  %17 = alloca i1
+  %malloccall10 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %18 = bitcast i8* %malloccall10 to %mpz*
+  %19 = alloca %block*
+  %malloccall11 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %20 = bitcast i8* %malloccall11 to %mpz*
+  %21 = call i1 @hook_STRING_length(%mpz* %20, %block* %VarS2)
+  br i1 %21, label %notstuck12, label %stuck
+
+notstuck12:                                       ; preds = %notstuck8
+  %22 = call i1 @hook_STRING_substr(%block** %19, %block* %VarS2, %mpz* @int_1, %mpz* %20)
+  br i1 %22, label %notstuck13, label %stuck
+
+notstuck13:                                       ; preds = %notstuck12
+  %23 = load %block*, %block** %19
+  %24 = call i1 @hook_STRING_findChar(%mpz* %18, %block* %VarS1, %block* %23, %mpz* %VarI)
+  br i1 %24, label %notstuck14, label %stuck
+
+notstuck14:                                       ; preds = %notstuck13
+  %25 = call i1 @hook_INT_eq(i1* %17, %mpz* %18, %mpz* @int_-1)
+  br i1 %25, label %notstuck15, label %stuck
+
+notstuck15:                                       ; preds = %notstuck14
+  %26 = load i1, i1* %17
+  %malloccall16 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %27 = bitcast i8* %malloccall16 to %mpz*
+  %28 = alloca %block*
+  %29 = call i1 @hook_STRING_substr(%block** %28, %block* %VarS2, %mpz* @int_0, %mpz* @int_1)
+  br i1 %29, label %notstuck17, label %stuck
+
+notstuck17:                                       ; preds = %notstuck15
+  %30 = load %block*, %block** %28
+  %31 = call i1 @hook_STRING_find(%mpz* %27, %block* %VarS1, %block* %30, %mpz* %VarI)
+  br i1 %31, label %notstuck18, label %stuck
+
+notstuck18:                                       ; preds = %notstuck17
+  %malloccall19 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %32 = bitcast i8* %malloccall19 to %mpz*
+  %malloccall20 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %33 = bitcast i8* %malloccall20 to %mpz*
+  %34 = alloca %block*
+  %35 = call i1 @hook_STRING_substr(%block** %34, %block* %VarS2, %mpz* @int_0, %mpz* @int_1)
+  br i1 %35, label %notstuck21, label %stuck
+
+notstuck21:                                       ; preds = %notstuck18
+  %36 = load %block*, %block** %34
+  %37 = call i1 @hook_STRING_find(%mpz* %33, %block* %VarS1, %block* %36, %mpz* %VarI)
+  br i1 %37, label %notstuck22, label %stuck
+
+notstuck22:                                       ; preds = %notstuck21
+  %malloccall23 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %38 = bitcast i8* %malloccall23 to %mpz*
+  %39 = alloca %block*
+  %malloccall24 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %40 = bitcast i8* %malloccall24 to %mpz*
+  %41 = call i1 @hook_STRING_length(%mpz* %40, %block* %VarS2)
+  br i1 %41, label %notstuck25, label %stuck
+
+notstuck25:                                       ; preds = %notstuck22
+  %42 = call i1 @hook_STRING_substr(%block** %39, %block* %VarS2, %mpz* @int_1, %mpz* %40)
+  br i1 %42, label %notstuck26, label %stuck
+
+notstuck26:                                       ; preds = %notstuck25
+  %43 = load %block*, %block** %39
+  %44 = call i1 @hook_STRING_findChar(%mpz* %38, %block* %VarS1, %block* %43, %mpz* %VarI)
+  br i1 %44, label %notstuck27, label %stuck
+
+notstuck27:                                       ; preds = %notstuck26
+  %45 = call i1 @hook_INT_min(%mpz* %32, %mpz* %33, %mpz* %38)
+  br i1 %45, label %notstuck28, label %stuck
+
+notstuck28:                                       ; preds = %notstuck27
+  %46 = call i1 @hook_KEQUAL_ite(%mpz* %16, i1 %26, %mpz* %27, %mpz* %32)
+  br i1 %46, label %notstuck29, label %stuck
+
+notstuck29:                                       ; preds = %notstuck28
+  %47 = call i1 @hook_KEQUAL_ite(%mpz* %0, i1 %8, %mpz* %9, %mpz* %16)
+  br i1 %47, label %notstuck30, label %stuck
+
+notstuck30:                                       ; preds = %notstuck29
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck29, %notstuck28, %notstuck27, %notstuck26, %notstuck25, %notstuck22, %notstuck21, %notstuck18, %notstuck17, %notstuck15, %notstuck14, %notstuck13, %notstuck12, %notstuck8, %notstuck7, %notstuck6, %notstuck3, %notstuck2, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_find(%mpz*, %block*, %block*, %mpz*)
+
+declare i1 @hook_STRING_findChar(%mpz*, %block*, %block*, %mpz*)
+
+declare i1 @hook_INT_min(%mpz*, %mpz*, %mpz*)
+
+declare i1 @hook_KEQUAL_ite(%mpz*, i1, %mpz*, %mpz*)
+
+define %mpz* @apply_rule_128(%block* %VarToCount, %block* %VarSource) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %2 = alloca %block*
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall2 to %mpz*
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall3 to %mpz*
+  %5 = call i1 @hook_STRING_find(%mpz* %4, %block* %VarSource, %block* %VarToCount, %mpz* @int_0)
+  br i1 %5, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %6 = bitcast i8* %malloccall4 to %mpz*
+  %7 = call i1 @hook_STRING_length(%mpz* %6, %block* %VarToCount)
+  br i1 %7, label %notstuck5, label %stuck
+
+notstuck5:                                        ; preds = %notstuck
+  %8 = call i1 @hook_INT_add(%mpz* %3, %mpz* %4, %mpz* %6)
+  br i1 %8, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck5
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to %mpz*
+  %10 = call i1 @hook_STRING_length(%mpz* %9, %block* %VarSource)
+  br i1 %10, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck6
+  %11 = call i1 @hook_STRING_substr(%block** %2, %block* %VarSource, %mpz* %3, %mpz* %9)
+  br i1 %11, label %notstuck9, label %stuck
+
+notstuck9:                                        ; preds = %notstuck8
+  %12 = load %block*, %block** %2
+  %13 = call i1 @hook_STRING_countAllOccurrences(%mpz* %1, %block* %12, %block* %VarToCount)
+  br i1 %13, label %notstuck10, label %stuck
+
+notstuck10:                                       ; preds = %notstuck9
+  %14 = call i1 @hook_INT_add(%mpz* %0, %mpz* @int_1, %mpz* %1)
+  br i1 %14, label %notstuck11, label %stuck
+
+notstuck11:                                       ; preds = %notstuck10
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck10, %notstuck9, %notstuck8, %notstuck6, %notstuck5, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_countAllOccurrences(%mpz*, %block*, %block*)
+
+define i1 @apply_rule_129() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_130(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 281487861612596 }, %blockheader* %"Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'UndsUnds'Id'Unds'AExp"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarK0, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarHOLE, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %4 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %9, %block** %10
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %13 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %12, %block** %13
+  %14 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %14, %block** %15
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %17
+}
+
+define i1 @apply_rule_131() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_132() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_133(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define %block* @apply_rule_134(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355913 }, %blockheader* %"Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK0, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define %mpz* @apply_rule_135(%mpz* %VarI2) {
+entry:
+  ret %mpz* %VarI2
+}
+
+define i1 @apply_rule_136(i1 %VarB1, i1 %VarB2) {
+entry:
+  %hook_BOOL_eq = icmp eq i1 %VarB1, %VarB2
+  %hook_BOOL_not = xor i1 %hook_BOOL_eq, true
+  ret i1 %hook_BOOL_not
+}
+
+define %block* @apply_rule_137(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355910 }, %blockheader* %"Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define i1 @apply_rule_138() {
+entry:
+  ret i1 true
+}
+
+define %mpz* @apply_rule_139(%mpz* %VarI1, %mpz* %VarI2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to %mpz*
+  %3 = call i1 @hook_INT_emod(%mpz* %2, %mpz* %VarI1, %mpz* %VarI2)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = call i1 @hook_INT_sub(%mpz* %1, %mpz* %VarI1, %mpz* %2)
+  br i1 %4, label %notstuck3, label %stuck
+
+notstuck3:                                        ; preds = %notstuck
+  %5 = call i1 @hook_INT_tdiv(%mpz* %0, %mpz* %1, %mpz* %VarI2)
+  br i1 %5, label %notstuck4, label %stuck
+
+notstuck4:                                        ; preds = %notstuck3
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck3, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_140() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_141(%block* %VarHOLE, %block* %VarK1, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355916 }, %blockheader* %"Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp1'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define %block* @apply_rule_142(%map %VarInit) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %1 = alloca %block*
+  %2 = alloca %map
+  store %map %VarInit, %map* %2
+  %3 = call i1 @"eval_LblinitKCell{SortMap{}}"(%block** %1, %map* %2)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %1
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %4, %block** %5
+  %6 = alloca %block*
+  %7 = call i1 @"eval_LblinitStateCell{}"(%block** %6)
+  br i1 %7, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %8 = load %block*, %block** %6
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %10
+
+stuck:                                            ; preds = %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @"eval_LblinitKCell{SortMap{}}"(%block**, %map*)
+
+declare i1 @"eval_LblinitStateCell{}"(%block**)
+
+define %mpz* @apply_rule_143(%mpz* %VarI, %mpz* %VarLEN, %mpz* %VarIDX) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to %mpz*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to %mpz*
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to %mpz*
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to %mpz*
+  %4 = call i1 @hook_INT_bitRange(%mpz* %3, %mpz* %VarI, %mpz* %VarIDX, %mpz* %VarLEN)
+  br i1 %4, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %5 = bitcast i8* %malloccall4 to %mpz*
+  %malloccall5 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %6 = bitcast i8* %malloccall5 to %mpz*
+  %7 = call i1 @hook_INT_sub(%mpz* %6, %mpz* %VarLEN, %mpz* @int_1)
+  br i1 %7, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck
+  %8 = call i1 @hook_INT_shl(%mpz* %5, %mpz* @int_1, %mpz* %6)
+  br i1 %8, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck6
+  %9 = call i1 @hook_INT_add(%mpz* %2, %mpz* %3, %mpz* %5)
+  br i1 %9, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck7
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %10 = bitcast i8* %malloccall9 to %mpz*
+  %11 = call i1 @hook_INT_shl(%mpz* %10, %mpz* @int_1, %mpz* %VarLEN)
+  br i1 %11, label %notstuck10, label %stuck
+
+notstuck10:                                       ; preds = %notstuck8
+  %12 = call i1 @hook_INT_emod(%mpz* %1, %mpz* %2, %mpz* %10)
+  br i1 %12, label %notstuck11, label %stuck
+
+notstuck11:                                       ; preds = %notstuck10
+  %malloccall12 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %13 = bitcast i8* %malloccall12 to %mpz*
+  %malloccall13 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %14 = bitcast i8* %malloccall13 to %mpz*
+  %15 = call i1 @hook_INT_sub(%mpz* %14, %mpz* %VarLEN, %mpz* @int_1)
+  br i1 %15, label %notstuck14, label %stuck
+
+notstuck14:                                       ; preds = %notstuck11
+  %16 = call i1 @hook_INT_shl(%mpz* %13, %mpz* @int_1, %mpz* %14)
+  br i1 %16, label %notstuck15, label %stuck
+
+notstuck15:                                       ; preds = %notstuck14
+  %17 = call i1 @hook_INT_sub(%mpz* %0, %mpz* %1, %mpz* %13)
+  br i1 %17, label %notstuck16, label %stuck
+
+notstuck16:                                       ; preds = %notstuck15
+  ret %mpz* %0
+
+stuck:                                            ; preds = %notstuck15, %notstuck14, %notstuck11, %notstuck10, %notstuck8, %notstuck7, %notstuck6, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_INT_bitRange(%mpz*, %mpz*, %mpz*, %mpz*)
+
+define %block* @apply_rule_144(%mpz* %VarCount, %block* %VarToReplace, %block* %VarReplacement, %block* %VarSource) {
+entry:
+  %0 = alloca %block*
+  %1 = alloca %block*
+  %2 = alloca %block*
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall to %mpz*
+  %4 = call i1 @hook_STRING_find(%mpz* %3, %block* %VarSource, %block* %VarToReplace, %mpz* @int_0)
+  br i1 %4, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %5 = call i1 @hook_STRING_substr(%block** %2, %block* %VarSource, %mpz* @int_0, %mpz* %3)
+  br i1 %5, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %6 = load %block*, %block** %2
+  %7 = call i1 @hook_STRING_concat(%block** %1, %block* %6, %block* %VarReplacement)
+  br i1 %7, label %notstuck2, label %stuck
+
+notstuck2:                                        ; preds = %notstuck1
+  %8 = load %block*, %block** %1
+  %9 = alloca %block*
+  %10 = alloca %block*
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %11 = bitcast i8* %malloccall3 to %mpz*
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %12 = bitcast i8* %malloccall4 to %mpz*
+  %13 = call i1 @hook_STRING_find(%mpz* %12, %block* %VarSource, %block* %VarToReplace, %mpz* @int_0)
+  br i1 %13, label %notstuck5, label %stuck
+
+notstuck5:                                        ; preds = %notstuck2
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %14 = bitcast i8* %malloccall6 to %mpz*
+  %15 = call i1 @hook_STRING_length(%mpz* %14, %block* %VarToReplace)
+  br i1 %15, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck5
+  %16 = call i1 @hook_INT_add(%mpz* %11, %mpz* %12, %mpz* %14)
+  br i1 %16, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck7
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %17 = bitcast i8* %malloccall9 to %mpz*
+  %18 = call i1 @hook_STRING_length(%mpz* %17, %block* %VarSource)
+  br i1 %18, label %notstuck10, label %stuck
+
+notstuck10:                                       ; preds = %notstuck8
+  %19 = call i1 @hook_STRING_substr(%block** %10, %block* %VarSource, %mpz* %11, %mpz* %17)
+  br i1 %19, label %notstuck11, label %stuck
+
+notstuck11:                                       ; preds = %notstuck10
+  %20 = load %block*, %block** %10
+  %malloccall12 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %21 = bitcast i8* %malloccall12 to %mpz*
+  %22 = call i1 @hook_INT_sub(%mpz* %21, %mpz* %VarCount, %mpz* @int_1)
+  br i1 %22, label %notstuck13, label %stuck
+
+notstuck13:                                       ; preds = %notstuck11
+  %23 = call i1 @hook_STRING_replace(%block** %9, %block* %20, %block* %VarToReplace, %block* %VarReplacement, %mpz* %21)
+  br i1 %23, label %notstuck14, label %stuck
+
+notstuck14:                                       ; preds = %notstuck13
+  %24 = load %block*, %block** %9
+  %25 = call i1 @hook_STRING_concat(%block** %0, %block* %8, %block* %24)
+  br i1 %25, label %notstuck15, label %stuck
+
+notstuck15:                                       ; preds = %notstuck14
+  %26 = load %block*, %block** %0
+  ret %block* %26
+
+stuck:                                            ; preds = %notstuck14, %notstuck13, %notstuck11, %notstuck10, %notstuck8, %notstuck7, %notstuck5, %notstuck2, %notstuck1, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_STRING_replace(%block**, %block*, %block*, %block*, %mpz*)
+
+define i1 @apply_rule_145() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_146() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_147() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_148() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_149(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355915 }, %blockheader* %"Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK0, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define i1 @apply_rule_150(%mpz* %VarI1, %mpz* %VarI2) {
+entry:
+  %0 = alloca i1
+  %1 = call i1 @hook_INT_eq(i1* %0, %mpz* %VarI1, %mpz* %VarI2)
+  br i1 %1, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %2 = load i1, i1* %0
+  %hook_BOOL_not = xor i1 %2, true
+  ret i1 %hook_BOOL_not
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define %block* @apply_rule_151(%block* %VarToReplace, %block* %VarReplacement, %block* %VarSource) {
+entry:
+  %0 = alloca %block*
+  %1 = alloca %block*
+  %2 = alloca %block*
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall to %mpz*
+  %4 = call i1 @hook_STRING_find(%mpz* %3, %block* %VarSource, %block* %VarToReplace, %mpz* @int_0)
+  br i1 %4, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %5 = call i1 @hook_STRING_substr(%block** %2, %block* %VarSource, %mpz* @int_0, %mpz* %3)
+  br i1 %5, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %6 = load %block*, %block** %2
+  %7 = call i1 @hook_STRING_concat(%block** %1, %block* %6, %block* %VarReplacement)
+  br i1 %7, label %notstuck2, label %stuck
+
+notstuck2:                                        ; preds = %notstuck1
+  %8 = load %block*, %block** %1
+  %9 = alloca %block*
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %10 = bitcast i8* %malloccall3 to %mpz*
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %11 = bitcast i8* %malloccall4 to %mpz*
+  %12 = call i1 @hook_STRING_find(%mpz* %11, %block* %VarSource, %block* %VarToReplace, %mpz* @int_0)
+  br i1 %12, label %notstuck5, label %stuck
+
+notstuck5:                                        ; preds = %notstuck2
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %13 = bitcast i8* %malloccall6 to %mpz*
+  %14 = call i1 @hook_STRING_length(%mpz* %13, %block* %VarToReplace)
+  br i1 %14, label %notstuck7, label %stuck
+
+notstuck7:                                        ; preds = %notstuck5
+  %15 = call i1 @hook_INT_add(%mpz* %10, %mpz* %11, %mpz* %13)
+  br i1 %15, label %notstuck8, label %stuck
+
+notstuck8:                                        ; preds = %notstuck7
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %16 = bitcast i8* %malloccall9 to %mpz*
+  %17 = call i1 @hook_STRING_length(%mpz* %16, %block* %VarSource)
+  br i1 %17, label %notstuck10, label %stuck
+
+notstuck10:                                       ; preds = %notstuck8
+  %18 = call i1 @hook_STRING_substr(%block** %9, %block* %VarSource, %mpz* %10, %mpz* %16)
+  br i1 %18, label %notstuck11, label %stuck
+
+notstuck11:                                       ; preds = %notstuck10
+  %19 = load %block*, %block** %9
+  %20 = call i1 @hook_STRING_concat(%block** %0, %block* %8, %block* %19)
+  br i1 %20, label %notstuck12, label %stuck
+
+notstuck12:                                       ; preds = %notstuck11
+  %21 = load %block*, %block** %0
+  ret %block* %21
+
+stuck:                                            ; preds = %notstuck11, %notstuck10, %notstuck8, %notstuck7, %notstuck5, %notstuck2, %notstuck1, %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_152() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_153() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_154() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_155() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_156(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarS) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356026 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarS, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define %block* @apply_rule_157(%map %VarInit) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %1 = alloca %block*
+  %2 = alloca %map
+  store %map %VarInit, %map* %2
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356034 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* bitcast ({ %blockheader, [4 x i8] }* @"token_$PGM" to %block*), %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = call i1 @hook_MAP_lookup(%block** %1, %map* %2, %block* %5)
+  br i1 %6, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %7 = load %block*, %block** %1
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %9
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_MAP_lookup(%block**, %map*, %block*)
+
+define %block* @apply_rule_158(%block* %VarX, %mpz* %VarI, %block* %VarDotVar1, %map %VarDotVar2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %2 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %VarDotVar1, %block** %2
+  %3 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %3, %block** %4
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %map }* getelementptr ({ %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* null, i32 1) to i64))
+  %5 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %map }*
+  %"Lbl'-LT-'state'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %5, i64 0, i32 0
+  store %blockheader { i64 844442110001154 }, %blockheader* %"Lbl'-LT-'state'-GT-'"
+  %6 = alloca %map
+  %7 = alloca %map
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543356036 }, %blockheader* %inj
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %VarX, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %11 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %mpz* }*
+  %inj5 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %11, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj5
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %11, i64 0, i32 2
+  store %mpz* %VarI, %mpz** %12
+  %13 = bitcast { %blockheader, [0 x i64], %mpz* }* %11 to %block*
+  %14 = call i1 @hook_MAP_element(%map* %7, %block* %10, %block* %13)
+  br i1 %14, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %15 = load %map, %map* %7
+  %16 = alloca %map
+  store %map %15, %map* %16
+  %17 = alloca %map
+  store %map %VarDotVar2, %map* %17
+  %18 = call i1 @hook_MAP_concat(%map* %6, %map* %16, %map* %17)
+  br i1 %18, label %notstuck6, label %stuck
+
+notstuck6:                                        ; preds = %notstuck
+  %19 = load %map, %map* %6
+  %20 = getelementptr inbounds { %blockheader, [0 x i64], %map }, { %blockheader, [0 x i64], %map }* %5, i64 0, i32 2
+  store %map %19, %map* %20
+  %21 = bitcast { %blockheader, [0 x i64], %map }* %5 to %block*
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %21, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+
+stuck:                                            ; preds = %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_159() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_160() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_161(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_162() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_163() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_164(%block* %VarHOLE, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %8 = inttoptr i64 17179869185 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %15, %block** %16
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %18
+}
+
+define %block* @apply_rule_165(%block* %VarHOLE, %block* %VarK1, %block* %VarK2, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block*, %block* }*
+  %"Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 0
+  store %blockheader { i64 4222141830529097 }, %blockheader* %"Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block"
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 2
+  store %block* %VarHOLE, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 3
+  store %block* %VarK1, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block*, %block* }, { %blockheader, [0 x i64], %block*, %block*, %block* }* %4, i64 0, i32 4
+  store %block* %VarK2, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block*, %block* }* %4 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %15, %block** %16
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %18
+}
+
+define i1 @apply_rule_166() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_167() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_168(%block* %VarDotVar0, %block* %VarDotVar1, %block* %VarS1, %block* %VarS2) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarS1, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %inj7 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543356035 }, %blockheader* %inj7
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %VarS2, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %13, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %15, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %18 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %17, %block** %18
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %20
+}
+
+define %block* @apply_rule_169(%block* %VarHOLE, %block* %VarK1, %block* %VarK2, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356024 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 281487861612557 }, %blockheader* %"Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'UndsUnds'BExp'Unds'Block'Unds'Block1'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356026 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK1, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %malloccall9 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %13 = bitcast i8* %malloccall9 to { %blockheader, [0 x i64], %block* }*
+  %inj10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %13, i64 0, i32 0
+  store %blockheader { i64 562958543356026 }, %blockheader* %inj10
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %13, i64 0, i32 2
+  store %block* %VarK2, %block** %14
+  %15 = bitcast { %blockheader, [0 x i64], %block* }* %13 to %block*
+  %16 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %8, i64 0, i32 3
+  store %block* %15, %block** %16
+  %17 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %8 to %block*
+  %18 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %17, %block** %18
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %20, %block** %21
+  %22 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %23 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %22, %block** %23
+  %24 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %25 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %24, %block** %25
+  %26 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %26
+  %27 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %27
+}
+
+define i1 @apply_rule_170() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_171(%block* %VarToReplace, %block* %VarReplacement, %block* %VarSource) {
+entry:
+  %0 = alloca %block*
+  %malloccall = tail call i8* @malloc(i64 ptrtoint (%mpz* getelementptr (%mpz, %mpz* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall to %mpz*
+  %2 = call i1 @hook_STRING_countAllOccurrences(%mpz* %1, %block* %VarSource, %block* %VarToReplace)
+  br i1 %2, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %3 = call i1 @hook_STRING_replace(%block** %0, %block* %VarSource, %block* %VarToReplace, %block* %VarReplacement, %mpz* %1)
+  br i1 %3, label %notstuck1, label %stuck
+
+notstuck1:                                        ; preds = %notstuck
+  %4 = load %block*, %block** %0
+  ret %block* %4
+
+stuck:                                            ; preds = %notstuck, %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_172(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_173() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_174(%block* %VarHOLE, %block* %VarK0, %block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* %VarHOLE, %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %malloccall4 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %7 = bitcast i8* %malloccall4 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq5
+  %malloccall6 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %8 = bitcast i8* %malloccall6 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 0
+  store %blockheader { i64 562958543355909 }, %blockheader* %"Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'UndsUnds'AExp'Unds'AExp0'Unds'"
+  %malloccall7 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %9 = bitcast i8* %malloccall7 to { %blockheader, [0 x i64], %block* }*
+  %inj8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 0
+  store %blockheader { i64 562958543356031 }, %blockheader* %inj8
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %9, i64 0, i32 2
+  store %block* %VarK0, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block* }* %9 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %8, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %8 to %block*
+  %14 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 2
+  store %block* %13, %block** %14
+  %15 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %7, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %15
+  %16 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %7 to %block*
+  %17 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %16, %block** %17
+  %18 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %19 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %18, %block** %19
+  %20 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %21 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %20, %block** %21
+  %22 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %22
+  %23 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %23
+}
+
+define %mpz* @apply_rule_175(%mpz* %VarI1) {
+entry:
+  ret %mpz* %VarI1
+}
+
+define i1 @apply_rule_176() {
+entry:
+  ret i1 true
+}
+
+define %block* @apply_rule_177(%block* %VarDotVar0, %block* %VarDotVar1) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %"Lbl'-LT-'T'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281487861612544 }, %blockheader* %"Lbl'-LT-'T'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 562958543355905 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281487861612686 }, %blockheader* %kseq
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 4503603922337918 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 false, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %2, i64 0, i32 3
+  store %block* %VarDotVar1, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_178() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_179(%mpz* %VarI1, %mpz* %VarI2) {
+entry:
+  %0 = alloca i1
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %mpz* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %1, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj
+  %2 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %1, i64 0, i32 2
+  store %mpz* %VarI1, %mpz** %2
+  %3 = bitcast { %blockheader, [0 x i64], %mpz* }* %1 to %block*
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %4 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %mpz* }*
+  %inj2 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %4, i64 0, i32 0
+  store %blockheader { i64 2814758357041277 }, %blockheader* %inj2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %4, i64 0, i32 2
+  store %mpz* %VarI2, %mpz** %5
+  %6 = bitcast { %blockheader, [0 x i64], %mpz* }* %4 to %block*
+  %7 = call i1 @hook_KEQUAL_eq(i1* %0, %block* %3, %block* %6)
+  br i1 %7, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %8 = load i1, i1* %0
+  ret i1 %8
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_180() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_181() {
+entry:
+  ret i1 false
+}
+
+attributes #0 = { noreturn }

--- a/test/test.kore
+++ b/test/test.kore
@@ -9,7 +9,7 @@ module KSEQ
   import BASIC-K []
 
   symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
-  symbol append{}(SortK{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
   symbol dotk{}() : SortK{} []
 
   axiom{R}
@@ -48,65 +48,81 @@ module TEST
   import K []
 
 // sorts
-  sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,3,197,31)")]
-  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)"), token{}()]
+  sort SortList{} [hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,3,197,31)")]
+  sort SortKConfigVar{} [token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)")]
   sort SortCell{} []
-  sort SortBool{} []
+  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(263,3,263,31)")]
   sort SortKCell{} []
-  sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(87,3,87,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.Map")]
+  sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(87,3,87,28)"), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)")]
   hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,3,320,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.Int")]
+  sort SortToken{} []
   sort SortFoo{} []
-  sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(153,3,153,28)"), hook{}("SET.Set")]
+  sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(153,3,153,28)")]
 
 // symbols
-  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [noThread{}(), functional{}(), function{}(), initializer{}(), originalPrd{}()]
-  symbol Lbl'Stop'Set{}() : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}(".Set"), hook{}("SET.unit"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,18,161,110)"), latex{}("\\dotCt{Set}"), functional{}(), function{}(), productionID{}("1753714541"), constructor{}(), originalPrd{}()]
-  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,19,132,79)"), functional{}(), function{}(), productionID{}("1595938139"), originalPrd{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,91)"), functional{}(), function{}(), productionID{}("1070501849"), originalPrd{}()]
-  hooked-symbol LblListItem{}(SortK{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("ListItem"), hook{}("LIST.element"), smtlib{}("smt_seq_elem"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(235,19,235,120)"), functional{}(), function{}(), productionID{}("605420629"), originalPrd{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [functional{}(), originalPrd{}(), function{}(), noThread{}(), initializer{}()]
+  symbol Lbl'Stop'Set{}() : SortSet{} [klabel{}(".Set"), functional{}(), constructor{}(), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,18,161,110)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{Set}"), productionID{}("238762799")]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [functional{}(), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,19,132,79)"), function{}(), productionID{}("1753714541")]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [klabel{}("sizeMap"), functional{}(), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,91)"), function{}(), productionID{}("787122337")]
+  hooked-symbol LblListItem{}(SortK{}) : SortList{} [klabel{}("ListItem"), functional{}(), smtlib{}("smt_seq_elem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(235,19,235,120)"), function{}(), symbol'Kywd'{}(), productionID{}("405896924")]
   symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}(), functional{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortK{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(116,18,116,105)"), functional{}(), function{}(), productionID{}("570794077"), originalPrd{}()]
-  hooked-symbol LblSet'Coln'in{}(SortK{}, SortSet{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Set:in"), hook{}("SET.in"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(175,19,175,90)"), functional{}(), function{}(), productionID{}("2059572982"), originalPrd{}()]
-  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(110,16,110,114)"), functional{}(), function{}(), productionID{}("968113504"), originalPrd{}()]
-  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,19,137,76)"), functional{}(), function{}(), productionID{}("596706728"), originalPrd{}()]
-  symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}("_|->_"), comm{}(), klabel{}("_Map_"), hook{}("MAP.concat"), left{}(), symbol'Kywd'{}(), format{}("%1%n%2"), unit{}(".Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(95,18,95,172)"), assoc{}(), functional{}(), function{}(), productionID{}("1219916644"), index{}("0"), originalPrd{}()]
-  symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}("ListItem"), klabel{}("_List_"), hook{}("LIST.concat"), smtlib{}("smt_seq_concat"), left{}(), symbol'Kywd'{}(), format{}("%1%n%2"), unit{}(".List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(230,19,230,180)"), assoc{}(), functional{}(), function{}(), productionID{}("817299424"), originalPrd{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,16,146,96)"), functional{}(), function{}(), productionID{}("2106900153"), originalPrd{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(181,18,181,68)"), functional{}(), function{}(), productionID{}("36657658"), originalPrd{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortK{}) : SortMap{} [klabel{}("_[_<-undef]"), functional{}(), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(116,18,116,105)"), function{}(), symbol'Kywd'{}(), productionID{}("2104973502")]
+  symbol Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortFoo{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,32,6,42)"), productionID{}("28597262")]
+  symbol Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(SortBool{}) : SortFoo{} [klabel{}("eq"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,70,6,77)"), productionID{}("1940445711")]
+  hooked-symbol LblSet'Coln'in{}(SortK{}, SortSet{}) : SortBool{} [klabel{}("Set:in"), functional{}(), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(175,19,175,90)"), function{}(), symbol'Kywd'{}(), productionID{}("2133655103")]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortK{} [klabel{}("Map:lookupOrDefault"), functional{}(), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(110,16,110,114)"), function{}(), productionID{}("1242027525")]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("or"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,19,275,144)"), function{}(), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), left{}(), productionID{}("1351478315")]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [klabel{}("values"), functional{}(), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,19,137,76)"), function{}(), productionID{}("177140066")]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("and"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(273,19,273,106)"), function{}(), left{}(), productionID{}("616674002")]
+  symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [index{}("0"), klabel{}("_Map_"), functional{}(), element{}("_|->_"), format{}("%1%n%2"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".Map"), comm{}(), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(95,18,95,172)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("1267149311")]
+  symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [klabel{}("_List_"), functional{}(), element{}("ListItem"), format{}("%1%n%2"), smtlib{}("smt_seq_concat"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".List"), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(230,19,230,180)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("746074699")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortK{} [klabel{}("Map:choice"), functional{}(), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,16,146,96)"), function{}(), productionID{}("2144838275")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [klabel{}("size"), functional{}(), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(181,18,181,68)"), function{}(), productionID{}("1345900725")]
   symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}(), functional{}()]
-  symbol Lbl'Stop'List{}() : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}(".List"), hook{}("LIST.unit"), smtlib{}("smt_seq_nil"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,19,232,134)"), latex{}("\\dotCt{List}"), functional{}(), function{}(), productionID{}("2031951755"), constructor{}(), originalPrd{}()]
+  symbol Lbl'Stop'List{}() : SortList{} [klabel{}(".List"), functional{}(), smtlib{}("smt_seq_nil"), constructor{}(), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,19,232,134)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{List}"), productionID{}("127791068")]
   symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}(), functional{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), prefer{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(113,18,113,84)"), functional{}(), function{}(), productionID{}("1153302647"), originalPrd{}()]
-  symbol Lblbar'Unds'TEST'Unds'{}() : SortFoo{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3,24,3,28)"), functional{}(), productionID{}("1616359099"), constructor{}(), originalPrd{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortMap{} [functional{}(), prefer{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(113,18,113,84)"), function{}(), productionID{}("1948810915")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), smtlib{}("distinct"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(280,19,280,91)"), function{}(), left{}(), productionID{}("2038522556")]
+  symbol Lblbar'Unds'TEST'Unds'{}() : SortFoo{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,24,6,28)"), productionID{}("1344697180")]
   symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}(), functional{}()]
-  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortK{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:lookup"), hook{}("MAP.lookup"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(108,16,108,104)"), functional{}(), function{}(), productionID{}("1122130699"), originalPrd{}()]
-  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,18,120,108)"), latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), function{}(), productionID{}("1928301845"), originalPrd{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortK{}) : SortK{} [klabel{}("Map:lookup"), functional{}(), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(108,16,108,104)"), function{}(), symbol'Kywd'{}(), productionID{}("943573036")]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("xor"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(274,19,274,102)"), function{}(), left{}(), productionID{}("2109839984")]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,18,120,108)"), function{}(), latex{}("{#1}-_{\\it Map}{#2}"), productionID{}("735937428")]
   symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}(), functional{}()]
-  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,79)"), functional{}(), function{}(), productionID{}("1789452565"), originalPrd{}()]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [klabel{}("updateMap"), functional{}(), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,79)"), function{}(), productionID{}("1604247316")]
   symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}(), functional{}()]
-  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("List:get"), hook{}("LIST.get"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,16,240,94)"), functional{}(), function{}(), productionID{}("351417028"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("or"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(276,19,276,104)"), function{}(), left{}(), productionID{}("508512860")]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortK{} [klabel{}("List:get"), functional{}(), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,16,240,94)"), function{}(), symbol'Kywd'{}(), productionID{}("1309335839")]
+  symbol Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(SortBool{}) : SortFoo{} [klabel{}("not"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,58,6,66)"), productionID{}("284686302")]
   symbol LblisFoo{}(SortK{}) : SortBool{} [function{}(), predicate{}("Foo"), originalPrd{}(), functional{}()]
-  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(131,18,131,74)"), functional{}(), function{}(), productionID{}("1370074462"), originalPrd{}()]
-  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("List:range"), hook{}("LIST.range"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(243,19,243,98)"), functional{}(), function{}(), productionID{}("331122245"), originalPrd{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,79)"), functional{}(), function{}(), productionID{}("1620823990"), originalPrd{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(184,16,184,90)"), functional{}(), function{}(), productionID{}("2029680286"), originalPrd{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("sizeList"), hook{}("LIST.size"), smtlib{}("smt_seq_len"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(249,18,249,109)"), functional{}(), function{}(), productionID{}("154173878"), originalPrd{}()]
-  symbol Lblfoo'Unds'TEST'Unds'{}() : SortFoo{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(3,16,3,20)"), functional{}(), productionID{}("53940034"), constructor{}(), originalPrd{}()]
-  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortK{}, SortK{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("_|->_"), hook{}("MAP.element"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(102,18,102,124)"), latex{}("{#1}\\mapsto{#2}"), functional{}(), function{}(), productionID{}("2079565272"), originalPrd{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [klabel{}("notBool_"), functional{}(), boolOperation{}(), smtlib{}("not"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,19,271,162)"), function{}(), symbol'Kywd'{}(), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), productionID{}("459718907")]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [klabel{}("keys"), functional{}(), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(131,18,131,74)"), function{}(), productionID{}("788625466")]
+  symbol Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(SortBool{}) : SortFoo{} [klabel{}("baz"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,46,6,54)"), productionID{}("300983713")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [klabel{}("List:range"), functional{}(), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(243,19,243,98)"), function{}(), symbol'Kywd'{}(), productionID{}("596470015")]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), boolOperation{}(), smtlib{}("=>"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,105)"), function{}(), left{}(), productionID{}("925973605")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,79)"), function{}(), productionID{}("2059572982")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortK{} [klabel{}("Set:choice"), functional{}(), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(184,16,184,90)"), function{}(), productionID{}("839998248")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [klabel{}("sizeList"), functional{}(), smtlib{}("smt_seq_len"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(249,18,249,109)"), function{}(), productionID{}("1481818223")]
+  symbol Lblfoo'Unds'TEST'Unds'{}() : SortFoo{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,16,6,20)"), productionID{}("376635015")]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortK{}, SortK{}) : SortMap{} [klabel{}("_|->_"), functional{}(), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(102,18,102,124)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}\\mapsto{#2}"), productionID{}("52514534")]
   symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}(), functional{}()]
-  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(SortK{}, SortList{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(246,19,246,85)"), functional{}(), function{}(), productionID{}("38544126"), originalPrd{}()]
-  hooked-symbol LblSetItem{}(SortK{}) : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("SetItem"), hook{}("SET.element"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(166,18,166,96)"), functional{}(), function{}(), productionID{}("1095273238"), originalPrd{}()]
-  symbol Lbl'Stop'Map{}() : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}(".Map"), hook{}("MAP.unit"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(97,18,97,116)"), latex{}("\\dotCt{Map}"), functional{}(), function{}(), productionID{}("412925308"), constructor{}(), originalPrd{}()]
-  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(169,18,169,76)"), functional{}(), function{}(), productionID{}("177140066"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(SortK{}, SortList{}) : SortBool{} [klabel{}("_inList_"), functional{}(), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(246,19,246,85)"), function{}(), productionID{}("1267105885")]
+  hooked-symbol LblSetItem{}(SortK{}) : SortSet{} [klabel{}("SetItem"), functional{}(), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(166,18,166,96)"), function{}(), symbol'Kywd'{}(), productionID{}("1358343316")]
+  symbol Lbl'Stop'Map{}() : SortMap{} [klabel{}(".Map"), functional{}(), constructor{}(), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(97,18,97,116)"), function{}(), symbol'Kywd'{}(), latex{}("\\dotCt{Map}"), productionID{}("102174918")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("intersectSet"), functional{}(), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(169,18,169,76)"), function{}(), productionID{}("1824837049")]
   symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}(), functional{}()]
-  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Set:difference"), hook{}("SET.difference"), symbol'Kywd'{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(172,18,172,134)"), latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), function{}(), productionID{}("787122337"), originalPrd{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(178,19,178,73)"), functional{}(), function{}(), productionID{}("2144838275"), originalPrd{}()]
-  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,18,128,79)"), functional{}(), function{}(), productionID{}("1579280783"), originalPrd{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("Set:difference"), functional{}(), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(172,18,172,134)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}-_{\\it Set}{#2}"), productionID{}("672746064")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(178,19,178,73)"), function{}(), productionID{}("442199874")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [klabel{}("removeAll"), functional{}(), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,18,128,79)"), function{}(), productionID{}("1752461090")]
   symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), smtlib{}("="), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,84)"), function{}(), left{}(), productionID{}("1179792105")]
   symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}(), functional{}()]
-  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [cell{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), topcell{}(), maincell{}(), contentStartColumn{}("17"), contentStartLine{}("204"), format{}("%1%i%n%2%d%n%3"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,17,204,32)"), functional{}(), constructor{}(), originalPrd{}()]
-  symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}("SetItem"), comm{}(), klabel{}("_Set_"), hook{}("SET.concat"), left{}(), idem{}(), symbol'Kywd'{}(), format{}("%1%n%2"), unit{}(".Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(159,18,159,164)"), assoc{}(), functional{}(), function{}(), productionID{}("788625466"), originalPrd{}()]
-  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(SortK{}, SortMap{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,19,134,77)"), functional{}(), function{}(), productionID{}("1923999715"), originalPrd{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), format{}("%1%i%n%2%d%n%3"), constructor{}(), contentStartLine{}("204"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), contentStartColumn{}("17"), topcell{}(), cell{}(), originalPrd{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), maincell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,17,204,32)")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [klabel{}("_andBool_"), functional{}(), boolOperation{}(), smtlib{}("and"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(272,19,272,175)"), function{}(), symbol'Kywd'{}(), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), left{}(), productionID{}("1041109062")]
+  symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [klabel{}("_Set_"), idem{}(), functional{}(), element{}("SetItem"), format{}("%1%n%2"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), unit{}(".Set"), comm{}(), assoc{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(159,18,159,164)"), function{}(), symbol'Kywd'{}(), left{}(), productionID{}("1342346098")]
+  symbol Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(SortMap{}) : SortFoo{} [klabel{}("map"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(7,16,7,23)"), productionID{}("1356840024")]
+  symbol LblisToken{}(SortK{}) : SortBool{} [function{}(), predicate{}("Token"), originalPrd{}(), functional{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(SortK{}, SortMap{}) : SortBool{} [functional{}(), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,19,134,77)"), function{}(), productionID{}("1095273238")]
 
 // generated axioms
   axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, LblinitKCell{}(K0:SortMap{}))) [functional{}()] // functional
@@ -116,9 +132,26 @@ module TEST
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(Y0:SortInt{}, Y1:SortInt{})), Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblbar'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblfoo'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{})), Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\and{SortBool{}} (X0:SortBool{}, Y0:SortBool{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblbar'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblfoo'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortK{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
   axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'Map'Unds'{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
@@ -130,22 +163,40 @@ module TEST
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblbar'Unds'TEST'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
   axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), Lblfoo'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, LblMap'Coln'lookup{}(K0:SortMap{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, LblList'Coln'get{}(K0:SortList{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{})), Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\and{SortBool{}} (X0:SortBool{}, Y0:SortBool{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblfoo'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFoo{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Y0:SortBool{})), Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\and{SortBool{}} (X0:SortBool{}, Y0:SortBool{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblfoo'Unds'TEST'Unds'{}())) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{}), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblList'Coln'range{}(K0:SortList{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblfoo'Unds'TEST'Unds'{}())) [functional{}()] // functional
+  axiom{}\not{SortFoo{}} (\and{SortFoo{}} (Lblfoo'Unds'TEST'Unds'{}(), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{}))) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(K0:SortK{}, K1:SortList{}))) [functional{}()] // functional
@@ -157,24 +208,30 @@ module TEST
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
   axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
   axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
   axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortFoo{}, \equals{SortFoo{}, R} (Val:SortFoo{}, Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{}\implies{SortFoo{}} (\and{SortFoo{}} (Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(X0:SortMap{}), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(Y0:SortMap{})), Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisToken{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(K0:SortK{}, K1:SortMap{}))) [functional{}()] // functional
-  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFoo{}, inj{SortFoo{}, SortKItem{}} (Val:SortFoo{})), \bottom{SortKItem{}}())))))))) [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortToken{}, inj{SortToken{}, SortKItem{}} (Val:SortToken{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFoo{}, inj{SortFoo{}, SortKItem{}} (Val:SortFoo{})), \bottom{SortKItem{}}()))))))))) [constructor{}()] // no junk
   axiom{} \or{SortList{}} (\exists{SortList{}} (X0:SortList{}, \exists{SortList{}} (X1:SortList{}, Lbl'Unds'List'Unds'{}(X0:SortList{}, X1:SortList{}))), \or{SortList{}} (Lbl'Stop'List{}(), \bottom{SortList{}}())) [constructor{}()] // no junk
   axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \bottom{SortCell{}}()) [constructor{}()] // no junk
-  axiom{} \bottom{SortBool{}}() [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
   axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \bottom{SortK{}}()) [constructor{}()] // no junk
   axiom{} \or{SortMap{}} (\exists{SortMap{}} (X0:SortMap{}, \exists{SortMap{}} (X1:SortMap{}, Lbl'Unds'Map'Unds'{}(X0:SortMap{}, X1:SortMap{}))), \or{SortMap{}} (Lbl'Stop'Map{}(), \bottom{SortMap{}}())) [constructor{}()] // no junk
   axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
-  axiom{} \or{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), \or{SortFoo{}} (Lblfoo'Unds'TEST'Unds'{}(), \bottom{SortFoo{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortToken{}} (\top{SortToken{}}(), \bottom{SortToken{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortInt{}, \exists{SortFoo{}} (X1:SortInt{}, Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(X0:SortInt{}, X1:SortInt{}))), \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBool{}, Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{})), \or{SortFoo{}} (Lblbar'Unds'TEST'Unds'{}(), \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBool{}, Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{})), \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortBool{}, Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(X0:SortBool{})), \or{SortFoo{}} (Lblfoo'Unds'TEST'Unds'{}(), \or{SortFoo{}} (\exists{SortFoo{}} (X0:SortMap{}, Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(X0:SortMap{})), \bottom{SortFoo{}}()))))))) [constructor{}()] // no junk
   axiom{} \or{SortSet{}} (Lbl'Stop'Set{}(), \or{SortSet{}} (\exists{SortSet{}} (X0:SortSet{}, \exists{SortSet{}} (X1:SortSet{}, Lbl'Unds'Set'Unds'{}(X0:SortSet{}, X1:SortSet{}))), \bottom{SortSet{}}())) [constructor{}()] // no junk
 
 // rules
@@ -188,6 +245,16 @@ module TEST
       \top{R}()))
   []
 
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(296) org.kframework.attributes.Location(Location(296,8,296,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("296"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(296,8,296,38)")]
+
 // rule isKCell(inj{KCell,K}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
@@ -198,6 +265,66 @@ module TEST
       \top{R}()))
   []
 
+// rule `_orBool__BOOL__Bool_Bool`(_3,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(301) org.kframework.attributes.Location(Location(301,8,301,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'3:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("301"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(301,8,301,34)")]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarList:SortList{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<k>`(inj{Foo,KItem}(`eq(_)_TEST__Bool`(#token("false","Bool")))~>DotVar0)=>`<k>`(inj{Token,KItem}(#token("token","Token"))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(20) org.kframework.attributes.Location(Location(20,6,20,24)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("false"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortToken{}, SortKItem{}}(\dv{SortToken{}}("token")),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("20"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(20,6,20,24)")]
+
+// rule isFoo(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarFoo:SortFoo{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisFoo{}(inj{SortFoo{}, SortK{}}(VarFoo:SortFoo{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFoo{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<k>`(inj{Foo,KItem}(`baz(_)_TEST__Bool`(#token("false","Bool")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`baz(_)_TEST__Bool`(`_orBool__BOOL__Bool_Bool`(`_orBool__BOOL__Bool_Bool`(#token("false","Bool"),#token("false","Bool")),`_orBool__BOOL__Bool_Bool`(#token("true","Bool"),#token("true","Bool")))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(14) org.kframework.attributes.Location(Location(14,6,14,71)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("false"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),\dv{SortBool{}}("false")),Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true"))))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("14"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,6,14,71)")]
+
 // rule isKItem(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
@@ -207,6 +334,35 @@ module TEST
         \dv{SortBool{}}("true")),
       \top{R}()))
   []
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_1)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(311) org.kframework.attributes.Location(Location(311,8,311,40)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'1:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("311"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,8,311,40)")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarKConfigVar:SortKConfigVar{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKConfigVar{}(inj{SortKConfigVar{}, SortK{}}(VarKConfigVar:SortKConfigVar{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
 
 // rule isSet(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
@@ -238,24 +394,31 @@ module TEST
       \top{R}()))
   []
 
-// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(313) org.kframework.attributes.Location(Location(313,8,313,45)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarSet:SortSet{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisSet{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{}))))),
-        \bottom{R}())),
-      \top{R}()),
+    \top{R}(),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisSet{}(VarK:SortK{}),
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
+      \top{R}()))
+  [contentStartLine{}("313"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(313,8,313,45)")]
+
+// rule `<k>`(inj{Foo,KItem}(`_+__TEST__Int_Int`(#token("1","Int"),#token("2","Int")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`baz(_)_TEST__Bool`(`_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`_andBool_`(#token("false","Bool"),#token("false","Bool")))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(13) org.kframework.attributes.Location(Location(13,6,13,69)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),\dv{SortInt{}}("2"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("false"),\dv{SortBool{}}("false"))))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("13"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,6,13,69)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool"),_6)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(292) org.kframework.attributes.Location(Location(292,8,292,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'6:SortBool{}),
         \dv{SortBool{}}("false")),
       \top{R}()))
-  [owise{}()]
+  [contentStartLine{}("292"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,8,292,36)")]
 
 // rule isKConfigVar(inj{KConfigVar,K}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
@@ -277,34 +440,108 @@ module TEST
       \top{R}()))
   []
 
-// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,K}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(310) org.kframework.attributes.Location(Location(310,8,310,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
-      \equals{SortKCell{},R} (
-        LblinitKCell{}(VarInit:SortMap{}),
-        Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortK{}}(\dv{SortKConfigVar{}}("$PGM"))))),
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
       \top{R}()))
-  [initializer{}()]
+  [contentStartLine{}("310"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(310,8,310,36)")]
 
-// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `<k>`(inj{Foo,K}(`map(_)_TEST__Map`(M)))=>`<k>`(`Map:lookup`(M,inj{Int,K}(#token("0","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(19) org.kframework.attributes.Location(Location(19,6,19,37)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(inj{SortFoo{}, SortK{}}(Lblmap'LParUndsRParUnds'TEST'UndsUnds'Map{}(VarM:SortMap{}))),Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarM:SortMap{},inj{SortInt{}, SortK{}}(\dv{SortInt{}}("0")))))))
+  [theRule{}(), contentStartLine{}("19"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(19,6,19,37)")]
+
+// rule `<k>`(inj{Foo,KItem}(`not(_)_TEST__Bool`(#token("false","Bool")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`not(_)_TEST__Bool`(`_impliesBool__BOOL__Bool_Bool`(`_impliesBool__BOOL__Bool_Bool`(#token("true","Bool"),#token("false","Bool")),#token("false","Bool"))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(16) org.kframework.attributes.Location(Location(16,6,16,67)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("false"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("false")),\dv{SortBool{}}("false")))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("16"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(16,6,16,67)")]
+
+// rule `<k>`(inj{Foo,KItem}(`baz(_)_TEST__Bool`(#token("true","Bool")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`not(_)_TEST__Bool`(`notBool_`(#token("true","Bool"))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(15) org.kframework.attributes.Location(Location(15,6,15,36)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("true"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(LblnotBool'Unds'{}(\dv{SortBool{}}("true")))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("15"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(15,6,15,36)")]
+
+// rule isToken(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
           \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarBool:SortBool{}, 
+            \exists{SortBool{}} (VarToken:SortToken{}, 
               \and{SortBool{}} (
                 \top{SortBool{}}(),
-                LblisBool{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
+                LblisToken{}(inj{SortToken{}, SortK{}}(VarToken:SortToken{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisBool{}(VarK:SortK{}),
+        LblisToken{}(VarK:SortK{}),
         \dv{SortBool{}}("false")),
       \top{R}()))
   [owise{}()]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(307) org.kframework.attributes.Location(Location(307,8,307,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("307"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(307,8,307,37)")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(286) org.kframework.attributes.Location(Location(286,8,286,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("286"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,8,286,37)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(303) org.kframework.attributes.Location(Location(303,8,303,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("303"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(303,8,303,32)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(302) org.kframework.attributes.Location(Location(302,8,302,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("302"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(302,8,302,32)")]
+
+// rule `<k>`(inj{Foo,KItem}(`bar_TEST_`(.KList))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`_+__TEST__Int_Int`(#token("1","Int"),#token("2","Int")))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(12) org.kframework.attributes.Location(Location(12,6,12,18)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblbar'Unds'TEST'Unds'{}()),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),\dv{SortInt{}}("2"))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("12"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,6,12,18)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool"),_2)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(305) org.kframework.attributes.Location(Location(305,8,305,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("305"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(305,8,305,33)")]
 
 // rule isKItem(inj{Cell,K}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
@@ -316,24 +553,189 @@ module TEST
       \top{R}()))
   []
 
-// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `_andBool_`(#token("false","Bool"),_4)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(287) org.kframework.attributes.Location(Location(287,8,287,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("false"),Var'Unds'4:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("287"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(287,8,287,37)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(297) org.kframework.attributes.Location(Location(297,8,297,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("297"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(297,8,297,38)")]
+
+// rule `<k>`(inj{Foo,K}(`foo_TEST_`(.KList)))=>`<k>`(inj{Foo,K}(`bar_TEST_`(.KList))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(11) org.kframework.attributes.Location(Location(11,6,11,25)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(inj{SortFoo{}, SortK{}}(Lblfoo'Unds'TEST'Unds'{}())),Lbl'-LT-'k'-GT-'{}(inj{SortFoo{}, SortK{}}(Lblbar'Unds'TEST'Unds'{}())))))
+  [theRule{}(), contentStartLine{}("11"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(11,6,11,25)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_8,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(312) org.kframework.attributes.Location(Location(312,8,312,39)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'8:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("312"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(312,8,312,39)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool"),_5)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(300) org.kframework.attributes.Location(Location(300,8,300,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'5:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("300"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(300,8,300,34)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(295) org.kframework.attributes.Location(Location(295,8,295,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("295"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(295,8,295,38)")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
           \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarList:SortList{}, 
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
               \and{SortBool{}} (
                 \top{SortBool{}}(),
-                LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{}))))),
+                LblisKCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
         \bottom{R}())),
       \top{R}()),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisList{}(VarK:SortK{}),
+        LblisKCell{}(VarK:SortK{}),
         \dv{SortBool{}}("false")),
       \top{R}()))
   [owise{}()]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarMap:SortMap{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisMap{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKItem(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(315) org.kframework.attributes.Location(Location(315,8,315,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [contentStartLine{}("315"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,8,315,57)")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(282) org.kframework.attributes.Location(Location(282,8,282,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("282"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(282,8,282,29)")]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(285) org.kframework.attributes.Location(Location(285,8,285,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("285"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(285,8,285,37)")]
+
+// rule `_andBool_`(_7,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(288) org.kframework.attributes.Location(Location(288,8,288,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'7:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("288"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(288,8,288,37)")]
+
+// rule isList(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
 
 // rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
@@ -389,11 +791,17 @@ module TEST
                 LblisKItem{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{}))))),
         \or{R} (
           \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarToken:SortToken{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisKItem{}(inj{SortToken{}, SortK{}}(VarToken:SortToken{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
             \exists{SortBool{}} (VarKItem:SortKItem{}, 
               \and{SortBool{}} (
                 \top{SortBool{}}(),
                 LblisKItem{}(inj{SortKItem{}, SortK{}}(VarKItem:SortKItem{}))))),
-        \bottom{R}())))))))))),
+        \bottom{R}()))))))))))),
       \top{R}()),
     \and{R} (
       \equals{SortBool{},R} (
@@ -402,143 +810,35 @@ module TEST
       \top{R}()))
   [owise{}()]
 
-// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarKCell:SortKCell{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarCell:SortCell{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisCell{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{}))))),
-        \bottom{R}()))),
-      \top{R}()),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisCell{}(VarK:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [owise{}()]
-
-// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarKCell:SortKCell{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisKCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKCell{}(VarK:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [owise{}()]
-
-// rule isKItem(inj{Set,K}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule isKItem(inj{Token,K}(Token))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisKItem{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{})),
+        LblisKItem{}(inj{SortToken{}, SortK{}}(VarToken:SortToken{})),
         \dv{SortBool{}}("true")),
       \top{R}()))
   []
 
-// rule isInt(inj{Int,K}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(290) org.kframework.attributes.Location(Location(290,8,290,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisInt{}(inj{SortInt{}, SortK{}}(VarInt:SortInt{})),
-        \dv{SortBool{}}("true")),
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarK:SortBool{}),
+        VarK:SortBool{}),
       \top{R}()))
-  []
+  [contentStartLine{}("290"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,8,290,37)")]
 
-// rule isKItem(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(298) org.kframework.attributes.Location(Location(298,8,298,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
   axiom{R} \implies{R} (
     \top{R}(),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisKItem{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{})),
-        \dv{SortBool{}}("true")),
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
       \top{R}()))
-  []
-
-// rule isFoo(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarFoo:SortFoo{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisFoo{}(inj{SortFoo{}, SortK{}}(VarFoo:SortFoo{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisFoo{}(VarK:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [owise{}()]
-
-// rule isKItem(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKItem{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{})),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarMap:SortMap{}, 
-              \and{SortBool{}} (
-                \top{SortBool{}}(),
-                LblisMap{}(inj{SortMap{}, SortK{}}(VarMap:SortMap{}))))),
-        \bottom{R}())),
-      \top{R}()),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisMap{}(VarK:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [owise{}()]
-
-// rule isList(inj{List,K}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
-  axiom{R} \implies{R} (
-    \top{R}(),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisList{}(inj{SortList{}, SortK{}}(VarList:SortList{})),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
-  []
-
-// rule `<k>`(inj{Foo,K}(`foo_TEST_`(.KList)))=>`<k>`(inj{Foo,K}(`bar_TEST_`(.KList))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(5) org.kframework.attributes.Location(Location(5,6,5,25)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
-  axiom{} \and{SortKCell{}} (
-    \top{SortKCell{}}(), \and{SortKCell{}} (
-    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(inj{SortFoo{}, SortK{}}(Lblfoo'Unds'TEST'Unds'{}())),Lbl'-LT-'k'-GT-'{}(inj{SortFoo{}, SortK{}}(Lblbar'Unds'TEST'Unds'{}())))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), contentStartLine{}("5"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), theRule{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(5,6,5,25)")]
+  [contentStartLine{}("298"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(298,8,298,57)")]
 
 // rule isMap(inj{Map,K}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
@@ -580,6 +880,51 @@ module TEST
       \top{R}()))
   []
 
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarBool:SortBool{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisBool{}(inj{SortBool{}, SortK{}}(VarBool:SortBool{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<k>`(inj{Foo,KItem}(`eq(_)_TEST__Bool`(#token("true","Bool")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`eq(_)_TEST__Bool`(`_==Bool__BOOL__Bool_Bool`(#token("true","Bool"),#token("false","Bool"))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(18) org.kframework.attributes.Location(Location(18,6,18,39)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("true"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("false")))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("18"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(18,6,18,39)")]
+
+// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,K}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortK{}}(\dv{SortKConfigVar{}}("$PGM"))))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(283) org.kframework.attributes.Location(Location(283,8,283,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("283"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,8,283,29)")]
+
 // rule isBool(inj{Bool,K}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
   axiom{R} \implies{R} (
     \top{R}(),
@@ -590,21 +935,37 @@ module TEST
       \top{R}()))
   []
 
-// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(308) org.kframework.attributes.Location(Location(308,8,308,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("308"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(308,8,308,37)")]
+
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
           \ceil{SortBool{},R} (
-            \exists{SortBool{}} (VarKConfigVar:SortKConfigVar{}, 
+            \exists{SortBool{}} (VarKCell:SortKCell{}, 
               \and{SortBool{}} (
                 \top{SortBool{}}(),
-                LblisKConfigVar{}(inj{SortKConfigVar{}, SortK{}}(VarKConfigVar:SortKConfigVar{}))))),
-        \bottom{R}())),
+                LblisCell{}(inj{SortKCell{}, SortK{}}(VarKCell:SortKCell{}))))),
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarCell:SortCell{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisCell{}(inj{SortCell{}, SortK{}}(VarCell:SortCell{}))))),
+        \bottom{R}()))),
       \top{R}()),
     \and{R} (
       \equals{SortBool{},R} (
-        LblisKConfigVar{}(VarK:SortK{}),
+        LblisCell{}(VarK:SortK{}),
         \dv{SortBool{}}("false")),
       \top{R}()))
   [owise{}()]
@@ -618,6 +979,71 @@ module TEST
         \dv{SortBool{}}("true")),
       \top{R}()))
   []
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_0,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(293) org.kframework.attributes.Location(Location(293,8,293,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [contentStartLine{}("293"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(293,8,293,36)")]
+
+// rule isToken(inj{Token,K}(Token))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisToken{}(inj{SortToken{}, SortK{}}(VarToken:SortToken{})),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \ceil{SortBool{},R} (
+            \exists{SortBool{}} (VarSet:SortSet{}, 
+              \and{SortBool{}} (
+                \top{SortBool{}}(),
+                LblisSet{}(inj{SortSet{}, SortK{}}(VarSet:SortSet{}))))),
+        \bottom{R}())),
+      \top{R}()),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<k>`(inj{Foo,KItem}(`not(_)_TEST__Bool`(#token("true","Bool")))~>DotVar0)=>`<k>`(inj{Foo,KItem}(`eq(_)_TEST__Bool`(`_=/=Bool__BOOL__Bool_Bool`(#token("false","Bool"),#token("false","Bool"))))~>DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(17) org.kframework.attributes.Location(Location(17,6,17,42)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K) theRule()]
+  axiom{} \and{SortKCell{}} (
+    \top{SortKCell{}}(), \and{SortKCell{}} (
+    \top{SortKCell{}}(), \rewrites{SortKCell{}}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool{}(\dv{SortBool{}}("true"))),VarDotVar0:SortK{})),Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortFoo{}, SortKItem{}}(Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool{}(Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),\dv{SortBool{}}("false")))),VarDotVar0:SortK{})))))
+  [theRule{}(), contentStartLine{}("17"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartColumn{}("6"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(17,6,17,42)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(291) org.kframework.attributes.Location(Location(291,8,291,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [contentStartLine{}("291"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(291,8,291,37)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_9,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(306) org.kframework.attributes.Location(Location(306,8,306,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'9:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [contentStartLine{}("306"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartColumn{}("8"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,8,306,33)")]
 
 // rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
   axiom{R} \implies{R} (
@@ -638,4 +1064,4 @@ module TEST
       \top{R}()))
   [owise{}()]
 
-endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,7,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)")]
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,22,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)")]

--- a/test/test.ll
+++ b/test/test.ll
@@ -1,3 +1,5 @@
+target datalayout = "e-m:e-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-unknown-linux-gnu"
 
 %blockheader = type { i64 }
 %mpz = type { i32, i32, i64* }
@@ -124,7 +126,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231244 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198540 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
   br i1 false, label %hook_BOOL_or, label %else
 
 else:                                             ; preds = %entry
@@ -216,7 +218,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231244 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198540 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
   br i1 true, label %then, label %hook_BOOL_and
 
 then:                                             ; preds = %entry
@@ -325,7 +327,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231261 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198557 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
   br i1 true, label %then, label %hook_BOOL_implies
 
 then:                                             ; preds = %entry
@@ -374,7 +376,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231261 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198557 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
   %hook_BOOL_not = xor i1 true, true
   %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
   store i1 %hook_BOOL_not, i1* %4
@@ -631,7 +633,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231245 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198541 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
   %hook_BOOL_eq = icmp eq i1 true, false
   %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
   store i1 %hook_BOOL_eq, i1* %4
@@ -738,7 +740,7 @@ entry:
   %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
   %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
   %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
-  store %blockheader { i64 1688854155231245 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  store %blockheader { i64 1688858450198541 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
   %hook_BOOL_ne = xor i1 false, false
   %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
   store i1 %hook_BOOL_ne, i1* %4

--- a/test/test.ll
+++ b/test/test.ll
@@ -1,8 +1,481 @@
 
-%block = type { %blockheader, [0 x i64*] }
 %blockheader = type { i64 }
+%mpz = type { i32, i32, i64* }
+%block = type { %blockheader, [0 x i64*] }
+%map = type { i64, i8*, i8* }
 
-define %block* @apply_rule_0() {
+@token_token = global { %blockheader, [5 x i8] } { %blockheader { i64 5 }, [5 x i8] c"token" }
+@int_0 = global %mpz { i32 0, i32 0, i64* getelementptr inbounds ([0 x i64], [0 x i64]* @int_0_limbs, i32 0, i32 0) }
+@int_0_limbs = global [0 x i64] zeroinitializer
+@int_1 = global %mpz { i32 1, i32 1, i64* getelementptr inbounds ([1 x i64], [1 x i64]* @int_1_limbs, i32 0, i32 0) }
+@int_1_limbs = global [1 x i64] [i64 1]
+@int_2 = global %mpz { i32 1, i32 1, i64* getelementptr inbounds ([1 x i64], [1 x i64]* @int_2_limbs, i32 0, i32 0) }
+@int_2_limbs = global [1 x i64] [i64 2]
+@"token_$PGM" = global { %blockheader, [4 x i8] } { %blockheader { i64 4 }, [4 x i8] c"$PGM" }
+
+define %block* @apply_rule_0(%block* %K2) {
+entry:
+  ret %block* %K2
+}
+
+; Function Attrs: noreturn
+declare void @abort() #0
+
+define %block* @apply_rule_1(%block* %K1, %block* %K2, %block* %K3) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %1 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 2
+  store %block* %K1, %block** %1
+  %2 = alloca %block*
+  %3 = call i1 @"eval_append{SortK{},SortK{}}"(%block** %2, %block* %K2, %block* %K3)
+  br i1 %3, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %4 = load %block*, %block** %2
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %0, i64 0, i32 3
+  store %block* %4, %block** %5
+  %6 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %0 to %block*
+  ret %block* %6
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare noalias i8* @malloc(i64)
+
+declare i1 @"eval_append{SortK{},SortK{}}"(%block**, %block*, %block*)
+
+define i1 @apply_rule_2() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_3(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_4() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_5() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_6() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_7(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645285 }, %blockheader* %inj
+  %3 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* bitcast ({ %blockheader, [5 x i8] }* @token_token to %block*), %block** %3
+  %4 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %4, %block** %5
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %9
+}
+
+define i1 @apply_rule_8() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_9(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231244 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  br i1 false, label %hook_BOOL_or, label %else
+
+else:                                             ; preds = %entry
+  br label %hook_BOOL_or
+
+hook_BOOL_or:                                     ; preds = %else, %entry
+  %phi = phi i1 [ false, %else ], [ false, %entry ]
+  br i1 %phi, label %hook_BOOL_or5, label %else4
+
+else4:                                            ; preds = %hook_BOOL_or
+  br i1 true, label %hook_BOOL_or7, label %else6
+
+hook_BOOL_or5:                                    ; preds = %hook_BOOL_or7, %hook_BOOL_or
+  %phi9 = phi i1 [ %phi8, %hook_BOOL_or7 ], [ %phi, %hook_BOOL_or ]
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %phi9, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+
+else6:                                            ; preds = %else4
+  br label %hook_BOOL_or7
+
+hook_BOOL_or7:                                    ; preds = %else6, %else4
+  %phi8 = phi i1 [ true, %else6 ], [ true, %else4 ]
+  br label %hook_BOOL_or5
+}
+
+define i1 @apply_rule_10() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_11() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_12() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_13() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_14() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_15() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_16(i1 %VarB) {
+entry:
+  %hook_BOOL_not = xor i1 %VarB, true
+  ret i1 %hook_BOOL_not
+}
+
+define %block* @apply_rule_17(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231244 }, %blockheader* %"Lblbaz'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  br i1 true, label %then, label %hook_BOOL_and
+
+then:                                             ; preds = %entry
+  br label %hook_BOOL_and
+
+hook_BOOL_and:                                    ; preds = %then, %entry
+  %phi = phi i1 [ true, %then ], [ true, %entry ]
+  br i1 %phi, label %then4, label %hook_BOOL_and5
+
+then4:                                            ; preds = %hook_BOOL_and
+  br i1 false, label %then6, label %hook_BOOL_and7
+
+hook_BOOL_and5:                                   ; preds = %hook_BOOL_and7, %hook_BOOL_and
+  %phi9 = phi i1 [ %phi8, %hook_BOOL_and7 ], [ %phi, %hook_BOOL_and ]
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %phi9, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+
+then6:                                            ; preds = %then4
+  br label %hook_BOOL_and7
+
+hook_BOOL_and7:                                   ; preds = %then6, %then4
+  %phi8 = phi i1 [ false, %then6 ], [ false, %then4 ]
+  br label %hook_BOOL_and5
+}
+
+define i1 @apply_rule_18() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_19() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_20() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_21(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define %block* @apply_rule_22(%map %VarM) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %1 = alloca %block*
+  %2 = alloca %map
+  store %map %VarM, %map* %2
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %mpz* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 0
+  store %blockheader { i64 3096233333751848 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %mpz* }, { %blockheader, [0 x i64], %mpz* }* %3, i64 0, i32 2
+  store %mpz* @int_0, %mpz** %4
+  %5 = bitcast { %blockheader, [0 x i64], %mpz* }* %3 to %block*
+  %6 = call i1 @hook_MAP_lookup(%block** %1, %map* %2, %block* %5)
+  br i1 %6, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %7 = load %block*, %block** %1
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %9
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+declare i1 @hook_MAP_lookup(%block**, %map*, %block*)
+
+define %block* @apply_rule_23(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231261 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  br i1 true, label %then, label %hook_BOOL_implies
+
+then:                                             ; preds = %entry
+  br label %hook_BOOL_implies
+
+hook_BOOL_implies:                                ; preds = %then, %entry
+  %phi = phi i1 [ false, %then ], [ true, %entry ]
+  br i1 %phi, label %then4, label %hook_BOOL_implies5
+
+then4:                                            ; preds = %hook_BOOL_implies
+  br label %hook_BOOL_implies5
+
+hook_BOOL_implies5:                               ; preds = %then4, %hook_BOOL_implies
+  %phi6 = phi i1 [ false, %then4 ], [ true, %hook_BOOL_implies ]
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %phi6, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+}
+
+define %block* @apply_rule_24(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231261 }, %blockheader* %"Lblnot'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  %hook_BOOL_not = xor i1 true, true
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %hook_BOOL_not, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+}
+
+define i1 @apply_rule_25() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_26(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_27(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_28(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_29(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define %block* @apply_rule_30(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %mpz*, %mpz* }* getelementptr ({ %blockheader, [0 x i64], %mpz*, %mpz* }, { %blockheader, [0 x i64], %mpz*, %mpz* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], %mpz*, %mpz* }*
+  %"Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int" = getelementptr inbounds { %blockheader, [0 x i64], %mpz*, %mpz* }, { %blockheader, [0 x i64], %mpz*, %mpz* }* %3, i64 0, i32 0
+  store %blockheader { i64 844437815033865 }, %blockheader* %"Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Int'Unds'Int"
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %mpz*, %mpz* }, { %blockheader, [0 x i64], %mpz*, %mpz* }* %3, i64 0, i32 2
+  store %mpz* @int_1, %mpz** %4
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %mpz*, %mpz* }, { %blockheader, [0 x i64], %mpz*, %mpz* }* %3, i64 0, i32 3
+  store %mpz* @int_2, %mpz** %5
+  %6 = bitcast { %blockheader, [0 x i64], %mpz*, %mpz* }* %3 to %block*
+  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %6, %block** %7
+  %8 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %8, %block** %9
+  %10 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %10
+  %11 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %12 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %11, %block** %12
+  %13 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %13
+}
+
+define i1 @apply_rule_31() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_32() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_33() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_34() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_35() {
 entry:
   %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
   %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
@@ -11,8 +484,8 @@ entry:
   %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
   %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
   %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
-  store %blockheader { i64 281483566645270 }, %blockheader* %inj
-  %2 = inttoptr i64 8589934593 to %block*
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %2 = inttoptr i64 47244640257 to %block*
   %3 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
   store %block* %2, %block** %3
   %4 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
@@ -22,9 +495,281 @@ entry:
   ret %block* %6
 }
 
-; Function Attrs: noreturn
-declare void @abort() #0
+define i1 @apply_rule_36() {
+entry:
+  ret i1 true
+}
 
-declare noalias i8* @malloc(i64)
+define i1 @apply_rule_37() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_38(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_39() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_40() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_41() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_42() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_43() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_44() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_45(i1 %VarB1, i1 %VarB2) {
+entry:
+  %hook_BOOL_eq = icmp eq i1 %VarB1, %VarB2
+  %hook_BOOL_not = xor i1 %hook_BOOL_eq, true
+  ret i1 %hook_BOOL_not
+}
+
+define i1 @apply_rule_46() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_47(i1 %VarB) {
+entry:
+  ret i1 %VarB
+}
+
+define i1 @apply_rule_48() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_49() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_50() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_51() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_52(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_53(i1 %VarB1, i1 %VarB2) {
+entry:
+  %hook_BOOL_eq = icmp eq i1 %VarB1, %VarB2
+  %hook_BOOL_not = xor i1 %hook_BOOL_eq, true
+  ret i1 %hook_BOOL_not
+}
+
+define i1 @apply_rule_54() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_55() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_56() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_57() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_58() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_59(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231245 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  %hook_BOOL_eq = icmp eq i1 true, false
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %hook_BOOL_eq, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+}
+
+define %block* @apply_rule_60(%map %VarInit) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %1 = alloca %block*
+  %2 = alloca %map
+  store %map %VarInit, %map* %2
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 0
+  store %blockheader { i64 281483566645286 }, %blockheader* %inj
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %3, i64 0, i32 2
+  store %block* bitcast ({ %blockheader, [4 x i8] }* @"token_$PGM" to %block*), %block** %4
+  %5 = bitcast { %blockheader, [0 x i64], %block* }* %3 to %block*
+  %6 = call i1 @hook_MAP_lookup(%block** %1, %map* %2, %block* %5)
+  br i1 %6, label %notstuck, label %stuck
+
+notstuck:                                         ; preds = %entry
+  %7 = load %block*, %block** %1
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %9
+
+stuck:                                            ; preds = %entry
+  call void @abort()
+  unreachable
+}
+
+define i1 @apply_rule_61() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_62() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_63(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_64() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_65() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_66() {
+entry:
+  ret i1 false
+}
+
+define i1 @apply_rule_67() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_68() {
+entry:
+  ret i1 false
+}
+
+define %block* @apply_rule_69(%block* %VarDotVar0) {
+entry:
+  %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
+  %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block*, %block* }* getelementptr ({ %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* null, i32 1) to i64))
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block*, %block* }*
+  %kseq = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 2251812698587180 }, %blockheader* %kseq
+  %malloccall2 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
+  %2 = bitcast i8* %malloccall2 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
+  store %blockheader { i64 281483566645284 }, %blockheader* %inj
+  %malloccall3 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], i1 }* getelementptr ({ %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* null, i32 1) to i64))
+  %3 = bitcast i8* %malloccall3 to { %blockheader, [0 x i64], i1 }*
+  %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool" = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 0
+  store %blockheader { i64 1688854155231245 }, %blockheader* %"Lbleq'LParUndsRParUnds'TEST'UndsUnds'Bool"
+  %hook_BOOL_ne = xor i1 false, false
+  %4 = getelementptr inbounds { %blockheader, [0 x i64], i1 }, { %blockheader, [0 x i64], i1 }* %3, i64 0, i32 2
+  store i1 %hook_BOOL_ne, i1* %4
+  %5 = bitcast { %blockheader, [0 x i64], i1 }* %3 to %block*
+  %6 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  store %block* %5, %block** %6
+  %7 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
+  %8 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 2
+  store %block* %7, %block** %8
+  %9 = getelementptr inbounds { %blockheader, [0 x i64], %block*, %block* }, { %blockheader, [0 x i64], %block*, %block* }* %1, i64 0, i32 3
+  store %block* %VarDotVar0, %block** %9
+  %10 = bitcast { %blockheader, [0 x i64], %block*, %block* }* %1 to %block*
+  %11 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
+  store %block* %10, %block** %11
+  %12 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %12
+}
+
+define i1 @apply_rule_70(i1 %VarK) {
+entry:
+  ret i1 %VarK
+}
+
+define i1 @apply_rule_71() {
+entry:
+  ret i1 true
+}
+
+define i1 @apply_rule_72() {
+entry:
+  ret i1 false
+}
 
 attributes #0 = { noreturn }

--- a/test/test.ll
+++ b/test/test.ll
@@ -2,24 +2,29 @@
 %block = type { %blockheader, [0 x i64*] }
 %blockheader = type { i64 }
 
-define %block* @test_rhs0() {
+define %block* @apply_rule_0() {
 entry:
   %malloccall = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
   %0 = bitcast i8* %malloccall to { %blockheader, [0 x i64], %block* }*
-  %1 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
-  store %blockheader { i64 281483566645248 }, %blockheader* %1
+  %"Lbl'-LT-'k'-GT-'" = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 0
+  store %blockheader { i64 281483566645248 }, %blockheader* %"Lbl'-LT-'k'-GT-'"
   %malloccall1 = tail call i8* @malloc(i64 ptrtoint ({ %blockheader, [0 x i64], %block* }* getelementptr ({ %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* null, i32 1) to i64))
-  %2 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
-  %3 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 0
-  store %blockheader { i64 281483566645270 }, %blockheader* %3
-  %4 = inttoptr i64 8589934593 to %block*
-  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %2, i64 0, i32 2
+  %1 = bitcast i8* %malloccall1 to { %blockheader, [0 x i64], %block* }*
+  %inj = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 0
+  store %blockheader { i64 281483566645270 }, %blockheader* %inj
+  %2 = inttoptr i64 8589934593 to %block*
+  %3 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %1, i64 0, i32 2
+  store %block* %2, %block** %3
+  %4 = bitcast { %blockheader, [0 x i64], %block* }* %1 to %block*
+  %5 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
   store %block* %4, %block** %5
-  %6 = bitcast { %blockheader, [0 x i64], %block* }* %2 to %block*
-  %7 = getelementptr inbounds { %blockheader, [0 x i64], %block* }, { %blockheader, [0 x i64], %block* }* %0, i64 0, i32 2
-  store %block* %6, %block** %7
-  %8 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
-  ret %block* %8
+  %6 = bitcast { %blockheader, [0 x i64], %block* }* %0 to %block*
+  ret %block* %6
 }
 
+; Function Attrs: noreturn
+declare void @abort() #0
+
 declare noalias i8* @malloc(i64)
+
+attributes #0 = { noreturn }

--- a/tools/test_rhs/CMakeLists.txt
+++ b/tools/test_rhs/CMakeLists.txt
@@ -4,7 +4,7 @@ add_llvm_tool(test_rhs
   main.cpp
 )
 
-target_link_libraries(test_rhs Codegen Parser AST)
+target_link_libraries(test_rhs Codegen Parser AST gmp)
 
 llvm_config(test_rhs
   ${LLVM_TARGETS_TO_BUILD}

--- a/tools/test_rhs/main.cpp
+++ b/tools/test_rhs/main.cpp
@@ -27,16 +27,9 @@ int main (int argc, char **argv) {
 
   std::unique_ptr<llvm::Module> mod = newModule("test", Context);
 
-  int idx = 0;
   for (auto axiom : definition->getAxioms()) {
     if (axiom->getAttributes().count("theRule")) {
-      KOREPattern *pattern = axiom->getRightHandSide();
-      llvm::StringMap<llvm::Value *> subst;
-      llvm::Constant *func = mod->getOrInsertFunction("test_rhs" + std::to_string(idx++), termType(pattern, subst, definition, Context, mod.get()), NULL);
-      llvm::Function *testRhs = llvm::cast<llvm::Function>(func);
-      llvm::BasicBlock *block = llvm::BasicBlock::Create(Context, "entry", testRhs);
-      llvm::Value *retval = createTerm(pattern, subst, definition, block, mod.get());
-      llvm::ReturnInst::Create(Context, retval, block);
+      makeApplyRuleFunction(axiom, definition, mod.get());
     }
   }
   mod->print(llvm::outs(), nullptr);

--- a/tools/test_rhs/main.cpp
+++ b/tools/test_rhs/main.cpp
@@ -28,9 +28,7 @@ int main (int argc, char **argv) {
   std::unique_ptr<llvm::Module> mod = newModule("test", Context);
 
   for (auto axiom : definition->getAxioms()) {
-    if (axiom->getAttributes().count("theRule")) {
-      makeApplyRuleFunction(axiom, definition, mod.get());
-    }
+    makeApplyRuleFunction(axiom, definition, mod.get());
   }
   mod->print(llvm::outs(), nullptr);
   return 0;


### PR DESCRIPTION
I have tested each feature I added by manually examining the code it generates in a single case, and I have tested that the generated code compiles, and added coverage of each feature to the ci testing, but I have not manually gone through the entire reference files.

That said, we can now handle 182 of the 183 axioms in imp.kore. The single missing case is injection transitivity which is polymorphic over its sorts and therefore must generate different code depending on the SortCategory of its argument. I will fix this in the next pull request.