### PR TITLE
Fixes for decision tree generation for linking semantics

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -73,8 +73,16 @@ class Column(val fringe: Fringe, val patterns: IndexedSeq[Pattern[String]], val 
 
   def isChoice: Boolean = fringe.sortInfo.isCollection && bestKey == None
 
+  private def asListP(p: Pattern[String]): Seq[ListP[String]] = {
+    p match {
+      case l@ListP(_, _, _, _, _) => Seq(l)
+      case AsP(_, _, pat) => asListP(pat)
+      case _ => Seq()
+    }
+  }
+
   def maxListSize: (Int, Int) = {
-    val listPs = patterns.filter(_.isInstanceOf[ListP[String]]).map(_.asInstanceOf[ListP[String]])
+    val listPs = patterns.flatMap(asListP(_))
     if (listPs.isEmpty) {
       (0, 0)
     } else {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -492,10 +492,10 @@ case class SymbolP[T](sym: SymbolOrAlias, ps: Seq[Pattern[T]]) extends Pattern[T
     def getVar(fringeP: Fringe, fringeT: Fringe, pat: Pattern[T], i: Int): Seq[(Constructor, VariableBinding[T])] = {
       val vars = pat.bindings(None, Inj(Num(i, o))) // compute variable bindings for this pattern
       val child = SymbolC(B.SymbolOrAlias("inj", Seq(fringeT.sort, fringeP.sort)))
-      val childOverloads = pat.overloadChildren(fringeP, Some(child), Num(i, o)) // recurse into child term
       if (fringeP.sort == fringeT.sort) {
         Seq() // exact match, so no bindings
       } else {
+        val childOverloads = pat.overloadChildren(fringeP, Some(child), Num(i, o)) // recurse into child term
         vars.map(v => (child, v)) ++ childOverloads
       }
     }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -67,7 +67,7 @@ case class AsP[T](name: T, sort: SortCategory, pat: Pattern[T]) extends Pattern[
   def canonicalize(clause: Clause): Pattern[Option[Occurrence]] = AsP(clause.canonicalize(name.toString), sort, pat.canonicalize(clause))
   def isBound(clause: Clause): Boolean = clause.isBound(name) && pat.isBound(clause)
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
-  def toShortString: String = name.toString + " #as " + pat.toShortString
+  def toShortString: String = pat.toShortString + " #as " + name.toString
 }
 
 case class ListP[T](head: Seq[Pattern[T]], frame: Option[Pattern[T]], tail: Seq[Pattern[T]], ctr: SymbolOrAlias, orig: Pattern[T]) extends Pattern[T] {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -432,7 +432,7 @@ case class SymbolP[T](sym: SymbolOrAlias, ps: Seq[Pattern[T]]) extends Pattern[T
         if (a == b) {
           Seq()
         } else {
-          ps.head.bindings(None, occurrence)
+          ps.head.bindings(Some(SymbolC(B.SymbolOrAlias("inj",Seq(a,b)))), occurrence)
         }
       case _ => Seq()
     }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -62,6 +62,7 @@ case class AsP[T](name: T, sort: SortCategory, pat: Pattern[T]) extends Pattern[
   }
   def expandOr: Seq[AsP[T]] = pat.expandOr.map(AsP(name, sort, _))
 
+  override def overloadChildren(f: Fringe, ix: Option[Constructor], o: Occurrence): Seq[(Constructor, VariableBinding[T])] = pat.overloadChildren(f, ix, o)
   def category: Option[SortCategory] = pat.category
   def variables: Set[T] = Set(name) ++ pat.variables
   def canonicalize(clause: Clause): Pattern[Option[Occurrence]] = AsP(clause.canonicalize(name.toString), sort, pat.canonicalize(clause))


### PR DESCRIPTION
With these changes and the others I have already made elsewhere, we can finally generate the decision trees for the linking semantics.

Includes:

* A Fix for maxListSize and AsP
* A bug in AsP.toShortString
* bugfix for crash in overload children
* Fix overload children through AsP.