### PR TITLE
Fix llvm backend for when k-to-kore gets top level rewrites fixed

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -295,6 +295,12 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
                       return rewrites->getArguments()[1];
                     }
                   }
+                } else if (andPattern2->getConstructor()->getName() == "\\rewrites" && andPattern2->getArguments().size() == 2) {
+                  if (auto andPattern3 = dynamic_cast<KOREObjectCompositePattern *>(andPattern2->getArguments()[1])) {
+                    if (andPattern3->getConstructor()->getName() == "\\and" && andPattern3->getArguments().size() == 2) {
+                      return andPattern3->getArguments()[1];
+                    }
+                  }
                 }
               }
             } else if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
@@ -317,6 +323,12 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
       }
     } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
       return top->getArguments()[1];
+    } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
+          return andPattern->getArguments()[1];
+        }
+      }
     }
   }
   assert(false && "could not compute right hand side of axiom");
@@ -346,6 +358,18 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
                   return nullptr;
                 }
               }
+            } else if (trueTop->getConstructor()->getName() == "\\rewrites" && trueTop->getArguments().size() == 2) {
+              if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(trueTop->getArguments()[0])) {
+                if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
+                  if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+                    if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+                      return equals->getArguments()[0];
+                    } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+                      return nullptr;
+                    }
+                  }
+                }
+              }
             }
           }
         }
@@ -360,6 +384,18 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
       }
     } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
       return nullptr;
+    } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
+          if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+            if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+              return equals->getArguments()[0];
+            } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+              return nullptr;
+            }
+          }
+        }
+      }
     }
   }
   assert(false && "ill-formed axiom");

--- a/matching/src/Pattern/Parser.hs
+++ b/matching/src/Pattern/Parser.hs
@@ -232,6 +232,12 @@ splitTop topPattern =
     And_ _ (Top_ _)
            (And_ _ _ rw@(Rewrites_ _ _ _)) ->
       Just (extract rw, Nothing)
+    Rewrites_ s (And_ _ (Equals_ _ _ pat _) l)
+           (And_ _ _ r) ->
+      Just ((Rewrites s l r), Just pat)
+    Rewrites_ s (And_ _ (Top_ _) l)
+           (And_ _ _ r) ->
+      Just ((Rewrites s l r), Nothing)
     Implies_ _ (Bottom_ _) p -> splitTop p
     KoreObjectPattern (ImpliesPattern (Implies _ (KoreObjectPattern (BottomPattern _)) p)) -> splitTop p
     _ -> Nothing

--- a/matching/src/Pattern/Parser.hs
+++ b/matching/src/Pattern/Parser.hs
@@ -5,7 +5,7 @@
 module Pattern.Parser where
 
 import           Data.Functor.Foldable
-                 ( Fix (..), cata, para )
+                 ( Fix (..), para )
 import           Data.Functor.Impredicative
                  ( Rotate31 (..) )
 import           Data.List
@@ -31,8 +31,7 @@ import           Kore.AST.Kore
                  ( CommonKorePattern, pattern KoreObjectPattern, KorePattern,
                  UnifiedPattern (..), UnifiedSortVariable )
 import           Kore.AST.MetaOrObject
-                 ( Meta (..), MetaOrObject (..), Object (..), Unified (..),
-                 transformUnified )
+                 ( Meta (..), Object (..), Unified (..) )
 import           Kore.AST.Sentence
                  ( Attributes (..), Definition (..), KoreDefinition,
                  Module (..), ModuleName (..), Sentence (..),


### PR DESCRIPTION
We previously had the wrong form to axioms about top level rewrites. I am keeping the old syntax working for backwards compatibility, but adding the new syntax as well.

This will go with an upcoming PR of k that I will tag this PR in.