### PR TITLE
Fix NaN score bug

### DIFF
--- a/matching/src/Everything.hs
+++ b/matching/src/Everything.hs
@@ -516,7 +516,9 @@ expandMatrix _ _ = error "Cannot expand empty matrix."
 getScore :: [Clause BoundPattern]
          -> Column Pattern BoundPattern
          -> Double
-getScore cs (Column m ps) = computeScore m (zip ps cs)
+getScore cs c@(Column m ps) =
+  let score = computeScore m (zip ps cs)
+  in if score /= score then error ("found a NaN score: " ++ (show (cs,c))) else score
 
 -- TODO: improve
 computeScore :: Metadata BoundPattern

--- a/matching/src/Everything.hs
+++ b/matching/src/Everything.hs
@@ -524,7 +524,7 @@ getScore cs c@(Column m ps) =
 computeScore :: Metadata BoundPattern
              -> [(Fix Pattern, Clause BoundPattern)] -> Double
 computeScore _ [] = 0.0
-computeScore m ((Fix (Pattern ix@(Left (Symbol (SymbolOrAlias (Id "inj" _) _))) _ _),_):tl) = (1.0 / fromIntegral (length $ getInjections m (getPatternConstructor ix))) + computeScore m tl
+computeScore m ((Fix (Pattern ix@(Left (Symbol (SymbolOrAlias (Id "inj" _) _))) _ _),_):tl) = (1.0 / (1.0 + fromIntegral (length $ getInjections m (getPatternConstructor ix)))) + computeScore m tl
 computeScore m ((Fix (Pattern ix _ _),_):tl) = (1.0 / (1.0 + fromIntegral (length $ getOverloads m $ getPatternConstructor ix))) + computeScore m tl
 computeScore m ((Fix ListPattern{}, _) : tl) = 1.0 + computeScore m tl
 computeScore m ((Fix (As _ _ pat),c):tl) = computeScore m ((pat,c):tl)


### PR DESCRIPTION
I encountered a bug where llvm-kompile-matching was failing because the score function was choosing a column with an unbound map key. Turns out the reason for this was that we were computing the score of a map value as infinity and then multiplying that score by zero, which yielded a score of NaN for the column. I have fixed the bug and also introduced a error condition so that we will more quickly catch errors when the score is NaN.