### PR TITLE
Minor bugfixes to llvm backend for EVM and IELE

### DIFF
--- a/bin/llvm-kompile-rust-lto
+++ b/bin/llvm-kompile-rust-lto
@@ -1,0 +1,17 @@
+#!/bin/bash
+dir="$(mktemp -d)"
+trap "rm -rf $dir" INT TERM EXIT
+archive=$(realpath -m $1)
+cd "$dir"
+ar x "$archive"
+rm ./*.o
+for file in *.bc.z; do
+len=`od -An -t u4 -j 15 -N4 $file`
+blen=`od -An -t u8 -j $((len+19)) -N8 $file`
+tail -c+$((len+28)) $file | head -c $blen > $file.bc.gz
+printf "\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00" |cat - $file.bc.gz |gzip -dc > ${file%.bc.z}.o
+done
+rm *.bc.z
+rm *.gz
+rm "$archive"
+llvm-ar-6.0 rs "${archive}" ./*

--- a/ciscript
+++ b/ciscript
@@ -28,4 +28,6 @@ llvm-kompile ../test/test6.kore TEST -o interpreter
 ./interpreter ../test/test6.kore -1 /dev/stdout | diff - ../test/test6.out
 llvm-kompile ../test/test7.kore TEST -o interpreter
 ./interpreter ../test/test7.in.kore -1 /dev/null
+llvm-kompile ../test/test8.kore TEST -o interpreter
+./interpreter ../test/test8.kore -1 /dev/stdout | diff - ../test/test8.out
 rm -f configparser configparser.ll interpreterQ

--- a/cmake/mkrlib.cmake
+++ b/cmake/mkrlib.cmake
@@ -1,0 +1,5 @@
+file(GLOB files ${CMAKE_INSTALL_PREFIX}/lib/kllvm/rust/deps/*.rlib)
+foreach(file ${files})
+  execute_process(COMMAND ../bin/llvm-kompile-rust-lto ${file})
+endforeach()
+execute_process(COMMAND ../bin/llvm-kompile-rust-lto ${CMAKE_INSTALL_PREFIX}/lib/kllvm/rust/libdatastructures.rlib)

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -286,9 +286,21 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
     if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
       if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
         if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
-            if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
-              return equals->getArguments()[1];
+          if (auto bottomPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+            if (bottomPattern->getConstructor()->getName() == "\\bottom" && bottomPattern->getArguments().empty()) {
+              if (auto andPattern2 = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[1])) {
+                if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
+                  if (auto rewrites = dynamic_cast<KOREObjectCompositePattern *>(andPattern2->getArguments()[1])) {
+                    if (rewrites->getConstructor()->getName() == "\\rewrites" && rewrites->getArguments().size() == 2) {
+                      return rewrites->getArguments()[1];
+                    }
+                  }
+                }
+              }
+            } else if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+              if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+                return equals->getArguments()[1];
+              }
             }
           }
         }
@@ -323,6 +335,19 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
           return equals->getArguments()[0];
         } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
           return nullptr;
+        } else if (equals->getConstructor()->getName() == "\\bottom" && equals->getArguments().empty()) {
+          // sttrategy axiom hack
+          if (auto trueTop = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+            if (trueTop->getConstructor()->getName() == "\\and" && trueTop->getArguments().size() == 2) {
+              if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(trueTop->getArguments()[0])) {
+                if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+                  return equals->getArguments()[0];
+                } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+                  return nullptr;
+                }
+              }
+            }
+          }
         }
       }
     } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -2,6 +2,7 @@
 #include "kllvm/codegen/GenAlloc.h"
 
 #include <gmp.h>
+#include <iomanip>
 
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/IR/BasicBlock.h"
@@ -189,6 +190,16 @@ llvm::Type *termType(KOREPattern *pattern, llvm::StringMap<llvm::Type *> &substi
   }
 }
 
+std::string escape(std::string str) {
+  std::stringstream os;
+  os << std::setfill('0') << std::setw(2) << std::hex;
+  for (char c : str) {
+    unsigned char uc = c;
+    os << (int)uc;
+  }
+  return os.str();
+}
+
 llvm::Value *CreateTerm::createToken(ValueType sort, std::string contents) {
   switch(sort.cat) {
   case SortCategory::Map:
@@ -226,7 +237,7 @@ llvm::Value *CreateTerm::createToken(ValueType sort, std::string contents) {
     return llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), contents == "true");
   case SortCategory::Symbol: {
     llvm::StructType *StringType = llvm::StructType::get(Ctx, {Module->getTypeByName(BLOCKHEADER_STRUCT), llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), contents.size())});
-    llvm::Constant *global = Module->getOrInsertGlobal("token_" + contents, StringType);
+    llvm::Constant *global = Module->getOrInsertGlobal("token_" + escape(contents), StringType);
     llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       llvm::StructType *BlockHeaderType = Module->getTypeByName(BLOCKHEADER_STRUCT);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -138,9 +138,6 @@ static llvm::Value *getArgValue(llvm::Value *ArgumentsArray, int idx,
       "", CaseBlock);
   llvm::Value *arg = new llvm::LoadInst(addr, "", CaseBlock);
   switch(cat.cat) {
-  case SortCategory::Map:
-  case SortCategory::List:
-  case SortCategory::Set:
   case SortCategory::Bool:
   case SortCategory::MInt: {
     auto cast = new llvm::BitCastInst(arg,
@@ -149,6 +146,11 @@ static llvm::Value *getArgValue(llvm::Value *ArgumentsArray, int idx,
     arg = load;
     break;
   }
+  case SortCategory::Map:
+  case SortCategory::List:
+  case SortCategory::Set:
+    arg = new llvm::BitCastInst(arg, llvm::PointerType::getUnqual(getValueType(cat, mod)), "", CaseBlock);
+    break;
   case SortCategory::Int:
   case SortCategory::Float:
   case SortCategory::StringBuffer:
@@ -440,6 +442,9 @@ static void getStore(KOREDefinition *definition, llvm::Module *module, KOREObjec
     llvm::Value *arg = getArgValue(ArgumentsArray, idx, CaseBlock, cat, module);
     llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, cast,
         {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)}, "", CaseBlock);
+    if (arg->getType() == ChildPtr->getType()) {
+      arg = new llvm::LoadInst(arg, "", CaseBlock);
+    }
     new llvm::StoreInst(arg, ChildPtr, CaseBlock);
   }
 }

--- a/matching/src/Pattern/Parser.hs
+++ b/matching/src/Pattern/Parser.hs
@@ -170,6 +170,7 @@ splitTop topPattern =
   case topPattern of
     KoreObjectPattern (AndPattern (And _ (KoreObjectPattern (EqualsPattern (Equals _ _ pat _))) (KoreObjectPattern (AndPattern ((And _ _ (KoreObjectPattern (RewritesPattern (r@(Rewrites _ _ _)))))))))) -> Just (r, Just pat)
     KoreObjectPattern (AndPattern (And _ (KoreObjectPattern (TopPattern _)) (KoreObjectPattern (AndPattern ((And _ _ (KoreObjectPattern (RewritesPattern (r@(Rewrites _ _ _)))))))))) -> Just (r, Nothing)
+    KoreObjectPattern (ImpliesPattern (Implies _ (KoreObjectPattern (BottomPattern _)) p)) -> splitTop p
     _ -> Nothing
 
 getAxioms :: KoreDefinition -> [SentenceAxiom UnifiedSortVariable UnifiedPattern Variable]

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -36,3 +36,7 @@ install(
   DESTINATION lib/kllvm/rust/deps
   PATTERN *.rlib
 )
+
+if (CMAKE_BUILD_TYPE STREQUAL "Release")
+  install(SCRIPT ../cmake/mkrlib.cmake)
+endif()

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -1,5 +1,6 @@
 #include<gmp.h>
-#include<stdlib.h>
+#include<cstdlib>
+#include<cstring>
 #include<stdexcept>
 
 extern "C" {
@@ -230,6 +231,7 @@ mpz_ptr hook_INT_log2(mpz_t a) {
 void extract(mpz_t result, mpz_t i, size_t off, size_t len) {
   size_t size = (len + LIMB_BITS - 1) / LIMB_BITS;
   mpz_init2(result, len+LIMB_BITS);
+  memset(result->_mp_d, 0, size);
   size_t off_words = off / LIMB_BITS;
   size_t off_bits = off % LIMB_BITS;
   size_t num_limbs = mpz_size(i);

--- a/runtime/datastructures/Cargo.toml
+++ b/runtime/datastructures/Cargo.toml
@@ -14,5 +14,6 @@ name = "datastructures"
 panic = "abort"
 
 [profile.release]
-lto = "true"
+lto = true
+codegen-units=1
 panic = "abort"

--- a/test/test8.kore
+++ b/test/test8.kore
@@ -1,0 +1,1641 @@
+[topCellInitializer{}(LblinitGeneratedTopCell{}()),
+initial-configuration{}(LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(kseq{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())))))]
+
+module BASIC-K
+  sort SortK{} []
+  sort SortKItem{} []
+endmodule []
+
+module KSEQ
+  import BASIC-K []
+
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+  symbol dotk{}() : SortK{} []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(dotk{}(),K2:SortK{}),
+      K2:SortK{})
+  []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
+      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
+  []
+
+endmodule []
+
+module INJ
+  symbol inj{From,To}(From) : To [sortInjection{}()]
+ 
+  axiom{S1,S2,S3,R} 
+    \equals{S3,R}(
+      inj{S2,S3}(inj{S1,S2}(T:S1)),
+      inj{S1,S3}(T:S1))
+  []
+
+endmodule []
+
+module K
+  import KSEQ []
+  import INJ []
+endmodule []
+
+module TEST
+
+// imports
+  import K []
+
+// sorts
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("LIST.List"), concat{}(Lbl'Unds'List'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,3,197,31)"), unit{}(Lbl'Stop'List{}()), element{}(LblListItem{}())]
+  sort SortKConfigVar{} [token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)")]
+  sort Sort'Hash'UpperId{} []
+  sort Sort'Hash'LowerId{} []
+  sort SortSCellOpt{} []
+  sort SortGeneratedCounterCell{} []
+  sort SortCell{} []
+  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(263,3,263,31)")]
+  sort SortKCell{} []
+  sort SortStrategyApplied{} []
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.Map"), concat{}(Lbl'Unds'Map'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(87,3,87,28)"), unit{}(Lbl'Stop'Map{}()), element{}(Lbl'UndsPipe'-'-GT-Unds'{}())]
+  sort SortKCellOpt{} []
+  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,3,320,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.Int")]
+  sort SortGeneratedTopCell{} []
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.Set"), concat{}(Lbl'Unds'Set'Unds'{}()), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(153,3,153,28)"), unit{}(Lbl'Stop'Set{}()), element{}(LblSetItem{}())]
+  sort SortStrategy{} []
+  sort Sort'Hash'RuleTag{} []
+  sort SortGeneratedTopCellFragment{} []
+  sort SortStrategyApply{} []
+  sort SortSCell{} []
+
+// symbols
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("\\dotCt{Set}"), hook{}("SET.unit"), klabel{}(".Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,18,161,122)"), productionID{}("1594873248")]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.bitRange"), klabel{}("bitRangeInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(364,18,364,108)"), productionID{}("2144838275")]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,19,132,79)"), productionID{}("196732636")]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.ge"), smtlib{}(">="), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(384,19,384,149)"), productionID{}("1423983012")]
+  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(356,18,356,146)"), productionID{}("788625466")]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortSCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(388,19,388,52)"), productionID{}("1309335839")]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.size"), klabel{}("sizeMap"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,103)"), productionID{}("483797427")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.ne"), smtlib{}("distinct"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(387,19,387,160)"), productionID{}("405896924")]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.rand"), klabel{}("randInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(397,18,397,56)"), productionID{}("1267105885")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.le"), smtlib{}("<="), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(382,19,382,149)"), productionID{}("2029680286")]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [equalEqualK{}(), function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}\\mathrel{=_K}{#2}"), hook{}("KEQUAL.eq"), smtlib{}("="), klabel{}("_==K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(723,21,723,156)"), productionID{}("1552341957")]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.log2"), klabel{}("log2Int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(362,18,362,74)"), productionID{}("2059572982")]
+  hooked-symbol LblListItem{}(SortK{}) : SortList{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("LIST.element"), smtlib{}("smt_seq_elem"), klabel{}("ListItem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(235,19,235,132)"), productionID{}("1281025083")]
+  symbol LblisStrategy{}(SortK{}) : SortBool{} [function{}(), predicate{}("Strategy"), originalPrd{}()]
+  symbol Lblis'Hash'RuleTag{}(SortK{}) : SortBool{} [function{}(), predicate{}("#RuleTag"), originalPrd{}()]
+  symbol LblinitSCell{}(SortMap{}) : SortSCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCellOpt"), originalPrd{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.add"), smtlib{}("+"), klabel{}("_+Int_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,18,348,176)"), productionID{}("1948810915")]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortK{}) : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("MAP.remove"), klabel{}("_[_<-undef]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(116,18,116,117)"), productionID{}("455501890")]
+  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,18,354,142)"), productionID{}("1752461090")]
+  hooked-symbol LblSet'Coln'in{}(SortK{}, SortSet{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("SET.in"), klabel{}("Set:in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(175,19,175,102)"), productionID{}("1856158867")]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortK{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.srand"), klabel{}("srandInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(398,16,398,56)"), productionID{}("1481818223")]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}, SortSCell{}) : SortGeneratedTopCell{} [format{}("%1%i%n%2%n%3%d%n%4"), topcell{}(), constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), cellName{}("generatedTop"), contentStartLine{}("7"), contentStartColumn{}("17"), cell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(7,17,7,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortK{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.lookupOrDefault"), klabel{}("Map:lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(110,16,110,126)"), productionID{}("1178587240")]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), boolOperation{}(), hook{}("BOOL.or"), smtlib{}("or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,19,275,156)"), productionID{}("418958713")]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.values"), klabel{}("values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,19,137,76)"), productionID{}("1720891078")]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), boolOperation{}(), hook{}("BOOL.andThen"), smtlib{}("and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(273,19,273,118)"), productionID{}("1365767549")]
+  symbol Lblis'Hash'LowerId{}(SortK{}) : SortBool{} [function{}(), predicate{}("#LowerId"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [format{}("%1%n%2"), function{}(), left{}(), unit{}(".Map"), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), assoc{}(), index{}("0"), element{}("_|->_"), hook{}("MAP.concat"), klabel{}("_Map_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(95,18,95,172)"), productionID{}("1044705957"), comm{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [format{}("%1%n%2"), function{}(), left{}(), unit{}(".List"), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), assoc{}(), element{}("ListItem"), hook{}("LIST.concat"), smtlib{}("smt_seq_concat"), klabel{}("_List_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(230,19,230,192)"), productionID{}("485845532")]
+  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.ediv"), smtlib{}("div"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,18,345,93)"), productionID{}("943573036")]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.powmod"), smtlib{}("(mod (^ #1 #2) #3)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(337,18,337,110)"), productionID{}("1173346575")]
+  symbol LblisSCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("SCell"), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.eq"), smtlib{}("="), klabel{}("_==Int_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(386,19,386,167)"), productionID{}("127791068")]
+  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.tmod"), smtlib{}("mod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(343,18,343,144)"), productionID{}("52514534")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortK{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.choice"), klabel{}("Map:choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,16,146,96)"), productionID{}("970419381")]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.size"), klabel{}("size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(181,18,181,80)"), productionID{}("258112787")]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.abs"), smtlib{}("int_abs"), klabel{}("absInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(361,18,361,102)"), productionID{}("787122337")]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("\\dotCt{List}"), hook{}("LIST.unit"), smtlib{}("smt_seq_nil"), klabel{}(".List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,19,232,146)"), productionID{}("871790326")]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(394,18,394,72)"), productionID{}("596470015")]
+  symbol LblisStrategyApplied{}(SortK{}) : SortBool{} [function{}(), predicate{}("StrategyApplied"), originalPrd{}()]
+  hooked-symbol Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,18,334,133)"), productionID{}("1807015220")]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(SortBool{}, SortS0, SortS0) : SortS0 [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("KEQUAL.ite"), poly{}("0, 2, 3"), smtlib{}("ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(731,16,731,122)"), productionID{}("1624972302")]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCell"), originalPrd{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(SortMap{}, SortK{}, SortK{}) : SortMap{} [prefer{}(), function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(113,18,113,96)"), productionID{}("144040807")]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(352,18,352,131)"), productionID{}("1604247316")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("BOOL.ne"), smtlib{}("distinct"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(280,19,280,103)"), productionID{}("1358343316")]
+  symbol LblisSCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("SCellOpt"), originalPrd{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.signExtendBitRange"), klabel{}("signExtendBitRangeInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(365,18,365,118)"), productionID{}("36657658")]
+  symbol LblnoSCell{}() : SortSCellOpt{} [cellOptAbsent{}("SCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortK{}) : SortK{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("MAP.lookup"), klabel{}("Map:lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(108,16,108,104)"), productionID{}("1601687801")]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), boolOperation{}(), hook{}("BOOL.xor"), smtlib{}("xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(274,19,274,114)"), productionID{}("105579928")]
+  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.emod"), smtlib{}("mod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(346,18,346,93)"), productionID{}("1242027525")]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}-_{\\it Map}{#2}"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,18,120,120)"), productionID{}("2050462663")]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,18,358,140)"), productionID{}("1753714541")]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.updateAll"), klabel{}("updateMap"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,91)"), productionID{}("1119072377")]
+  symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), boolOperation{}(), hook{}("BOOL.orElse"), smtlib{}("or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(276,19,276,116)"), productionID{}("1042306518")]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCell"), originalPrd{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortK{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("LIST.get"), klabel{}("List:get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(240,16,240,94)"), productionID{}("40170008")]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [format{}("%1%i%n%2%d%n%3"), topcell{}(), constructor{}(), originalPrd{}(), functional{}(), cellName{}("generatedCounter"), cell{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), boolOperation{}(), hook{}("BOOL.not"), smtlib{}("not"), klabel{}("notBool_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(271,19,271,174)"), productionID{}("37981645")]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.keys"), klabel{}("keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(131,18,131,86)"), productionID{}("1305935114")]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("LIST.range"), klabel{}("List:range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(243,19,243,98)"), productionID{}("896982466")]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), boolOperation{}(), hook{}("BOOL.implies"), smtlib{}("=>"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,117)"), productionID{}("1342346098")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,91)"), productionID{}("1486726131")]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortK{} [function{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.choice"), klabel{}("Set:choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(184,16,184,90)"), productionID{}("1318227903")]
+  symbol Lbl'-LT-'s'-GT-'{}(SortK{}) : SortSCell{} [format{}("%1%i%n%2%d%n%3"), topcell{}(), constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), cellName{}("s"), contentStartLine{}("1260"), contentStartColumn{}("19"), cell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1260,19,1260,40)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("LIST.size"), smtlib{}("smt_seq_len"), klabel{}("sizeList"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(249,18,249,121)"), productionID{}("777457133")]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(351,18,351,131)"), productionID{}("735937428")]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortK{}, SortK{}) : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}\\mapsto{#2}"), hook{}("MAP.element"), klabel{}("_|->_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(102,18,102,136)"), productionID{}("288379405")]
+  symbol Lbl'Hash'applyRule{}(Sort'Hash'RuleTag{}) : SortStrategyApply{} [constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("#applyRule"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1254,30,1254,91)"), productionID{}("1332691311")]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(SortK{}, SortList{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("LIST.in"), klabel{}("_inList_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(246,19,246,97)"), productionID{}("901205084")]
+  symbol Lbl'Hash'STUCK{}() : SortStrategy{} [constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("#STUCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1252,25,1252,41)"), productionID{}("65488937")]
+  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.mul"), smtlib{}("*"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,18,339,155)"), productionID{}("1267149311")]
+  symbol Lblis'Hash'UpperId{}(SortK{}) : SortBool{} [function{}(), predicate{}("#UpperId"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.gt"), smtlib{}(">"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(385,19,385,145)"), productionID{}("746074699")]
+  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.tdiv"), smtlib{}("div"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(342,18,342,146)"), productionID{}("102174918")]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}\\mathrel{\\neq_K}{#2}"), hook{}("KEQUAL.ne"), notEqualEqualK{}(), smtlib{}("distinct"), klabel{}("_=/=K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(724,19,724,168)"), productionID{}("1176164144")]
+  hooked-symbol LblSetItem{}(SortK{}) : SortSet{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), hook{}("SET.element"), klabel{}("SetItem"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(166,18,166,108)"), productionID{}("1692885405")]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("\\dotCt{Map}"), hook{}("MAP.unit"), klabel{}(".Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(97,18,97,128)"), productionID{}("693958407")]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.min"), smtlib{}("int_min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(359,18,359,102)"), productionID{}("1095273238")]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.intersection"), klabel{}("intersectSet"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(169,18,169,88)"), productionID{}("1230955136")]
+  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.lt"), smtlib{}("<"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,19,383,145)"), productionID{}("375466577")]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}-_{\\it Set}{#2}"), hook{}("SET.difference"), klabel{}("Set:difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(172,18,172,146)"), productionID{}("1336001042")]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(178,19,178,85)"), productionID{}("823575379")]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.removeAll"), klabel{}("removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,18,128,91)"), productionID{}("1696263571")]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCellFragment"), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("BOOL.eq"), smtlib{}("="), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,96)"), productionID{}("238762799")]
+  symbol LblisStrategyApply{}(SortK{}) : SortBool{} [function{}(), predicate{}("StrategyApply"), originalPrd{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), hook{}("INT.sub"), smtlib{}("-"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,18,349,152)"), productionID{}("2104973502")]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.max"), smtlib{}("int_max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(360,18,360,102)"), productionID{}("177140066")]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [format{}("%1%i%n%2%d%n%3"), constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), cellName{}("k"), contentStartLine{}("7"), contentStartColumn{}("17"), cell{}(), maincell{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(7,17,7,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [function{}(), left{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), boolOperation{}(), hook{}("BOOL.and"), smtlib{}("and"), klabel{}("_andBool_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(272,19,272,187)"), productionID{}("605052357")]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [format{}("%1%n%2"), function{}(), left{}(), unit{}(".Set"), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), assoc{}(), element{}("SetItem"), hook{}("SET.concat"), idem{}(), klabel{}("_Set_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(159,18,159,176)"), productionID{}("1916700921"), comm{}()]
+  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [function{}(), left{}(), originalPrd{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), hook{}("INT.pow"), smtlib{}("^"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,18,336,151)"), productionID{}("2107577743")]
+  symbol Lbl'Hash'appliedRule{}(Sort'Hash'RuleTag{}) : SortStrategyApplied{} [constructor{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("#appliedRule"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1256,32,1256,93)"), productionID{}("999230073")]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(SortK{}, SortMap{}) : SortBool{} [function{}(), originalPrd{}(), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,19,134,89)"), productionID{}("1414967210")]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortGeneratedTopCell{}, SortCell{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:Sort'Hash'RuleTag{}, \equals{Sort'Hash'RuleTag{}, R} (Val:Sort'Hash'RuleTag{}, inj{Sort'Hash'UpperId{}, Sort'Hash'RuleTag{}} (From:Sort'Hash'UpperId{}))) [subsort{Sort'Hash'UpperId{}, Sort'Hash'RuleTag{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortSCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortSCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortSCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortSCellOpt{}} (X1:SortSCellOpt{}, Y1:SortSCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortKCell{}, SortCell{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStrategy{}, SortKItem{}} (From:SortStrategy{}))) [subsort{SortStrategy{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortSCell{}, SortCell{}} (From:SortSCell{}))) [subsort{SortSCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortSCellOpt{}, \equals{SortSCellOpt{}, R} (Val:SortSCellOpt{}, inj{SortSCell{}, SortSCellOpt{}} (From:SortSCell{}))) [subsort{SortSCell{}, SortSCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:Sort'Hash'RuleTag{}, \equals{Sort'Hash'RuleTag{}, R} (Val:Sort'Hash'RuleTag{}, inj{Sort'Hash'LowerId{}, Sort'Hash'RuleTag{}} (From:Sort'Hash'LowerId{}))) [subsort{Sort'Hash'LowerId{}, Sort'Hash'RuleTag{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortK{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}, K2:SortSCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}, X2:SortSCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{}, Y2:SortSCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}), \and{SortSCell{}} (X2:SortSCell{}, Y2:SortSCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStrategyApply{}, SortKItem{}} (From:SortStrategyApply{}))) [subsort{SortStrategyApply{}, SortKItem{}}()] // subsort
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSCell{}, SortKItem{}} (From:SortSCell{}))) [subsort{SortSCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStrategy{}, \equals{SortStrategy{}, R} (Val:SortStrategy{}, inj{SortStrategyApply{}, SortStrategy{}} (From:SortStrategyApply{}))) [subsort{SortStrategyApply{}, SortStrategy{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'UndsUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortS0} \exists{R} (Val:SortS0, \equals{SortS0, R} (Val:SortS0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(K0:SortBool{}, K1:SortS0, K2:SortS0))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'K'Unds'K{}(K0:SortMap{}, K1:SortK{}, K2:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSCellOpt{}, \equals{SortSCellOpt{}, R} (Val:SortSCellOpt{}, LblnoSCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, inj{SortKItem{}, SortK{}} (From:SortKItem{}))) [subsort{SortKItem{}, SortK{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSCellOpt{}, SortKItem{}} (From:SortSCellOpt{}))) [subsort{SortSCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCell{}, SortKItem{}} (From:SortCell{}))) [subsort{SortCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortSCell{}, \equals{SortSCell{}, R} (Val:SortSCell{}, Lbl'-LT-'s'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortSCell{}} (\and{SortSCell{}} (Lbl'-LT-'s'-GT-'{}(X0:SortK{}), Lbl'-LT-'s'-GT-'{}(Y0:SortK{})), Lbl'-LT-'s'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStrategyApply{}, \equals{SortStrategyApply{}, R} (Val:SortStrategyApply{}, Lbl'Hash'applyRule{}(K0:Sort'Hash'RuleTag{}))) [functional{}()] // functional
+  axiom{}\implies{SortStrategyApply{}} (\and{SortStrategyApply{}} (Lbl'Hash'applyRule{}(X0:Sort'Hash'RuleTag{}), Lbl'Hash'applyRule{}(Y0:Sort'Hash'RuleTag{})), Lbl'Hash'applyRule{}(\and{Sort'Hash'RuleTag{}} (X0:Sort'Hash'RuleTag{}, Y0:Sort'Hash'RuleTag{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'K'Unds'List{}(K0:SortK{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStrategy{}, \equals{SortStrategy{}, R} (Val:SortStrategy{}, Lbl'Hash'STUCK{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStrategy{}, \equals{SortStrategy{}, R} (Val:SortStrategy{}, inj{SortStrategyApplied{}, SortStrategy{}} (From:SortStrategyApplied{}))) [subsort{SortStrategyApplied{}, SortStrategy{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStrategyApplied{}, SortKItem{}} (From:SortStrategyApplied{}))) [subsort{SortStrategyApplied{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortStrategyApplied{}, \equals{SortStrategyApplied{}, R} (Val:SortStrategyApplied{}, Lbl'Hash'appliedRule{}(K0:Sort'Hash'RuleTag{}))) [functional{}()] // functional
+  axiom{}\implies{SortStrategyApplied{}} (\and{SortStrategyApplied{}} (Lbl'Hash'appliedRule{}(X0:Sort'Hash'RuleTag{}), Lbl'Hash'appliedRule{}(Y0:Sort'Hash'RuleTag{})), Lbl'Hash'appliedRule{}(\and{Sort'Hash'RuleTag{}} (X0:Sort'Hash'RuleTag{}, Y0:Sort'Hash'RuleTag{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'K'Unds'Map{}(K0:SortK{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSCellOpt{}, inj{SortSCellOpt{}, SortKItem{}} (Val:SortSCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStrategyApplied{}, inj{SortStrategyApplied{}, SortKItem{}} (Val:SortStrategyApplied{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStrategy{}, inj{SortStrategy{}, SortKItem{}} (Val:SortStrategy{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStrategyApply{}, inj{SortStrategyApply{}, SortKItem{}} (Val:SortStrategyApply{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSCell{}, inj{SortSCell{}, SortKItem{}} (Val:SortSCell{})), \bottom{SortKItem{}}())))))))))))))))) [constructor{}()] // no junk
+  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{Sort'Hash'UpperId{}} (\top{Sort'Hash'UpperId{}}(), \bottom{Sort'Hash'UpperId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{Sort'Hash'LowerId{}} (\top{Sort'Hash'LowerId{}}(), \bottom{Sort'Hash'LowerId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortSCellOpt{}} (LblnoSCell{}(), \or{SortSCellOpt{}} (\exists{SortSCellOpt{}} (Val:SortSCell{}, inj{SortSCell{}, SortSCellOpt{}} (Val:SortSCell{})), \bottom{SortSCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortCell{}} (Val:SortGeneratedTopCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortSCell{}, inj{SortSCell{}, SortCell{}} (Val:SortSCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \or{SortK{}} (\exists{SortK{}} (Val:SortList{}, inj{SortList{}, SortK{}} (Val:SortList{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSCellOpt{}, inj{SortSCellOpt{}, SortK{}} (Val:SortSCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortK{}} (Val:SortGeneratedCounterCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortCell{}, inj{SortCell{}, SortK{}} (Val:SortCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortBool{}, inj{SortBool{}, SortK{}} (Val:SortBool{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCell{}, inj{SortKCell{}, SortK{}} (Val:SortKCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStrategyApplied{}, inj{SortStrategyApplied{}, SortK{}} (Val:SortStrategyApplied{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMap{}, inj{SortMap{}, SortK{}} (Val:SortMap{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortK{}} (Val:SortKCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortInt{}, inj{SortInt{}, SortK{}} (Val:SortInt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortK{}} (Val:SortGeneratedTopCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSet{}, inj{SortSet{}, SortK{}} (Val:SortSet{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStrategy{}, inj{SortStrategy{}, SortK{}} (Val:SortStrategy{})), \or{SortK{}} (\exists{SortK{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortK{}} (Val:SortGeneratedTopCellFragment{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStrategyApply{}, inj{SortStrategyApply{}, SortK{}} (Val:SortStrategyApply{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSCell{}, inj{SortSCell{}, SortK{}} (Val:SortSCell{})), \bottom{SortK{}}()))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortStrategyApplied{}} (\exists{SortStrategyApplied{}} (X0:Sort'Hash'RuleTag{}, Lbl'Hash'appliedRule{}(X0:Sort'Hash'RuleTag{})), \bottom{SortStrategyApplied{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, \exists{SortGeneratedTopCell{}} (X2:SortSCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}, X2:SortSCell{})))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortStrategy{}} (Lbl'Hash'STUCK{}(), \or{SortStrategy{}} (\exists{SortStrategy{}} (Val:SortStrategyApplied{}, inj{SortStrategyApplied{}, SortStrategy{}} (Val:SortStrategyApplied{})), \or{SortStrategy{}} (\exists{SortStrategy{}} (Val:SortStrategyApply{}, inj{SortStrategyApply{}, SortStrategy{}} (Val:SortStrategyApply{})), \bottom{SortStrategy{}}()))) [constructor{}()] // no junk
+  axiom{} \or{Sort'Hash'RuleTag{}} (\exists{Sort'Hash'RuleTag{}} (Val:Sort'Hash'UpperId{}, inj{Sort'Hash'UpperId{}, Sort'Hash'RuleTag{}} (Val:Sort'Hash'UpperId{})), \or{Sort'Hash'RuleTag{}} (\exists{Sort'Hash'RuleTag{}} (Val:Sort'Hash'LowerId{}, inj{Sort'Hash'LowerId{}, Sort'Hash'RuleTag{}} (Val:Sort'Hash'LowerId{})), \bottom{Sort'Hash'RuleTag{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortSCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortSCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortStrategyApply{}} (\exists{SortStrategyApply{}} (X0:Sort'Hash'RuleTag{}, Lbl'Hash'applyRule{}(X0:Sort'Hash'RuleTag{})), \bottom{SortStrategyApply{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortSCell{}} (\exists{SortSCell{}} (X0:SortK{}, Lbl'-LT-'s'-GT-'{}(X0:SortK{})), \bottom{SortSCell{}}()) [constructor{}()] // no junk
+
+// rules
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_2)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(311) org.kframework.attributes.Location(Location(311,8,311,40)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'2:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("311"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,8,311,40)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(379) org.kframework.attributes.Location(Location(379,8,379,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI1:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("379"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(379,8,379,57)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule inj{StrategyApplied,Strategy}(#appliedRule(#token("regular","#RuleTag")))=>inj{StrategyApply,Strategy}(#applyRule(#token("regular","#RuleTag"))) requires #token("true","Bool") ensures #token("true","Bool") [anywhere() contentStartColumn(10) contentStartLine(1266) org.kframework.attributes.Location(Location(1266,10,1266,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(282) org.kframework.attributes.Location(Location(282,8,282,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("282"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(282,8,282,29)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isStrategyApply(inj{StrategyApply,KItem}(StrategyApply))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategyApply{}(kseq{}(inj{SortStrategyApply{}, SortKItem{}}(VarStrategyApply:SortStrategyApply{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `minInt(_,_)_INT__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(380) org.kframework.attributes.Location(Location(380,8,380,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI2:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("380"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(380,8,380,57)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_10,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(734) org.kframework.attributes.Location(Location(734,8,734,64)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},Var'Unds'10:SortK{},VarB2:SortK{}),
+        VarB2:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("734"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(734,8,734,64)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule isStrategyApplied(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarStrategyApplied:SortStrategyApplied{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStrategyApplied{}, SortKItem{}}(VarStrategyApplied:SortStrategyApplied{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategyApplied{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(_1,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(288) org.kframework.attributes.Location(Location(288,8,288,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'1:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("288"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(288,8,288,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarCell:SortCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(290) org.kframework.attributes.Location(Location(290,8,290,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("290"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,8,290,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(298) org.kframework.attributes.Location(Location(298,8,298,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("298"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(298,8,298,57)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblinitGeneratedCounterCell{}(),
+        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarKItem:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(VarKItem:SortKItem{},dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(315) org.kframework.attributes.Location(Location(315,8,315,57)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("315"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,8,315,57)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool"),_4)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(300) org.kframework.attributes.Location(Location(300,8,300,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'4:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("300"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(300,8,300,34)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `<generatedTop>`(_0,_1,`<s>`(S~>DotVar1))=>`<generatedTop>`(_0,_1,`<s>`(inj{Strategy,KItem}(#STUCK(.KList))~>S~>DotVar1)) requires `_=/=K_`(S,inj{Strategy,KItem}(#STUCK(.KList))) ensures #token("true","Bool") [owise()]
+  axiom{} \implies{SortGeneratedTopCell{}}(\bottom{SortGeneratedTopCell{}}(),\and{SortGeneratedTopCell{}} (
+    \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'UndsEqlsSlshEqls'K'Unds'{}(kseq{}(VarS:SortKItem{},dotk{}()),kseq{}(inj{SortStrategy{}, SortKItem{}}(Lbl'Hash'STUCK{}()),dotk{}())),
+        \dv{SortBool{}}("true")), \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \rewrites{SortGeneratedTopCell{}}(Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'0:SortKCell{},Var'Unds'1:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(VarS:SortKItem{},VarDotVar1:SortK{}))),Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'0:SortKCell{},Var'Unds'1:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategy{}, SortKItem{}}(Lbl'Hash'STUCK{}()),kseq{}(VarS:SortKItem{},VarDotVar1:SortK{}))))))))
+  [owise{}()]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarGeneratedTopCell:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarMap:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isStrategy(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarStrategy:SortStrategy{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStrategy{}, SortKItem{}}(VarStrategy:SortStrategy{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategy{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisK{}(VarK:SortK{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `is#LowerId`(inj{#LowerId,KItem}(#LowerId))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'LowerId{}(kseq{}(inj{Sort'Hash'LowerId{}, SortKItem{}}(Var'Hash'LowerId:Sort'Hash'LowerId{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(312) org.kframework.attributes.Location(Location(312,8,312,39)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("312"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(312,8,312,39)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_dividesInt__INT__Int_Int`(I1,I2)=>`_==Int__INT__Int_Int`(`_%Int__INT__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(392) org.kframework.attributes.Location(Location(392,8,392,58)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'dividesInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("392"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,8,392,58)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isSCellOpt(inj{SCellOpt,KItem}(SCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSCellOpt{}(kseq{}(inj{SortSCellOpt{}, SortKItem{}}(VarSCellOpt:SortSCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isSCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarSCellOpt:SortSCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSCellOpt{}, SortKItem{}}(VarSCellOpt:SortSCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(283) org.kframework.attributes.Location(Location(283,8,283,29)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("283"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,8,283,29)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(296) org.kframework.attributes.Location(Location(296,8,296,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("296"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(296,8,296,38)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarKCellOpt:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `<generatedTop>`(_0,_1,`<s>`(inj{StrategyApplied,KItem}(#appliedRule(#token("regular","#RuleTag")))~>DotVar1))=>`<generatedTop>`(_0,_1,`<s>`(inj{StrategyApply,KItem}(#applyRule(#token("regular","#RuleTag")))~>DotVar1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(12) org.kframework.attributes.Location(Location(12,8,12,43)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \rewrites{SortGeneratedTopCell{}}(Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'0:SortKCell{},Var'Unds'1:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategyApplied{}, SortKItem{}}(Lbl'Hash'appliedRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),VarDotVar1:SortK{}))),Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'0:SortKCell{},Var'Unds'1:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategyApply{}, SortKItem{}}(Lbl'Hash'applyRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),VarDotVar1:SortK{}))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartLine{}("12"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,8,12,43)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool"),_9)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(305) org.kframework.attributes.Location(Location(305,8,305,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),Var'Unds'9:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("305"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(305,8,305,33)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(295) org.kframework.attributes.Location(Location(295,8,295,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("295"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(295,8,295,38)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isSCell(inj{SCell,KItem}(SCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSCell{}(kseq{}(inj{SortSCell{}, SortKItem{}}(VarSCell:SortSCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(310) org.kframework.attributes.Location(Location(310,8,310,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("310"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(310,8,310,36)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarInt:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(285) org.kframework.attributes.Location(Location(285,8,285,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("285"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(285,8,285,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_modInt__INT__Int_Int`(I1,I2)=>`_%Int__INT__Int_Int`(`_+Int_`(`_%Int__INT__Int_Int`(I1,`absInt(_)_INT__Int`(I2)),`absInt(_)_INT__Int`(I2)),`absInt(_)_INT__Int`(I2)) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(374) org.kframework.attributes.Location(Location(374,5,377,23)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI2:SortInt{}))),
+      \top{R}()))
+  [concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("374"), contentStartColumn{}("5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(374,5,377,23)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule `_==Int__INT__Int_Int`(I1,I2)=>`_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(390) org.kframework.attributes.Location(Location(390,8,390,40)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI1:SortInt{}),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(VarI2:SortInt{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("390"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(390,8,390,40)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_orBool__BOOL__Bool_Bool`(_3,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(301) org.kframework.attributes.Location(Location(301,8,301,34)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'3:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("301"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(301,8,301,34)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarKCell:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isStrategyApply(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarStrategyApply:SortStrategyApply{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStrategyApply{}, SortKItem{}}(VarStrategyApply:SortStrategyApply{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategyApply{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(kseq{}(VarKItem:SortKItem{},dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarList:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(297) org.kframework.attributes.Location(Location(297,8,297,38)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("297"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(297,8,297,38)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_=/=Int__INT__Int_Int`(I1,I2)=>`notBool_`(`_==Int__INT__Int_Int`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(391) org.kframework.attributes.Location(Location(391,8,391,53)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("391"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(391,8,391,53)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN)=>`_-Int__INT__Int_Int`(`_modInt__INT__Int_Int`(`_+Int_`(`bitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT__Int_Int`(#token("1","Int"),`_-Int__INT__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(369) org.kframework.attributes.Location(Location(369,8,369,149)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("369"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(369,8,369,149)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `is#RuleTag`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Hash'RuleTag:Sort'Hash'RuleTag{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'RuleTag{}, SortKItem{}}(Var'Hash'RuleTag:Sort'Hash'RuleTag{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'RuleTag{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_7,#token("false","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(293) org.kframework.attributes.Location(Location(293,8,293,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'7:SortBool{},\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("293"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(293,8,293,36)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(729) org.kframework.attributes.Location(Location(729,8,729,43)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:SortBool{},VarK2:SortBool{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK1:SortBool{}),dotk{}()),kseq{}(inj{SortBool{}, SortKItem{}}(VarK2:SortBool{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("729"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(729,8,729,43)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarKConfigVar:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(308) org.kframework.attributes.Location(Location(308,8,308,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("308"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(308,8,308,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `<generatedTop>`(`<k>`(inj{Int,KItem}(#token("5","Int"))),DotVar0,`<s>`(inj{Strategy,KItem}(#STUCK(.KList))~>DotVar1))=>`<generatedTop>`(`<k>`(inj{Int,KItem}(#token("6","Int"))),DotVar0,`<s>`(DotVar1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(10) org.kframework.attributes.Location(Location(10,8,10,50)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{} \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \rewrites{SortGeneratedTopCell{}}(Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("5")),dotk{}())),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategy{}, SortKItem{}}(Lbl'Hash'STUCK{}()),VarDotVar1:SortK{}))),Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(VarDotVar1:SortK{})))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartLine{}("10"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(10,8,10,50)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(291) org.kframework.attributes.Location(Location(291,8,291,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("true")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("291"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(291,8,291,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(313) org.kframework.attributes.Location(Location(313,8,313,45)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("313"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(313,8,313,45)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `<generatedTop>`(`<k>`(inj{Int,KItem}(I)),DotVar0,`<s>`(inj{StrategyApply,KItem}(#applyRule(#token("regular","#RuleTag")))~>SREST))=>`<generatedTop>`(`<k>`(inj{Int,KItem}(`_+Int_`(I,#token("1","Int")))),DotVar0,`<s>`(inj{StrategyApplied,KItem}(#appliedRule(#token("regular","#RuleTag")))~>SREST)) requires `_<Int__INT__Int_Int`(I,#token("5","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(9) org.kframework.attributes.Location(Location(9,8,9,48)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{} \and{SortGeneratedTopCell{}} (
+    \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},\dv{SortInt{}}("5")),
+        \dv{SortBool{}}("true")), \and{SortGeneratedTopCell{}} (
+    \top{SortGeneratedTopCell{}}(), \rewrites{SortGeneratedTopCell{}}(Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI:SortInt{}),dotk{}())),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategyApply{}, SortKItem{}}(Lbl'Hash'applyRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),VarSREST:SortK{}))),Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarI:SortInt{},\dv{SortInt{}}("1"))),dotk{}())),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategyApplied{}, SortKItem{}}(Lbl'Hash'appliedRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),VarSREST:SortK{}))))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), contentStartLine{}("9"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,8,9,48)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(286) org.kframework.attributes.Location(Location(286,8,286,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\dv{SortBool{}}("true")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("286"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,8,286,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `bitRangeInt(_,_,_)_INT__Int_Int_Int`(I,IDX,LEN)=>`_modInt__INT__Int_Int`(`_>>Int__INT__Int_Int`(I,IDX),`_<<Int__INT__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(367) org.kframework.attributes.Location(Location(367,8,367,70)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("367"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(367,8,367,70)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(307) org.kframework.attributes.Location(Location(307,8,307,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("307"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(307,8,307,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_11)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(733) org.kframework.attributes.Location(Location(733,8,733,56)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},VarB1:SortK{},Var'Unds'11:SortK{}),
+        VarB1:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("733"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(733,8,733,56)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarSet:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_divInt__INT__Int_Int`(I1,I2)=>`_/Int__INT__Int_Int`(`_-Int__INT__Int_Int`(I1,`_modInt__INT__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(371) org.kframework.attributes.Location(Location(371,8,372,23)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K "requires" K)]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'divInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsSlsh'Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},Lbl'Unds'modInt'UndsUnds'INT'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("371"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(371,8,372,23)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K \"requires\" K")]
+
+// rule `is#LowerId`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Hash'LowerId:Sort'Hash'LowerId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'LowerId{}, SortKItem{}}(Var'Hash'LowerId:Sort'Hash'LowerId{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'LowerId{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `freshInt(_)_INT__Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(395) org.kframework.attributes.Location(Location(395,8,395,28)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI:SortInt{}),
+        VarI:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("395"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,8,395,28)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isStrategyApplied(inj{StrategyApplied,KItem}(StrategyApplied))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategyApplied{}(kseq{}(inj{SortStrategyApplied{}, SortKItem{}}(VarStrategyApplied:SortStrategyApplied{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(302) org.kframework.attributes.Location(Location(302,8,302,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("302"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(302,8,302,32)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule initSCell(_12)=>`<s>`(inj{StrategyApply,KItem}(#applyRule(#token("regular","#RuleTag")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(10) contentStartLine(1268) org.kframework.attributes.Location(Location(1268,10,1268,44)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortSCell{},R} (
+        LblinitSCell{}(Var'Unds'12:SortMap{}),
+        Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategyApply{}, SortKItem{}}(Lbl'Hash'applyRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("1268"), contentStartColumn{}("10"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1268,10,1268,44)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(727) org.kframework.attributes.Location(Location(727,8,727,45)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("727"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(727,8,727,45)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_andBool_`(#token("false","Bool"),_6)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(287) org.kframework.attributes.Location(Location(287,8,287,37)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("false"),Var'Unds'6:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("287"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(287,8,287,37)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `is#RuleTag`(inj{#RuleTag,KItem}(#RuleTag))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'RuleTag{}(kseq{}(inj{Sort'Hash'RuleTag{}, SortKItem{}}(Var'Hash'RuleTag:Sort'Hash'RuleTag{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isStrategy(inj{Strategy,KItem}(Strategy))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStrategy{}(kseq{}(inj{SortStrategy{}, SortKItem{}}(VarStrategy:SortStrategy{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarGeneratedCounterCell:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'k'-GT-'{}(LblMap'Coln'lookup{}(VarInit:SortMap{},kseq{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),dotk{}())))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(303) org.kframework.attributes.Location(Location(303,8,303,32)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("303"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(303,8,303,32)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList),initSCell(Init)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCell{},R} (
+        LblinitGeneratedTopCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}(),LblinitSCell{}(VarInit:SortMap{}))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule isCell(inj{Cell,KItem}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `is#UpperId`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Hash'UpperId:Sort'Hash'UpperId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'UpperId{}, SortKItem{}}(Var'Hash'UpperId:Sort'Hash'UpperId{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'UpperId{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarBool:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isSCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (VarSCell:SortSCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSCell{}, SortKItem{}}(VarSCell:SortSCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `is#UpperId`(inj{#UpperId,KItem}(#UpperId))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'UpperId{}(kseq{}(inj{Sort'Hash'UpperId{}, SortKItem{}}(Var'Hash'UpperId:Sort'Hash'UpperId{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_8,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(306) org.kframework.attributes.Location(Location(306,8,306,33)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'8:SortBool{},\dv{SortBool{}}("true")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("306"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,8,306,33)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool"),_5)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(292) org.kframework.attributes.Location(Location(292,8,292,36)) org.kframework.attributes.Source(Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax RuleContent ::= K)]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'5:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/k/k-distribution/target/release/k/include/builtin/domains.k)"), contentStartLine{}("292"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,8,292,36)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax RuleContent ::= K")]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,14,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)")]

--- a/test/test8.out
+++ b/test/test8.out
@@ -1,0 +1,1 @@
+Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("6")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),Lbl'-LT-'s'-GT-'{}(kseq{}(inj{SortStrategy{}, SortKItem{}}(Lbl'Hash'STUCK{}()),kseq{}(inj{SortStrategyApply{}, SortKItem{}}(Lbl'Hash'applyRule{}(\dv{Sort'Hash'RuleTag{}}("regular"))),dotk{}()))))


### PR DESCRIPTION
Includes:
* rename the symbols associated with string token globals so that they do not have null bytes, which is apparently forbidden in llvm
* some bugfixes in how we pass collections around
* case for strategies in llvm and haskell code
* fix a bug in INT.bitRange hook where memory was being read uninitialized
* add lto for rust code
* fix a bug in computeMapElementScore that was causing a crash after we changed the Map sort to have keys which are KItem.