### PR TITLE
use docker to build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM ubuntu:bionic
 
 RUN apt-get update
 RUN apt-get install -y git cmake clang-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
+RUN curl -sSL https://get.haskellstack.org/ | sh      
+
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID user && \
+    useradd -u $USER_ID -s /bin/sh -g user user
+
+USER $USER_ID:$GROUP_ID
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH "${HOME}/.cargo/bin:${PATH}"
+ENV PATH "$HOME/.cargo/bin:$PATH"
 RUN rustup toolchain install 1.28.0
 RUN rustup default 1.28.0
-RUN curl -sSL https://get.haskellstack.org/ | sh      
-RUN mkdir -p ~/.stack
-RUN echo 'allow-different-user: true' > ~/.stack/config.yaml
- 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,4 @@ RUN groupadd -g $GROUP_ID user && \
     useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER $USER_ID:$GROUP_ID
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH "$HOME/.cargo/bin:$PATH"
-RUN rustup toolchain install 1.28.0
-RUN rustup default 1.28.0
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.28

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g $GROUP_ID user && \
-    useradd -u $USER_ID -s /bin/sh -g user user
+    useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER $USER_ID:$GROUP_ID
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:bionic
+
+RUN apt-get update
+RUN apt-get install -y git cmake clang-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH "${HOME}/.cargo/bin:${PATH}"
+RUN rustup toolchain install 1.28.0
+RUN rustup default 1.28.0
+RUN curl -sSL https://get.haskellstack.org/ | sh      
+RUN mkdir -p ~/.stack
+RUN echo 'allow-different-user: true' > ~/.stack/config.yaml
+ 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN groupadd -g $GROUP_ID user && \
     useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER $USER_ID:$GROUP_ID
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.28
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.28.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,6 @@
 pipeline {
   agent {
-    docker {
-      image 'ubuntu:bionic'
+    dockerfile {
       args '-u 0'
     }
   }
@@ -21,21 +20,6 @@ pipeline {
       steps {
         sh 'rm -rf ./*'
         checkout scm
-      }
-    }
-    stage('Install dependencies') {
-      steps {
-        sh '''
-          apt-get update
-          apt-get install -y git cmake clang-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
-          curl https://sh.rustup.rs -sSf | sh -s -- -y
-          . $HOME/.cargo/env
-          rustup toolchain install 1.28.0
-          rustup default 1.28.0
-          curl -sSL https://get.haskellstack.org/ | sh      
-          mkdir -p ~/.stack
-          echo 'allow-different-user: true' > ~/.stack/config.yaml
-        '''
       }
     }
     stage('Build and Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,8 @@
 pipeline {
   agent {
     dockerfile {
-      args '-u 0'
+      additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
     }
-  }
-  options {
-    skipDefaultCheckout true
   }
   stages {
     stage("Init title") {
@@ -14,12 +11,6 @@ pipeline {
         script {
           currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}"
         }
-      }
-    }
-    stage('Checkout code') {
-      steps {
-        sh 'rm -rf ./*'
-        checkout scm
       }
     }
     stage('Build and Test') {


### PR DESCRIPTION
Ready for review. This should speed up the build by caching as many dependencies as we can.