### PR TITLE
fix build errors on mac

### DIFF
--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -2,11 +2,13 @@
 #include <cstring>
 #include <stdexcept>
 #include <map>
+#include <fcntl.h>
+#include <libgen.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string>
+#include <cerrno>
 
-#include "fcntl.h"
-#include "libgen.h"
-#include "sys/types.h"
-#include "unistd.h"
 #include "runtime/alloc.h"
 #include "runtime/header.h"
 


### PR DESCRIPTION
It seems that there were some implicit declarations of errno and std::string that existed on linux but not mac os.