### PR TITLE
Garbage collection for the old generation

### DIFF
--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -22,7 +22,8 @@ void* koreAllocTokenOld(size_t requested);
 // allocates exactly requested bytes into the not garbage-collected arena
 void* koreAllocNoGC(size_t requested);
 // swaps the two semispace of the young generation as part of garbage collection
-void koreAllocSwap(void);
+// if the swapOld flag is set, it also swaps the two semispaces of the old generation
+void koreAllocSwap(bool swapOld);
 // resizes the last allocation into the young generation
 void* koreResizeLastAlloc(void* oldptr, size_t newrequest, size_t oldrequest);
 

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -453,7 +453,7 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
   }
   if (sret) {
     // we don't use alloca here because the tail call optimization pass for llvm doesn't handle correctly functions with alloca
-    AllocSret = allocateTerm(returnType, CurrentBlock, "koreAllocOld");
+    AllocSret = allocateTerm(returnType, CurrentBlock, "koreAllocNoGC");
     args.insert(args.begin(), AllocSret);
     types.insert(types.begin(), AllocSret->getType());
     returnType = llvm::Type::getVoidTy(Ctx);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -343,7 +343,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     }
     case SortCategory::Float: {
       llvm::Type *Float = module->getTypeByName(FLOAT_STRUCT);
-      llvm::Value *Term = allocateTerm(Float, CaseBlock, "koreAllocOld");
+      llvm::Value *Term = allocateTerm(Float, CaseBlock, "koreAllocNoGC");
       llvm::Constant *InitFloat = module->getOrInsertFunction("init_float",
           llvm::Type::getVoidTy(Ctx), llvm::PointerType::getUnqual(Float), 
           llvm::Type::getInt8PtrTy(Ctx));
@@ -356,7 +356,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     }
     case SortCategory::Int: {
       llvm::Type *Int = module->getTypeByName(INT_STRUCT);
-      llvm::Value *Term = allocateTerm(Int, CaseBlock, "koreAllocOld");
+      llvm::Value *Term = allocateTerm(Int, CaseBlock, "koreAllocNoGC");
       llvm::Constant *MpzInitSet = module->getOrInsertFunction("__gmpz_init_set_str",
           llvm::Type::getInt32Ty(Ctx), llvm::PointerType::getUnqual(Int), 
           llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt32Ty(Ctx));

--- a/runtime/alloc/alloc.c
+++ b/runtime/alloc/alloc.c
@@ -34,8 +34,15 @@ char youngspace_collection_id() {
   return getArenaCollectionSemispaceID(&youngspace);
 }
 
-void koreAllocSwap() {
+char oldspace_collection_id() {
+  return getArenaCollectionSemispaceID(&oldspace);
+}
+
+void koreAllocSwap(bool swapOld) {
   arenaSwapAndReset(&youngspace);
+  if (swapOld) {
+    arenaSwapAndReset(&oldspace);
+  }
 }
 
 void freeAllKoreMem() {

--- a/runtime/alloc/collect.c
+++ b/runtime/alloc/collect.c
@@ -112,13 +112,13 @@ static char* evacuate(char* scan_ptr, char **alloc_ptr) {
       switch(argData->cat) {
       case MAP_LAYOUT:
         map_foreach(arg, migrate_once);
-	break;
+        break;
       case LIST_LAYOUT:
         list_foreach(arg, migrate_once); 
-	break;
+        break;
       case SET_LAYOUT:
         set_foreach(arg, migrate_once);
-	break;
+        break;
       case STRINGBUFFER_LAYOUT:
         migrate_string_buffer(arg);
         break;

--- a/runtime/alloc/collect.c
+++ b/runtime/alloc/collect.c
@@ -151,7 +151,7 @@ static char* evacuate(char* scan_ptr, char **alloc_ptr) {
 // Contains the decision logic for collecting the old generation.
 // For now, we collect the old generation every 10 young generation collections.
 static bool shouldCollectOldGen() {
-  if (++num_collection_only_young == 10) {
+  if (++num_collection_only_young == 50) {
     num_collection_only_young = 0;
     return true;
   }

--- a/runtime/alloc/collect.c
+++ b/runtime/alloc/collect.c
@@ -12,11 +12,14 @@ char **old_alloc_ptr(void);
 char* youngspace_ptr(void);
 char* oldspace_ptr(void);
 char youngspace_collection_id(void);
+char oldspace_collection_id(void);
 void map_foreach(void *, void(block**));
 void set_foreach(void *, void(block**));
 void list_foreach(void *, void(block**));
 
 static bool is_gc = false;
+static bool collect_old = false;
+static uint8_t num_collection_only_young = 0;
 
 bool during_gc() {
   return is_gc;
@@ -38,11 +41,12 @@ static void migrate(block** blockPtr) {
     return;
   }
   const uint64_t hdr = currBlock->h.hdr;
-  bool isNotOnKoreHeap = hdr & NOT_YOUNG_OBJECT_BIT;
-  if (isNotOnKoreHeap) {
+  bool isNotInYoungGen = hdr & NOT_YOUNG_OBJECT_BIT;
+  bool hasAged = hdr & YOUNG_AGE_BIT;
+  if (isNotInYoungGen && !(hasAged && collect_old)) {
     return;
   }
-  bool shouldPromote = hdr & YOUNG_AGE_BIT;
+  bool shouldPromote = !isNotInYoungGen && hasAged;
   uint64_t mask = shouldPromote ? NOT_YOUNG_OBJECT_BIT : YOUNG_AGE_BIT;
   bool hasForwardingAddress = hdr & FWD_PTR_BIT;
   uint16_t layout = layout_hdr(hdr);
@@ -50,7 +54,7 @@ static void migrate(block** blockPtr) {
   block** forwardingAddress = (block**)(currBlock + 1);
   if (!hasForwardingAddress) {
     block *newBlock;
-    if (shouldPromote) {
+    if (shouldPromote || (hasAged && collect_old)) {
       newBlock = koreAllocOld(lenInBytes);
     } else {
       newBlock = koreAlloc(lenInBytes);
@@ -69,20 +73,27 @@ static void migrate(block** blockPtr) {
 // that are not tracked by gc
 static void migrate_once(block** blockPtr) {
   block* currBlock = *blockPtr;
-  if (youngspace_collection_id() == getArenaSemispaceIDOfObject((void *)currBlock)) {
+  if (youngspace_collection_id() == getArenaSemispaceIDOfObject((void *)currBlock) ||
+      oldspace_collection_id() == getArenaSemispaceIDOfObject((void *)currBlock)) {
     migrate(blockPtr);
   }
 }
 
 static void migrate_string_buffer(stringbuffer** bufferPtr) {
   stringbuffer* buffer = *bufferPtr;
-  bool shouldPromote = buffer->contents->h.hdr & YOUNG_AGE_BIT;
+  const uint64_t hdr = buffer->contents->h.hdr;
+  bool isNotInYoungGen = hdr & NOT_YOUNG_OBJECT_BIT;
+  bool hasAged = hdr & YOUNG_AGE_BIT;
+  if (isNotInYoungGen && !(hasAged && collect_old)) {
+    return;
+  }
+  bool shouldPromote = !isNotInYoungGen && hasAged;
   uint64_t mask = shouldPromote ? NOT_YOUNG_OBJECT_BIT : YOUNG_AGE_BIT;
-  bool hasForwardingAddress = buffer->contents->h.hdr & FWD_PTR_BIT;
+  bool hasForwardingAddress = hdr & FWD_PTR_BIT;
   if (!hasForwardingAddress) {
     stringbuffer *newBuffer;
     string *newContents;
-    if (shouldPromote) {
+    if (shouldPromote || (hasAged && collect_old)) {
       newBuffer = koreAllocOld(sizeof(stringbuffer));
       newBuffer->capacity = buffer->capacity; // contents is written below
       newContents = koreAllocTokenOld(sizeof(string) + buffer->capacity);
@@ -137,37 +148,31 @@ static char* evacuate(char* scan_ptr, char **alloc_ptr) {
   return movePtr(scan_ptr, get_size(hdr, layoutInt), *alloc_ptr);
 }
 
-// computes scan ptr, current_tospace_start, and current_tospace_end for old generation
-// this is necessary because unlike the young generation, we don't start scanning at the beginning,
-// so the process of computing the address to scan from is more complicated.
-static char* computeScanPtr(char* oldspace_start) {
-  // if no allocations have happened yet, don't scan anything.
-  // if no allocations had happened at the start of gc, start scanning from
-  // the beginning. otherwise, start scanning from where we were at beginning of gc.
-  char* scan_ptr = oldspace_start == 0 ? oldspace_ptr() : oldspace_start;
-  uintptr_t oldspace_block_start = (uintptr_t)scan_ptr;
-  if (!(oldspace_block_start & (BLOCK_SIZE-1))) {
-    // this happens when oldspace_start is at the exact end of a block
-    // we need to jump to the next block, so we use movePtr with a length of 0 to do this
-    scan_ptr = movePtr(scan_ptr, 0, *old_alloc_ptr());
+// Contains the decision logic for collecting the old generation.
+// For now, we collect the old generation every 10 young generation collections.
+static bool shouldCollectOldGen() {
+  if (++num_collection_only_young == 10) {
+    num_collection_only_young = 0;
+    return true;
   }
-  return scan_ptr;
+
+  return false;
 }
 
 void koreCollect(block** root) {
   is_gc = true;
+  collect_old = shouldCollectOldGen();
   MEM_LOG("Starting garbage collection\n");
-  koreAllocSwap();
-  char* oldspace_start = *old_alloc_ptr();
+  koreAllocSwap(collect_old);
   migrate(root);
   char *scan_ptr = youngspace_ptr();
   MEM_LOG("Evacuating young generation\n");
   while(scan_ptr) {
     scan_ptr = evacuate(scan_ptr, young_alloc_ptr());
   }
-  scan_ptr = computeScanPtr(oldspace_start);
+  scan_ptr = oldspace_ptr();
   if (scan_ptr != *old_alloc_ptr()) {
-    MEM_LOG("Evacuating promoted objects\n");
+    MEM_LOG("Evacuating old generation\n");
     while(scan_ptr) {
       scan_ptr = evacuate(scan_ptr, old_alloc_ptr());
     }

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -100,6 +100,7 @@ extern "C" {
     size_t size = sizeof(string) + len(b);
     string *result = static_cast<string *>(koreAllocToken(size));
     memcpy(result, b, size);
+    reset_gc(result);
     return result;
   }
 


### PR DESCRIPTION
This PR implements a garbage collection for the old generation. It uses the same copy-collector infrastructure for the old generation. For now, the old generation is collected every 10 young generation collections. We can change this in future by adding desirable logic in the `shouldCollectOldGen` function. It is tested with the EVM vm and blockchain tests.