### PR TITLE
Updates to make build on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,12 @@ set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto")
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -flto")
 
-# On MacOs the compiler version is not appended
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 set(CMAKE_AR "llvm-ar")
 set(CMAKE_RANLIB "llvm-ranlib")
+
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
 set(RUST_TARGET_TRIPLE "x86_64-apple-darwin")
 else()
-set(CMAKE_AR "llvm-ar-6.0")
-set(CMAKE_RANLIB "llvm-ranlib-6.0")
 set(RUST_TARGET_TRIPLE "x86_64-unknown-linux-gnu")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,11 @@ else()
 set(RUST_TARGET_TRIPLE "x86_64-unknown-linux-gnu")
 endif()
 
-find_package(LLVM 6 REQUIRED CONFIG)
+find_package(LLVM 7 REQUIRED CONFIG)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS 6.0)
-  message(FATAL_ERROR "LLVM 6.0 or newer is required")
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS 7.0)
+  message(FATAL_ERROR "LLVM 7.0 or newer is required")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,21 +1,59 @@
-On Ubuntu 18.04:
+System Dependencies
+===================
 
-```
-sudo apt-get update
+Ubuntu 18.04
+------------
+
+```sh
 sudo apt-get install git cmake clang-6.0 clang++-6.0 llvm-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
 curl https://sh.rustup.rs -sSf | sh
 source $HOME/.cargo/env
 rustup toolchain install 1.28.0
 rustup default 1.28.0
 curl -sSL https://get.haskellstack.org/ | sh
-git clone https://github.com/kframework/llvm-backend
-cd llvm-backend
+```
+
+and setup your environment with:
+
+```sh
+export CC=clang-6.0
+export CXX=clang++-6.0
+```
+
+Arch
+----
+
+```sh
+sudo pacman -Syu
+sudo pacman -S cmake git clang llvm llvm-libs bison flex boost gmp mpfr libyaml yaml-cpp jemalloc curl zlib
+rustup install stable
+rustup default stable
+curl -sSL https://get.haskellstack.org/ | sh
+```
+
+and setup your environment with:
+
+```sh
+export CC=clang
+export CXX=clang++
+```
+
+Building
+========
+
+Make sure the environment variables `CC` and `CCX` are set as described above, then build with:
+
+```sh
 git submodule update --init
 mkdir build
 cd build
-CC=clang-6.0 CXX=clang++-6.0 cmake .. -DCMAKE_BUILD_TYPE=Release # or Debug
+cmake .. -DCMAKE_BUILD_TYPE=Release # or Debug
 make -j16
 make install
 ```
 
-Then add `llvm-backend/build/install/bin` to your $PATH.
+Finally, setup your `PATH` environment variable:
+
+```sh
+export PATH=$PATH:/path/to/llvm-backend/build/install/bin
+```


### PR DESCRIPTION
These are the changes I made to make the LLVM backend build properly on Arch linux (including updated build instructions).

Note that I don't think this can be merged as-is, because Ubuntu still needs LLVM 6.0, and this updates to LLVM 7.0. @dwightguth do you know how to set the version of LLVM based on the distro, or how to make CMakeLists.txt not care about the version?