### PR TITLE
Improvements to rust allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,11 +59,6 @@ else()
 endif()
 endmacro(kllvm_add_tool)
 
-install(
-  FILES rustalloc.lds rustalloc.alias
-  DESTINATION lib/kllvm/rust
-)
-
 FILE(GLOB LLVMFiles runtime/*.ll)
 
 install(

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -47,7 +47,6 @@ fi
   "$RUSTDIR"/libcompiler_builtins-*.rlib \
   "$RUSTDIR"/libpanic_abort-*.rlib \
   "$RUSTDIR"/liballoc_system-*.rlib \
-  "$LIBDIR"/rust/rustalloc.lds \
   "$LIBDIR"/llvm/*.ll \
   "$MAINFILES" \
   "$LIBDIR"/libconfigurationparser.a \

--- a/runtime/alloc/collect.c
+++ b/runtime/alloc/collect.c
@@ -29,6 +29,12 @@ void map_foreach(void *, void(block**));
 void set_foreach(void *, void(block**));
 void list_foreach(void *, void(block**));
 
+static bool is_gc = false;
+
+bool during_gc() {
+  return is_gc;
+}
+
 static size_t get_size(uint64_t hdr, uint16_t layout) {
   if (!layout) {
     size_t size = (len_hdr(hdr)  + sizeof(block) + 7) & ~7;
@@ -186,6 +192,7 @@ static char* computeScanPtr(char* oldspace_start) {
 }
 
 void koreCollect(block** root) {
+  is_gc = true;
   MEM_LOG("Starting garbage collection\n");
   koreAllocSwap();
   char* oldspace_start = *old_alloc_ptr();
@@ -205,4 +212,5 @@ void koreCollect(block** root) {
     }
   }
   MEM_LOG("Finishing garbage collection\n");
+  is_gc = false;
 }

--- a/runtime/rustalloc.ll
+++ b/runtime/rustalloc.ll
@@ -1,0 +1,21 @@
+declare i8* @__rg_alloc(i64, i64)
+declare i8* @__rg_alloc_zeroed(i64, i64)
+declare void @__rg_dealloc(i8*, i64, i64)
+declare i8* @__rg_realloc(i8*, i64, i64, i64)
+
+define i8* @__rust_alloc(i64, i64) {
+  %3 = tail call i8* @__rg_alloc(i64 %0, i64 %1)
+  ret i8* %3
+}
+define i8* @__rust_alloc_zeroed(i64, i64) {
+  %3 = tail call i8* @__rg_alloc_zeroed(i64 %0, i64 %1)
+  ret i8* %3
+}
+define void @__rust_dealloc(i8*, i64, i64) {
+  tail call void @__rg_dealloc(i8* %0, i64 %1, i64 %2)
+  ret void
+}
+define i8* @__rust_realloc(i8*, i64, i64, i64) {
+  %5 = tail call i8* @__rg_realloc(i8* %0, i64 %1, i64 %2, i64 %3)
+  ret i8* %5
+}

--- a/rustalloc.alias
+++ b/rustalloc.alias
@@ -1,4 +1,0 @@
-___rdl_alloc ___rust_alloc 
-___rdl_alloc_zeroed ___rust_alloc_zeroed
-___rdl_dealloc ___rust_dealloc
-___rdl_realloc ___rust_realloc

--- a/rustalloc.lds
+++ b/rustalloc.lds
@@ -1,4 +1,0 @@
-PROVIDE(__rust_alloc = __rdl_alloc);
-PROVIDE(__rust_alloc_zeroed = __rdl_alloc_zeroed);
-PROVIDE(__rust_dealloc = __rdl_dealloc);
-PROVIDE(__rust_realloc = __rdl_realloc);


### PR DESCRIPTION
Fixes a bug where we were still using malloc to allocate rust objects. Also fixes an issue where code generation generated a call to 0 for the __rust_alloc function.