### PR TITLE
Pattern cleanup

### DIFF
--- a/matching/package.yaml
+++ b/matching/package.yaml
@@ -38,6 +38,7 @@ default-extensions:
   - DeriveFunctor
   - FlexibleContexts
   - FlexibleInstances
+  - GADTs
   - OverloadedStrings
   - TemplateHaskell
   - TupleSections

--- a/matching/src/Pattern/Class.hs
+++ b/matching/src/Pattern/Class.hs
@@ -11,4 +11,4 @@ class IsPattern a where
   toPattern :: a -> Fix Pattern
 
 class HasMetadata a where
-  getMetadata :: Proxy a -> Metadata
+  getMetadata :: Proxy a -> Metadata BoundPattern

--- a/matching/src/Pattern/Gen.hs
+++ b/matching/src/Pattern/Gen.hs
@@ -1,47 +1,61 @@
-{-# LANGUAGE GADTs      #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs             #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Pattern.Gen where
 
-import qualified Pattern               as P
-import qualified Pattern.Type          as P
-import           Pattern.Parser        (unifiedPatternRAlgebra,SymLib(..), getTopChildren,
-                                        AxiomInfo(..))
-import           Control.Monad.Free    (Free (..))
-import           Data.Bits             (shiftL)
-import           Data.Either           (fromRight)
-import           Data.Functor.Foldable (Fix (..), para)
-import           Data.List             (transpose)
-import qualified Data.Map              as Map
-import           Data.Maybe            (maybe, isJust, fromJust)
-import           Data.Text             (unpack, Text)
-import           Data.Tuple.Select     (sel1, sel2)
-import           Kore.AST.Common       (Rewrites (..), Sort (..), SortActual(..),
-                                        Variable (..), Application (..),
-                                        DomainValue (..), StringLiteral (..),
-                                        And (..), Ceil (..), Equals (..), Exists (..),
-                                        Floor (..), Forall (..), Implies (..), Iff (..),
-                                        In (..), Next (..), Not (..), Or (..),
-                                        Pattern (..), Id (..), SymbolOrAlias (..), AstLocation(..),
-                                        BuiltinDomain (..))
-import           Kore.AST.Kore         (CommonKorePattern)
-import           Kore.AST.MetaOrObject (Object (..))
-import           Kore.AST.Sentence     (Attributes (..))
-import           Kore.ASTHelpers       (ApplicationSorts (..))
-import           Kore.Attribute.Parser (parseAttributes)
-import           Kore.Builtin.Hook     (Hook (..))
+import           Control.Monad.Free
+                 ( Free (..) )
+import           Data.Bits
+                 ( shiftL )
+import           Data.Either
+                 ( fromRight )
+import           Data.Functor.Foldable
+                 ( Fix (..), para )
+import           Data.List
+                 ( transpose )
+import qualified Data.Map as Map
+import           Data.Maybe
+                 ( fromJust, isJust, maybe )
+import           Data.Text
+                 ( Text, unpack )
+import           Data.Tuple.Select
+                 ( sel1, sel2 )
+import           Kore.AST.Common
+                 ( And (..), Application (..), AstLocation (..),
+                 BuiltinDomain (..), Ceil (..), DomainValue (..), Equals (..),
+                 Exists (..), Floor (..), Forall (..), Id (..), Iff (..),
+                 Implies (..), In (..), Next (..), Not (..), Or (..),
+                 Pattern (..), Rewrites (..), Sort (..), SortActual (..),
+                 StringLiteral (..), SymbolOrAlias (..), Variable (..) )
+import           Kore.AST.Kore
+                 ( CommonKorePattern )
+import           Kore.AST.MetaOrObject
+                 ( Object (..) )
+import           Kore.AST.Sentence
+                 ( Attributes (..) )
+import           Kore.ASTHelpers
+                 ( ApplicationSorts (..) )
+import           Kore.Attribute.Parser
+                 ( parseAttributes )
+import           Kore.Builtin.Hook
+                 ( Hook (..) )
 import           Kore.IndexedModule.IndexedModule
-                                       (KoreIndexedModule)
+                 ( KoreIndexedModule )
 import           Kore.IndexedModule.MetadataTools
-                                       (MetadataTools (..), extractMetadataTools)
+                 ( MetadataTools (..), extractMetadataTools )
 import           Kore.Step.StepperAttributes
-                                       (StepperAttributes (..))
+                 ( StepperAttributes (..) )
+import qualified Pattern as P
+import           Pattern.Parser
+                 ( AxiomInfo (..), SymLib (..), getTopChildren,
+                 unifiedPatternRAlgebra )
+import qualified Pattern.Type as P
 
 parseAtt :: Attributes -> StepperAttributes
 parseAtt = fromRight (error "invalid attr") . parseAttributes
 
 bitwidth :: MetadataTools Object Attributes -> Sort Object -> Int
-bitwidth tools sort = 
+bitwidth tools sort =
   let att = parseAtt $ sortAttributes tools sort
       hookAtt = hook att
   in case getHook hookAtt of
@@ -78,7 +92,7 @@ genPattern tools (SymLib _ sorts _) rewrite =
                                          Fix P.Pattern)
              -> Fix P.Pattern
     rAlgebra (ApplicationPattern (Application rawSym ps)) =
-      let sym = stripLoc rawSym 
+      let sym = stripLoc rawSym
           att = fmap unpack $ getHook $ hook $ parseAtt $ symAttributes tools sym
           sort = applicationSortsResult $ symbolOrAliasSorts tools sym
       in case att of
@@ -91,14 +105,15 @@ genPattern tools (SymLib _ sorts _) rewrite =
         Just "SET.concat" -> setPattern sym Concat (map snd ps) (getSym "SET.element" (sorts Map.! sort))
         Just "SET.unit" -> setPattern sym Unit [] (getSym "SET.element" (sorts Map.! sort))
         Just "SET.element" -> setPattern sym Element (map snd ps) (getSym "SET.element" (sorts Map.! sort))
-        Just _ -> Fix $ P.Pattern (P.Symbol sym) Nothing (map snd ps)
-        Nothing -> Fix $ P.Pattern (P.Symbol sym) Nothing (map snd ps)
+        Just _ -> Fix $ P.Pattern (Left (P.Symbol sym)) Nothing (map snd ps)
+        Nothing -> Fix $ P.Pattern (Left (P.Symbol sym)) Nothing (map snd ps)
     rAlgebra (DomainValuePattern (DomainValue sort (BuiltinDomainPattern (Fix (StringLiteralPattern (StringLiteral str)))))) =
       let att = fmap unpack $ getHook $ hook $ parseAtt $ sortAttributes tools sort
       in Fix $ P.Pattern (if att == Just "BOOL.Bool" then case str of
-                           "true" -> P.Literal "1"
-                           "false" -> P.Literal "0"
-                           _ -> P.Literal str else P.Literal str)
+                           "true" -> Right $ P.Literal "1"
+                           "false" -> Right $ P.Literal "0"
+                           _ -> Right $ P.Literal str
+                           else Right $ P.Literal str)
           (if att == Nothing then Just "STRING.String" else att) []
     rAlgebra (VariablePattern (Variable (Id name _) sort)) =
       let att = fmap unpack $ getHook $ hook $ parseAtt $ sortAttributes tools sort
@@ -111,19 +126,19 @@ genPattern tools (SymLib _ sorts _) rewrite =
                 -> SymbolOrAlias Object
                 -> Fix P.Pattern
     listPattern sym Concat [Fix (P.ListPattern hd Nothing tl _ o), Fix (P.ListPattern hd' frame tl' _ o')] c =
-      Fix (P.ListPattern (hd ++ tl ++ hd') frame tl' c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.ListPattern (hd ++ tl ++ hd') frame tl' c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     listPattern sym Concat [Fix (P.ListPattern hd frame tl _ o), Fix (P.ListPattern hd' Nothing tl' _ o')] c =
-      Fix (P.ListPattern hd frame (tl ++ hd' ++ tl') c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.ListPattern hd frame (tl ++ hd' ++ tl') c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     listPattern sym Concat [Fix (P.ListPattern hd Nothing tl _ o), p@(Fix (P.Variable _ _))] c =
-      Fix (P.ListPattern (hd ++ tl) (Just p) [] c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.ListPattern (hd ++ tl) (Just p) [] c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     listPattern sym Concat [Fix (P.ListPattern hd Nothing tl _ o), p@(Fix P.Wildcard)] c =
-      Fix (P.ListPattern (hd ++ tl) (Just p) [] c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.ListPattern (hd ++ tl) (Just p) [] c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     listPattern sym Concat [p@(Fix (P.Variable _ _)), Fix (P.ListPattern hd Nothing tl _ o)] c =
-      Fix (P.ListPattern [] (Just p) (hd ++ tl) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
+      Fix (P.ListPattern [] (Just p) (hd ++ tl) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
     listPattern sym Concat [p@(Fix P.Wildcard), Fix (P.ListPattern hd Nothing tl _ o)] c =
-      Fix (P.ListPattern [] (Just p) (hd ++ tl) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
-    listPattern sym Unit [] c = Fix (P.ListPattern [] Nothing [] c $ Fix $ P.Pattern (P.Symbol sym) Nothing [])
-    listPattern sym Element [p] c = Fix (P.ListPattern [p] Nothing [] c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p])
+      Fix (P.ListPattern [] (Just p) (hd ++ tl) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
+    listPattern sym Unit [] c = Fix (P.ListPattern [] Nothing [] c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [])
+    listPattern sym Element [p] c = Fix (P.ListPattern [p] Nothing [] c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p])
     listPattern _ Concat [_, Fix (P.MapPattern _ _ _ _ _)] _ = error "unsupported list pattern"
     listPattern _ Concat [Fix (P.MapPattern _ _ _ _ _), _] _ = error "unsupported list pattern"
     listPattern _ Concat [_, Fix (P.SetPattern _ _ _ _)] _ = error "unsupported list pattern"
@@ -148,19 +163,19 @@ genPattern tools (SymLib _ sorts _) rewrite =
                -> SymbolOrAlias Object
                -> Fix P.Pattern
     mapPattern sym Concat [Fix (P.MapPattern ks vs Nothing _ o), Fix (P.MapPattern ks' vs' frame _ o')] c =
-      Fix (P.MapPattern (ks ++ ks') (vs ++ vs') frame c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.MapPattern (ks ++ ks') (vs ++ vs') frame c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     mapPattern sym Concat [Fix (P.MapPattern ks vs frame _ o), Fix (P.MapPattern ks' vs' Nothing _ o')] c =
-      Fix (P.MapPattern (ks ++ ks') (vs ++ vs') frame c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.MapPattern (ks ++ ks') (vs ++ vs') frame c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     mapPattern sym Concat [Fix (P.MapPattern ks vs Nothing _ o), p@(Fix (P.Variable _ _))] c =
-      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     mapPattern sym Concat [Fix (P.MapPattern ks vs Nothing _ o), p@(Fix P.Wildcard)] c =
-      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     mapPattern sym Concat [p@(Fix (P.Variable _ _)), Fix (P.MapPattern ks vs Nothing _ o)] c =
-      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
+      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
     mapPattern sym Concat [p@(Fix P.Wildcard), Fix (P.MapPattern ks vs Nothing _ o)] c =
-      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
-    mapPattern sym Unit [] c = Fix (P.MapPattern [] [] Nothing c $ Fix $ P.Pattern (P.Symbol sym) Nothing [])
-    mapPattern sym Element [k,v] c = Fix (P.MapPattern [k] [v] Nothing c $ Fix $ P.Pattern (P.Symbol sym) Nothing [k,v])
+      Fix (P.MapPattern ks vs (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
+    mapPattern sym Unit [] c = Fix (P.MapPattern [] [] Nothing c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [])
+    mapPattern sym Element [k,v] c = Fix (P.MapPattern [k] [v] Nothing c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [k,v])
     mapPattern _ Concat [_, Fix (P.MapPattern _ _ (Just _) _ _)] _ = error "unsupported map pattern"
     mapPattern _ Concat [Fix (P.MapPattern _ _ (Just _) _ _), _] _ = error "unsupported map pattern"
     mapPattern _ Concat [_, Fix (P.ListPattern _ _ _ _ _)] _ = error "unsupported map pattern"
@@ -186,19 +201,19 @@ genPattern tools (SymLib _ sorts _) rewrite =
                -> SymbolOrAlias Object
                -> Fix P.Pattern
     setPattern sym Concat [Fix (P.SetPattern ks Nothing _ o), Fix (P.SetPattern ks' frame _ o')] c =
-      Fix (P.SetPattern (ks ++ ks') frame c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.SetPattern (ks ++ ks') frame c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     setPattern sym Concat [Fix (P.SetPattern ks frame _ o), Fix (P.SetPattern ks' Nothing _ o')] c =
-      Fix (P.SetPattern (ks ++ ks') frame c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, o'])
+      Fix (P.SetPattern (ks ++ ks') frame c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, o'])
     setPattern sym Concat [Fix (P.SetPattern ks Nothing _ o), p@(Fix (P.Variable _ _))] c =
-      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     setPattern sym Concat [Fix (P.SetPattern ks Nothing _ o), p@(Fix P.Wildcard)] c =
-      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [o, p])
+      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [o, p])
     setPattern sym Concat [p@(Fix (P.Variable _ _)), Fix (P.SetPattern ks Nothing _ o)] c =
-      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
+      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
     setPattern sym Concat [p@(Fix P.Wildcard), Fix (P.SetPattern ks Nothing _ o)] c =
-      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (P.Symbol sym) Nothing [p, o])
-    setPattern sym Unit [] c = Fix (P.SetPattern [] Nothing c $ Fix $ P.Pattern (P.Symbol sym) Nothing [])
-    setPattern sym Element [e] c = Fix (P.SetPattern [e] Nothing c $ Fix $ P.Pattern (P.Symbol sym) Nothing [e])
+      Fix (P.SetPattern ks (Just p) c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [p, o])
+    setPattern sym Unit [] c = Fix (P.SetPattern [] Nothing c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [])
+    setPattern sym Element [e] c = Fix (P.SetPattern [e] Nothing c $ Fix $ P.Pattern (Left $ P.Symbol sym) Nothing [e])
     setPattern _ Concat [_, Fix (P.SetPattern _ (Just _) _ _)] _ = error "unsupported set pattern"
     setPattern _ Concat [Fix (P.SetPattern _ (Just _) _ _), _] _ = error "unsupported set pattern"
     setPattern _ Concat [_, Fix (P.MapPattern _ _ _ _ _)] _ = error "unsupported set pattern"
@@ -217,7 +232,7 @@ genPattern tools (SymLib _ sorts _) rewrite =
     setPattern _ Unit (_:_) _ = error "unsupported set pattern"
     setPattern _ Element [] _ = error "unsupported set pattern"
     setPattern _ Element (_:_:_) _ = error "unsupported set pattern"
- 
+
     getSym :: Text -> [SymbolOrAlias Object] -> SymbolOrAlias Object
     getSym hookAtt syms = head $ filter (isHook hookAtt) syms
     isHook :: Text -> SymbolOrAlias Object -> Bool
@@ -247,25 +262,27 @@ genVars = para (unifiedPatternRAlgebra rAlgebra rAlgebra)
     rAlgebra (OrPattern (Or _ (_, p₀) (_, p₁)))           = p₀ ++ p₁
     rAlgebra _                                            = []
 
-metaLookup :: (P.Constructor -> Maybe [P.Metadata]) -> P.Constructor -> Maybe [P.Metadata]
-metaLookup f c@(P.Symbol _) = f c
-metaLookup _ (P.Literal _) = Just []
-metaLookup f (P.List c i) = Just $ replicate i $ head $ fromJust $ f $ P.Symbol c
+metaLookup :: (P.Constructor P.BoundPattern -> Maybe [P.Metadata P.BoundPattern])
+           -> P.Constructor P.BoundPattern
+           -> Maybe [P.Metadata P.BoundPattern]
+metaLookup f c@(P.SymbolConstructor (P.Symbol _)) = f c
+metaLookup _ (P.LiteralConstructor (P.Literal _)) = Just []
+metaLookup f (P.List c i) = Just $ replicate i $ head $ fromJust $ f $ P.SymbolConstructor $ P.Symbol c
 metaLookup _ P.Empty = Just []
 metaLookup _ (P.NonEmpty (P.Ignoring m)) = Just [m]
-metaLookup f (P.HasKey isSet e (P.Ignoring m) _) = 
-  let metas = fromJust $ f $ P.Symbol e
+metaLookup f (P.HasKey isSet e (P.Ignoring m) _) =
+  let metas = fromJust $ f $ P.SymbolConstructor $ P.Symbol e
   in if isSet then Just [m, m] else Just [head $ tail $ metas, m, m]
 metaLookup _ (P.HasNoKey (P.Ignoring m) _) = Just [m]
 
-defaultMetadata :: Sort Object -> P.Metadata
+defaultMetadata :: Sort Object -> P.Metadata P.BoundPattern
 defaultMetadata sort = P.Metadata 1 (const []) (const []) sort $ metaLookup $ const Nothing
 
-genMetadatas :: SymLib -> KoreIndexedModule Attributes -> Map.Map (Sort Object) P.Metadata
+genMetadatas :: SymLib -> KoreIndexedModule Attributes -> Map.Map (Sort Object) (P.Metadata P.BoundPattern)
 genMetadatas syms@(SymLib symbols sorts allOverloads) indexedMod =
   Map.mapMaybeWithKey genMetadata sorts
   where
-    genMetadata :: Sort Object -> [SymbolOrAlias Object] -> Maybe P.Metadata
+    genMetadata :: Sort Object -> [SymbolOrAlias Object] -> Maybe (P.Metadata P.BoundPattern)
     genMetadata sort@(SortActualSort _) constructors =
       let att = parseAtt $ sortAttributes (extractMetadataTools indexedMod) sort
           hookAtt = getHook $ hook att
@@ -279,12 +296,12 @@ genMetadatas syms@(SymLib symbols sorts allOverloads) indexedMod =
         in Just $ P.Metadata (shiftL 1 bw) (const []) (const []) sort (metaLookup $ const Nothing)
       else
         let metadatas = genMetadatas syms indexedMod
-            keys = map P.Symbol constructors
+            keys = map (P.SymbolConstructor . P.Symbol) constructors
             args = map getArgs constructors
             injections = filter isInjection keys
             overloads = filter isOverload keys
             usedInjs = map (\c -> filter (isSubsort metadatas c) injections) injections
-            usedOverloads = map (map P.Symbol . (allOverloads Map.!) . (\(P.Symbol s) -> s)) overloads
+            usedOverloads = map (map (P.SymbolConstructor . P.Symbol) . (allOverloads Map.!) . (\(P.SymbolConstructor (P.Symbol s)) -> s)) overloads
             children = map (map $ (\s -> Map.findWithDefault (defaultMetadata s) s metadatas)) args
             metaMap = Map.fromList (zip keys children)
             injMap = Map.fromList (zip injections usedInjs)
@@ -295,20 +312,20 @@ genMetadatas syms@(SymLib symbols sorts allOverloads) indexedMod =
     genMetadata _ _ = Nothing
     getArgs :: SymbolOrAlias Object -> [Sort Object]
     getArgs sym = sel1 $ symbols Map.! sym
-    isInjection :: P.Constructor -> Bool
-    isInjection (P.Symbol (SymbolOrAlias (Id "inj" _) _)) = True
+    isInjection :: P.Constructor P.BoundPattern -> Bool
+    isInjection (P.SymbolConstructor (P.Symbol (SymbolOrAlias (Id "inj" _) _))) = True
     isInjection _ = False
-    isOverload :: P.Constructor -> Bool
-    isOverload (P.Symbol s) = Map.member s allOverloads
+    isOverload :: P.Constructor P.BoundPattern -> Bool
+    isOverload (P.SymbolConstructor (P.Symbol s)) = Map.member s allOverloads
     isOverload _ = False
-    isSubsort :: Map.Map (Sort Object) P.Metadata -> P.Constructor -> P.Constructor -> Bool
-    isSubsort metas (P.Symbol (SymbolOrAlias name [b,_])) (P.Symbol (SymbolOrAlias _ [a,_])) =
+    isSubsort :: Map.Map (Sort Object) (P.Metadata P.BoundPattern) -> P.Constructor P.BoundPattern -> P.Constructor P.BoundPattern -> Bool
+    isSubsort metas (P.SymbolConstructor (P.Symbol (SymbolOrAlias name [b,_]))) (P.SymbolConstructor (P.Symbol (SymbolOrAlias _ [a,_]))) =
       let (P.Metadata _ _ _ _ childMeta) = Map.findWithDefault (defaultMetadata b) b metas
           child = P.Symbol (SymbolOrAlias name [a,b])
-      in isJust $ childMeta $ child
+      in isJust $ childMeta $ (P.SymbolConstructor child)
     isSubsort _ _ _ = error "invalid injection"
-    injectionForOverload :: P.Constructor -> P.Constructor -> P.Constructor
-    injectionForOverload (P.Symbol g) (P.Symbol l) = P.Symbol $ SymbolOrAlias (Id "inj" AstLocationNone) [sel2 (symbols Map.! l), sel2 (symbols Map.! g)]
+    injectionForOverload :: P.Constructor P.BoundPattern -> P.Constructor P.BoundPattern -> P.Constructor P.BoundPattern
+    injectionForOverload (P.SymbolConstructor (P.Symbol g)) (P.SymbolConstructor (P.Symbol l)) = P.SymbolConstructor $ P.Symbol $ SymbolOrAlias (Id "inj" AstLocationNone) [sel2 (symbols Map.! l), sel2 (symbols Map.! g)]
     injectionForOverload _ _ = error "invalid overload"
 
 genClauseMatrix :: KoreRewrite pat
@@ -316,7 +333,7 @@ genClauseMatrix :: KoreRewrite pat
                -> KoreIndexedModule Attributes
                -> [AxiomInfo pat]
                -> [Sort Object]
-               -> (P.ClauseMatrix, P.Fringe)
+               -> (P.ClauseMatrix P.Pattern P.BoundPattern, P.Fringe)
 genClauseMatrix symlib indexedMod axioms sorts =
   let indices = map getOrdinal axioms
       rewrites = map getRewrite axioms

--- a/matching/src/Pattern/Optimiser/Score.hs
+++ b/matching/src/Pattern/Optimiser/Score.hs
@@ -9,7 +9,7 @@ import Pattern.Type
 import Pattern.Var
 
 -- | This computes the final score for a map given the best key.
-computeElementScore :: Fix Pattern -> Clause -> [(Fix Pattern,Clause)] -> Double
+computeElementScore :: Fix Pattern -> Clause BoundPattern -> [(Fix Pattern, Clause BoundPattern)] -> Double
 computeElementScore k c tl =
   let bound = isBound getName c k
   in if bound then
@@ -26,7 +26,7 @@ computeElementScore k c tl =
   where
     mapContainsKey :: Fix BoundPattern -> Fix BoundPattern -> Bool
     mapContainsKey _ _ = False
-    canonicalizeClause :: Clause -> Clause
+    canonicalizeClause :: Clause BoundPattern -> Clause BoundPattern
     canonicalizeClause (Clause a vars ranges children) =
       let hooks = map getHook vars
           os = map getOccurrence vars

--- a/matching/src/Pattern/Set.hs
+++ b/matching/src/Pattern/Set.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ScopedTypeVariables #-}
 module Pattern.Set
   ( getSetCs ) where
 
@@ -9,17 +10,17 @@ import Pattern.Var
 
 -- | Extracts the constructors from a set pattern. It also returns
 -- a pattern for the next values in the set.
-getSetCs :: Column
-         -> Clause
+getSetCs :: Column Pattern BoundPattern
+         -> Clause BoundPattern
          -> Fix Pattern
-         -> ([Constructor], Maybe (Fix Pattern))
+         -> ([Constructor BoundPattern], Maybe (Fix Pattern))
 getSetCs c cls = go
   where
-    metadata :: Ignoring Metadata
+    metadata :: Ignoring (Metadata BoundPattern)
     metadata  = Ignoring (getMetadata c)
     value :: Fix Pattern -> Maybe (Fix BoundPattern)
     value  = lookupCanonicalName cls
-    go :: Fix Pattern -> ([Constructor], Maybe (Fix Pattern))
+    go :: Fix Pattern -> ([Constructor BoundPattern], Maybe (Fix Pattern))
     go (Fix (SetPattern [] Nothing _ _))  = ([Empty], Nothing)
     go (Fix (SetPattern [] (Just next) _ _)) = ([], Just next)
     go p@(Fix (SetPattern (k : _) _ e _)) =

--- a/matching/src/Pattern/Var.hs
+++ b/matching/src/Pattern/Var.hs
@@ -15,7 +15,7 @@ import           Data.Maybe
 import Pattern.Type
 
 -- | Checks to see if the variable name has been bound in the clause.
-lookupCanonicalName :: Clause
+lookupCanonicalName :: Clause BoundPattern
                     -> Fix Pattern
                     -> Maybe (Fix BoundPattern)
 lookupCanonicalName cls p =
@@ -25,7 +25,7 @@ lookupCanonicalName cls p =
 
 -- | Looks up all variables from the pattern in the clause and replaces
 -- them with the occurrences it finds.
-canonicalizePattern :: Clause
+canonicalizePattern :: Clause BoundPattern
                     -> Fix Pattern
                     -> Fix BoundPattern
 canonicalizePattern clause = cata go
@@ -46,7 +46,7 @@ canonicalizePattern clause = cata go
 -- | Checks if all variables in the pattern are bound.
 isBound :: forall a. Eq a
         => (VariableBinding -> a)
-        -> Clause
+        -> Clause BoundPattern
         -> Fix (P a)
         -> Bool
 isBound get (Clause _ vars _ _) = cata go


### PR DESCRIPTION
Replace patterns with type variables.
    
Even though this change seems to be quite large only two small changes have been done that ripple through all the sources.

1. Change the data types to begin abstracting away patterns.
    
We have two patterns: Pattern and BoundPattern that should be abstracted away in order to properly decouple the code. This first change removed by-name references to patterns from the data types, but still keeps them in the rest of the code.

2. Remove the Constructor reference from the Pattern constructor.
    
The Constructor data type also includes Map/Set/List constructors, and the corresponding Pattern data constructor is always instantiated with Symbols or Literals.

This change has two benefits:

a. It's more type-safe since now by construction you can only use symbols or literals with the Pattern data constructor.
b. The code is simplified since we do not need to add a variable for the BoundPattern that appears in Constructors to the Pattern data type. This would mean that we will have two fix points in the same data structure.