### PR TITLE
Make move_int part of the runtime API

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -111,6 +111,7 @@ extern "C" {
   block *parseConfiguration(const char *filename);
   void printConfiguration(const char *filename, block *subject);
   void printConfigurationInternal(FILE *file, block *subject, const char *sort, bool);
+  mpz_ptr move_int(mpz_t);
 
   // The following functions have to be generated at kompile time
   // and linked with the interpreter.


### PR DESCRIPTION
This PR makes move_int part of the runtime API because it is needed by the blockchain plugin of the K evm semantics.