### PR TITLE
Lto rust standard library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:bionic
 
 RUN apt-get update && \
-    apt-get install -y git cmake clang-6.0 llvm-6.0-tools zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
+    apt-get install -y git cmake clang-6.0 llvm-6.0-tools lld-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl
 RUN curl -sSL https://get.haskellstack.org/ | sh      
 
 ARG USER_ID=1000

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,7 +2,7 @@ On Ubuntu 18.04:
 
 ```
 sudo apt-get update
-sudo apt-get install git cmake clang-6.0 llvm-6.0-tools zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl libtinfo-dev
+sudo apt-get install git cmake clang-6.0 llvm-6.0-tools lld-6.0 zlib1g-dev bison flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-cpp-dev libjemalloc-dev curl libtinfo-dev
 curl -sSL https://get.haskellstack.org/ | sh
 git clone https://github.com/kframework/llvm-backend
 ./llvm-backend/install-rust

--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -21,6 +21,6 @@ shift; shift; shift
 if [[ "$OSTYPE" == "darwin"* ]]; then
   flags=-Wl,-mllvm,-tailcallopt
 else
-  flags="-fuse-ld=gold -Wl,-plugin-opt=-tailcallopt"
+  flags="-fuse-ld=lld -Wl,-mllvm,-tailcallopt"
 fi
 "$(dirname "$0")"/llvm-kompile-clang "$modopt" "$main" $flags -flto "$@"

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -22,7 +22,9 @@ fi
   "$LIBDIR"/libstrings.a \
   "$LIBDIR"/libio.a \
   "$LIBDIR"/rust/libdatastructures.rlib \
-  "$LIBDIR"/rust/deps/*.rlib \
+  "$LIBDIR"/rust/deps/libim_rc-*.rlib \
+  "$LIBDIR"/rust/deps/libsized_chunks-*.rlib \
+  "$LIBDIR"/rust/deps/libtypenum-*.rlib \
   "$LIBDIR"/rust/deps/stdlib/libstd-*.rlib \
   "$LIBDIR"/rust/deps/stdlib/libcore-*.rlib \
   "$LIBDIR"/rust/deps/stdlib/liballoc-*.rlib \

--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -23,6 +23,7 @@ fi
   "$LIBDIR"/libio.a \
   "$LIBDIR"/rust/libdatastructures.rlib \
   "$LIBDIR"/rust/deps/libim_rc-*.rlib \
+  "$LIBDIR"/rust/deps/liblibc-*.rlib \
   "$LIBDIR"/rust/deps/libsized_chunks-*.rlib \
   "$LIBDIR"/rust/deps/libtypenum-*.rlib \
   "$LIBDIR"/rust/deps/stdlib/libstd-*.rlib \

--- a/bin/llvm-kompile-rust-lto
+++ b/bin/llvm-kompile-rust-lto
@@ -4,7 +4,7 @@ trap "rm -rf $dir" INT TERM EXIT
 archive=$(realpath -m $1)
 cd "$dir"
 ar x "$archive"
-rm ./*.o
+rm ./*.rcgu.o
 for file in *.bc.z; do
 len=`od -An -t u4 -j 15 -N4 $file`
 blen=`od -An -t u8 -j $((len+19)) -N8 $file`

--- a/cmake/mkrlib.cmake
+++ b/cmake/mkrlib.cmake
@@ -1,4 +1,4 @@
-file(GLOB files ${CMAKE_INSTALL_PREFIX}/lib/kllvm/rust/deps/*.rlib)
+file(GLOB files "${CMAKE_INSTALL_PREFIX}/lib/kllvm/rust/deps/*.rlib" "${CMAKE_INSTALL_PREFIX}/lib/kllvm/rust/deps/stdlib/*.rlib")
 foreach(file ${files})
   execute_process(COMMAND ${CMAKE_INSTALL_PREFIX}/bin/llvm-kompile-rust-lto ${file})
 endforeach()


### PR DESCRIPTION
We could not do this previously due to the rust version mismatch issue, but it is now possible. It seems to have uncovered a bug in gold though, so we switch to using lld as our linker.

Interestingly, it seems one rust standard library crate, libbacktrace_sys, contains non-rust object files contained inside of it. This mandated a fix to the llvm-kompile-rust-lto script.