### PR TITLE
Refactor set/map choice

### DIFF
--- a/ciscript
+++ b/ciscript
@@ -77,4 +77,6 @@ llvm-kompile-testing ../test/test16.kore TEST main -o interpreter
 llvm-kompile-testing ../test/test17.kore TEST main -o interpreter
 llvm-kompile-testing ../test/test18.kore TEST main -o interpreter
 ./interpreter ../test/test18.in.kore -1 /dev/stdout | diff - ../test/test18.out.kore
+llvm-kompile-testing ../test/test19.kore TEST main -o interpreter
+./interpreter ../test/test19.in.kore -1 /dev/stdout | diff - ../test/test19.out.kore
 rm -f configparser configparser.ll interpreter

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -16,7 +16,7 @@ class DecisionCase;
 class DecisionNode {
 public:
   llvm::BasicBlock * cachedCode = nullptr;
-  llvm::StringMap<llvm::PHINode *> phis;
+  llvm::StringMap<std::map<llvm::Type *, llvm::PHINode *>> phis;
   std::vector<llvm::BasicBlock *> predecessors;
   /* completed tracks whether codegen for this DecisionNode has concluded */
   bool completed = false;

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -4,6 +4,7 @@
 #include "kllvm/ast/AST.h"
 
 #include "llvm/ADT/StringMap.h"
+#include "llvm/IR/Instructions.h" 
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Value.h"
 
@@ -16,6 +17,7 @@ class DecisionNode {
 public:
   llvm::BasicBlock * cachedCode = nullptr;
   llvm::StringMap<llvm::PHINode *> phis;
+  std::vector<llvm::BasicBlock *> predecessors;
   /* completed tracks whether codegen for this DecisionNode has concluded */
   bool completed = false;
 
@@ -358,8 +360,9 @@ class Decision {
 private:
   KOREDefinition *Definition;
   llvm::BasicBlock *CurrentBlock;
-  llvm::BasicBlock *StuckBlock;
   llvm::BasicBlock *FailureBlock;
+  llvm::IndirectBrInst *FailJump;
+  llvm::AllocaInst *FailAddress;
   llvm::BasicBlock *ChoiceBlock;
   DecisionNode *ChoiceNode;
   std::set<std::string> ChoiceVars;
@@ -367,18 +370,24 @@ private:
   llvm::LLVMContext &Ctx;
   ValueType Cat;
 
+  llvm::StringMap<std::map<llvm::Type *, llvm::PHINode *>> failPhis;
+
   llvm::Value *getTag(llvm::Value *);
+  void addFailPhiIncoming(llvm::StringMap<llvm::Value *> oldSubst, llvm::BasicBlock *switchBlock);
 public:
   Decision(
     KOREDefinition *Definition,
     llvm::BasicBlock *EntryBlock,
-    llvm::BasicBlock *StuckBlock,
+    llvm::BasicBlock *FailureBlock,
+    llvm::IndirectBrInst *FailJump,
+    llvm::AllocaInst *FailAddress,
     llvm::Module *Module,
     ValueType Cat) :
       Definition(Definition),
       CurrentBlock(EntryBlock),
-      StuckBlock(StuckBlock),
-      FailureBlock(StuckBlock),
+      FailureBlock(FailureBlock),
+      FailJump(FailJump),
+      FailAddress(FailAddress),
       ChoiceBlock(nullptr),
       ChoiceNode(nullptr),
       ChoiceVars(),

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -1,6 +1,7 @@
 #include "kllvm/codegen/Decision.h"
 #include "kllvm/codegen/CreateTerm.h"
 
+#include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h" 
 #include "llvm/Support/raw_ostream.h"
@@ -18,6 +19,20 @@ void Decision::operator()(DecisionNode *entry, llvm::StringMap<llvm::Value *> su
     llvm::BranchInst::Create(this->FailureBlock, this->CurrentBlock);
   } else {
     entry->codegen(this, substitution);
+  }
+  for (auto &entry : failPhis) {
+    for (auto &entry2 : entry.second) {
+      llvm::PHINode *Phi = entry2.second;
+      std::vector<llvm::BasicBlock *> undefBlocks;
+      for (llvm::BasicBlock *block : llvm::predecessors(Phi->getParent())) {
+        if (Phi->getBasicBlockIndex(block) == -1) {
+          undefBlocks.push_back(block);
+	}
+      }
+      for (llvm::BasicBlock *block : undefBlocks) {
+        Phi->addIncoming(llvm::UndefValue::get(Phi->getType()), block);
+      }
+    }
   }
 }
 
@@ -44,12 +59,14 @@ void DecisionNode::sharedNode(Decision *d, llvm::StringMap<llvm::Value *> &oldSu
   for (std::string var : vars) {
     auto Phi = phis.lookup(var);
     if (!Phi) {
-      for (std::string v : collectVars()) {
-        std::cerr << v << std::endl;
+      Phi = llvm::PHINode::Create(oldSubst[var]->getType(), 1, "phi" + var, Block->getFirstNonPHI());
+      for (llvm::BasicBlock *pred : predecessors) {
+        Phi->addIncoming(llvm::UndefValue::get(Phi->getType()), pred);
       }
-      abort();
+      phis[var] = Phi;
     }
     Phi->addIncoming(oldSubst[var], Block);
+    predecessors.push_back(Block);
     substitution[var] = phis.lookup(var);
   }
 }
@@ -82,6 +99,7 @@ bool DecisionNode::beginNode(Decision *d, std::string name, llvm::StringMap<llvm
     }
     auto Phi = llvm::PHINode::Create(substitution[var]->getType(), 1, "phi" + var, Block);
     Phi->addIncoming(substitution[var], d->CurrentBlock);
+    predecessors.push_back(d->CurrentBlock);
     phis[var] = Phi;
     substitution[var] = Phi;
   }
@@ -89,16 +107,20 @@ bool DecisionNode::beginNode(Decision *d, std::string name, llvm::StringMap<llvm
   return false;
 }
 
+void Decision::addFailPhiIncoming(llvm::StringMap<llvm::Value *> oldSubst, llvm::BasicBlock *switchBlock) {
+  if (ChoiceNode != nullptr) {
+    for (std::string var : ChoiceVars) {
+      failPhis[var][oldSubst[var]->getType()]->addIncoming(oldSubst[var], switchBlock);
+    }
+  }
+}
+
 void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitution) {
   if (beginNode(d, "switch" + name, substitution)) {
     return;
   }
-  llvm::BasicBlock *CurrentFailureBlock = d->FailureBlock;
-  if (d->ChoiceBlock) {
-    d->FailureBlock = d->ChoiceBlock;
-  }
   llvm::Value *val = substitution.lookup(name);
-  llvm::BasicBlock *_default = CurrentFailureBlock;
+  llvm::BasicBlock *_default = d->FailureBlock;
   const DecisionCase *defaultCase = nullptr;
   std::vector<std::pair<llvm::BasicBlock *, const DecisionCase *>> caseData;
   int idx = 0;
@@ -107,7 +129,7 @@ void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitutio
     auto child = _case.getChild();
     llvm::BasicBlock *CaseBlock;
     if (child == FailNode::get()) {
-      CaseBlock = CurrentFailureBlock;
+      CaseBlock = d->FailureBlock;
     } else {
       CaseBlock = llvm::BasicBlock::Create(d->Ctx, 
           name + "_case_" + std::to_string(idx++),
@@ -126,6 +148,11 @@ void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitutio
     auto cmp = new llvm::ICmpInst(*d->CurrentBlock, llvm::CmpInst::ICMP_NE, cast, llvm::ConstantExpr::getPtrToInt(llvm::ConstantPointerNull::get(llvm::dyn_cast<llvm::PointerType>(val->getType())), llvm::Type::getInt64Ty(d->Ctx)));
     val = cmp;
     isInt = true;
+  }
+  if (d->ChoiceBlock) {
+    new llvm::StoreInst(llvm::BlockAddress::get(d->CurrentBlock->getParent(), d->ChoiceBlock), d->FailAddress, d->CurrentBlock);
+    d->FailJump->addDestination(d->ChoiceBlock);
+    d->ChoiceBlock = nullptr;
   }
   if (isInt) {
     auto _switch = llvm::SwitchInst::Create(val, _default, cases.size(), d->CurrentBlock);
@@ -147,10 +174,8 @@ void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitutio
   auto oldSubst = substitution;
   for (auto &entry : caseData) {
     auto &_case = *entry.second;
-    if (entry.first == CurrentFailureBlock) {
-      if (CurrentFailureBlock == d->ChoiceBlock) {
-        d->ChoiceNode->sharedNode(d, oldSubst, substitution, switchBlock);
-      }
+    if (entry.first == d->FailureBlock) {
+      d->addFailPhiIncoming(oldSubst, switchBlock);
       continue;
     }
     d->CurrentBlock = entry.first;
@@ -162,7 +187,7 @@ void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitutio
       llvm::Value *Renamed;
       for (std::string binding : _case.getBindings()) {
         llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Cast, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(d->Ctx), offset+2)}, "", d->CurrentBlock);
-	llvm::Value *Child;
+        llvm::Value *Child;
         switch (dynamic_cast<KOREObjectCompositeSort *>(_case.getConstructor()->getArguments()[offset])->getCategory(d->Definition).cat) {
         case SortCategory::Map:
         case SortCategory::List:
@@ -177,32 +202,33 @@ void SwitchNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitutio
         if (symbolDecl->getAttributes().count("binder")) {
           if (offset == 0) {
             Renamed = llvm::CallInst::Create(d->Module->getOrInsertFunction("alphaRename", BlockPtr, BlockPtr), Child, "renamedVar", d->CurrentBlock);
-	    substitution[binding] = Renamed;
+            substitution[binding] = Renamed;
           } else if (offset == _case.getBindings().size() - 1) {
             llvm::Value *Replaced = llvm::CallInst::Create(d->Module->getOrInsertFunction("replaceBinderIndex", BlockPtr, BlockPtr, BlockPtr), {Child, Renamed}, "withUnboundIndex", d->CurrentBlock);
-	    substitution[binding] = Replaced;
+            substitution[binding] = Replaced;
           } else {
             substitution[binding] = Child;
           }
         } else {
           substitution[binding] = Child;
         }
-	offset++;
+        offset++;
       }
     }
     _case.getChild()->codegen(d, substitution);
   }
   if (defaultCase) {
-    if (_default != CurrentFailureBlock) {
+    if (_default != d->FailureBlock) {
       // process default also
       d->CurrentBlock = _default;
       defaultCase->getChild()->codegen(d, substitution);
-    } else if (CurrentFailureBlock == d->ChoiceBlock) {
-      d->ChoiceNode->sharedNode(d, oldSubst, substitution, switchBlock);
+    } else {
+      d->addFailPhiIncoming(oldSubst, switchBlock);
     }
-  } else if (CurrentFailureBlock == d->ChoiceBlock) {
-    d->ChoiceNode->sharedNode(d, oldSubst, substitution, switchBlock);
+  } else {
+    d->addFailPhiIncoming(oldSubst, switchBlock);
   }
+
   setCompleted();
 }
 
@@ -280,6 +306,25 @@ void IterNextNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitut
   d->ChoiceNode = this;
   llvm::Value *arg = substitution.lookup(iterator);
 
+  collectFail();
+  if (containsFailNode) {
+    for (std::string var : d->ChoiceVars) {
+      auto Phi = phis.lookup(var);
+      if (!Phi) {
+        for (std::string v : collectVars()) {
+          std::cerr << v << std::endl;
+        }
+        abort();
+      }
+      auto failPhi = d->failPhis[var][Phi->getType()];
+      if (!failPhi) {
+        failPhi = llvm::PHINode::Create(Phi->getType(), 0, "phi" + var, d->FailureBlock->getFirstNonPHI());
+        d->failPhis[var][Phi->getType()] = failPhi;
+      }
+      Phi->addIncoming(failPhi, d->FailureBlock);
+    }
+  }
+
   llvm::FunctionType *funcType = llvm::FunctionType::get(getValueType({SortCategory::Symbol, 0}, d->Module), {arg->getType()}, false);
   llvm::Constant *constant = d->Module->getOrInsertFunction(hookName, funcType);
   llvm::Function *func = llvm::dyn_cast<llvm::Function>(constant);
@@ -291,7 +336,7 @@ void IterNextNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> substitut
   substitution[binding] = Call;
   child->codegen(d, substitution);
   d->ChoiceBlock = nullptr;
-  d->FailureBlock = d->StuckBlock;
+  d->ChoiceNode = nullptr;
   d->ChoiceVars.clear();
   setCompleted();
 }
@@ -351,10 +396,17 @@ void makeEvalOrAnywhereFunction(KOREObjectSymbol *function, KOREDefinition *defi
     val->setName("_" + std::to_string(i+1));
     subst.insert({val->getName(), val});
   }
+  llvm::AllocaInst *addr = new llvm::AllocaInst(llvm::Type::getInt8PtrTy(module->getContext()), 0, "jumpTo", block);
   llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  new llvm::StoreInst(llvm::BlockAddress::get(matchFunc, stuck), addr, block);
   addStuck(stuck, module, function, subst, definition);
 
-  Decision codegen(definition, block, stuck, module, returnSort);
+  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::LoadInst *load = new llvm::LoadInst(addr, "", fail);
+  llvm::IndirectBrInst *jump = llvm::IndirectBrInst::Create(load, 1, fail);
+  jump->addDestination(stuck);
+
+  Decision codegen(definition, block, fail, jump, addr, module, returnSort);
   codegen(dt, subst);
 }
 
@@ -397,10 +449,17 @@ void makeStepFunction(KOREDefinition *definition, llvm::Module *module, Decision
   val->setName("_1");
   subst.insert({val->getName(), val});
   llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
+  llvm::AllocaInst *addr = new llvm::AllocaInst(llvm::Type::getInt8PtrTy(module->getContext()), 0, "jumpTo", block);
   llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  new llvm::StoreInst(llvm::BlockAddress::get(matchFunc, stuck), addr, block);
   llvm::ReturnInst::Create(module->getContext(), llvm::ConstantPointerNull::get(llvm::dyn_cast<llvm::PointerType>(blockType)), stuck);
 
-  Decision codegen(definition, block, stuck, module, {SortCategory::Symbol, 0});
+  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::LoadInst *load = new llvm::LoadInst(addr, "", fail);
+  llvm::IndirectBrInst *jump = llvm::IndirectBrInst::Create(load, 1, fail);
+  jump->addDestination(stuck);
+
+  Decision codegen(definition, block, fail, jump, addr, module, {SortCategory::Symbol, 0});
   codegen(dt, subst);
 }
 

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
@@ -14,7 +14,7 @@ object Matching {
     val axioms = Parser.parseTopAxioms(allAxioms)
     val symlib = Parser.parseSymbols(defn)
     val dt = if (axioms.isEmpty) {
-      Failure(0)
+      Failure()
     } else {
       Generator.mkDecisionTree(symlib, defn, axioms, Seq(axioms.head.rewrite.sort))
     }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
@@ -19,7 +19,7 @@ sealed trait DecisionTree {
   def representation: AnyRef
 }
 
-case class Failure private(private val failureId: Int) extends DecisionTree {
+case class Failure private() extends DecisionTree {
   val representation = "fail"
   override lazy val hashCode: Int = super.hashCode
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
@@ -162,10 +162,8 @@ case class IterNext private(hookName: String, iterator: Occurrence, binding: Occ
 }
 
 object Failure {
-  private val cache = new ConcurrentHashMap[Int, Failure]()
-  def apply(failureId: Int): Failure = {
-    cache.computeIfAbsent(failureId, k => new Failure(k))
-  }
+  private val instance = new Failure()
+  def apply(): Failure = Failure.instance
 }
 
 object Leaf {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
@@ -53,7 +53,7 @@ abstract class EqualLiteral() extends SortCategory {
       Switch(litO, Seq(), Some(matrix.default.get.compile))
     } else if (ls.isEmpty) {
       // if no specializations remain and no default exists, fail the match
-      Failure(matrix.failureId)
+      Failure()
     } else {
       // consume each specialization one at a time and try to match it
       // if it succeseds, consume the occurrence and continue with the specialized matrix

--- a/runtime/equality.ll
+++ b/runtime/equality.ll
@@ -145,4 +145,10 @@ define i1 @hook_KEQUAL_ne(%block* %arg1, %block* %arg2) {
   ret i1 %ne
 }
 
+define i1 @hook_BOOL_eq(i1 %arg1, i1 %arg2) #1 {
+  %eq = icmp eq i1 %arg1, %arg2
+  ret i1 %eq
+}
+
 attributes #0 = { noreturn }
+attributes #1 = { alwaysinline }

--- a/test/test19.in.kore
+++ b/test/test19.in.kore
@@ -1,0 +1,4 @@
+[initial-configuration{}(LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortExp{}, SortKItem{}}(Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(\dv{SortId{}}("x"),\dv{SortInt{}}("0"),Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("0")),Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")),inj{SortInt{}, SortExp{}}(\dv{SortInt{}}("1")))))))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$STDIN")),inj{SortString{}, SortKItem{}}(\dv{SortString{}}("")))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$IO")),inj{SortString{}, SortKItem{}}(\dv{SortString{}}("on"))))))]
+
+module TMP
+endmodule []

--- a/test/test19.kore
+++ b/test/test19.kore
@@ -1,0 +1,2214 @@
+[topCellInitializer{}(LblinitGeneratedTopCell{}())]
+
+module BASIC-K
+  sort SortK{} []
+  sort SortKItem{} []
+endmodule []
+
+module KSEQ
+  import BASIC-K []
+
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+  symbol dotk{}() : SortK{} []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(dotk{}(),K2:SortK{}),
+      K2:SortK{})
+  []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
+      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
+  []
+
+endmodule []
+
+module INJ
+  symbol inj{From,To}(From) : To [sortInjection{}()]
+ 
+  axiom{S1,S2,S3,R} 
+    \equals{S3,R}(
+      inj{S2,S3}(inj{S1,S2}(T:S1)),
+      inj{S1,S3}(T:S1))
+  []
+
+endmodule []
+
+module K
+  import KSEQ []
+  import INJ []
+
+  // Defnitions for reachability aliases
+  // Until we will have `mu` we resort to dummy definitions
+  alias weakExistsFinally{A}(A) : A
+  where weakExistsFinally{A}(X:A) := X:A []
+
+  alias weakAlwaysFinally{A}(A) : A
+  where weakAlwaysFinally{A}(X:A) := X:A []
+
+  // Definitions for CTL aliases
+  // Until we will have `mu` we resort to dummy definitions
+  alias allPathGlobally{A}(A) : A
+  where allPathGlobally{A}(X:A) := X:A []
+
+endmodule []
+
+module TEST
+
+// imports
+  import K []
+
+// sorts
+  sort SortGeneratedTopCell{} []
+  sort SortKCell{} []
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,3,232,31)")]
+  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(363,3,363,28)"), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)")]
+  sort SortKCellOpt{} []
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(188,3,188,28)")]
+  sort SortStateCell{} []
+  hooked-sort SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,3,306,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("BOOL.Bool")]
+  sort SortKResult{} []
+  sort SortExp{} []
+  sort SortStateCellOpt{} []
+  sort Sort'Hash'KVariable{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(68,3,68,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/kast.k)")]
+  hooked-sort SortFloat{} [hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(462,3,462,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)")]
+  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/kast.k)"), token{}()]
+  sort SortCell{} []
+  sort SortId{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(779,3,779,19)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)")]
+  hooked-sort SortString{} [hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(543,3,543,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)")]
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(96,3,96,28)")]
+  sort SortGeneratedTopCellFragment{} []
+  sort SortGeneratedCounterCell{} []
+
+// symbols
+  hooked-symbol Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("="), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(413,19,413,169)"), productionID{}("987249254"), originalPrd{}(), function{}()]
+  symbol Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(SortId{}, SortInt{}, SortExp{}) : SortExp{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,16,8,39)"), productionID{}("1465346452"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,18,393,131)"), productionID{}("1896232624"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("or"), boolOperation{}(), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(318,19,318,158)"), productionID{}("1208825205"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_abs"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(403,18,403,102)"), productionID{}("2077742806"), originalPrd{}(), function{}()]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,19,283,77)"), productionID{}("1304589447"), originalPrd{}(), function{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortKCell{}, SortGeneratedCounterCell{}, SortStateCell{}) : SortGeneratedTopCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), cellName{}("generatedTop"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("6"), contentStartColumn{}("15"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,15,6,52)"), format{}("%1%i%n%2%n%4%d%n%5"), cell{}(), originalPrd{}(), topcell{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Int"), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(570,21,570,91)"), productionID{}("1640296160"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,19,146,76)"), productionID{}("554348863"), originalPrd{}(), function{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,20,275,98)"), productionID{}("1902671237"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("<="), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(409,19,409,151)"), productionID{}("1864387098"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(587,19,587,82)"), productionID{}("633240419"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,121)"), productionID{}("125994398"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("^"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(377,18,377,153)"), productionID{}("2106592975"), originalPrd{}(), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(155,20,155,100)"), productionID{}("1863702030"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'StateCell{}(SortK{}) : SortStateCell{} [function{}(), projection{}(), originalPrd{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), predicate{}("String"), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("distinct"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(414,19,414,162)"), productionID{}("1020154737"), originalPrd{}(), function{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}()]
+  symbol Lblproject'Coln'StateCellOpt{}(SortK{}) : SortStateCellOpt{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(117,20,117,112)"), productionID{}("1795816257"), originalPrd{}(), function{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}()]
+  symbol LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(SortInt{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), freshGenerator{}(), klabel{}("freshId"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(783,17,783,70)"), productionID{}("271800170"), originalPrd{}(), function{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [function{}(), projection{}(), originalPrd{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCellFragment"), originalPrd{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(407,18,407,118)"), productionID{}("713312506"), originalPrd{}(), function{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCell"), originalPrd{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCell"), originalPrd{}()]
+  symbol Lblproject'Coln'GeneratedTopCell{}(SortK{}) : SortGeneratedTopCell{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(201,18,201,112)"), productionID{}("1396721535"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(106,18,106,128)"), productionID{}("1263668904"), originalPrd{}(), function{}()]
+  symbol Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(SortExp{}, SortExp{}) : SortExp{} [functional{}(), constructor{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,16,9,35)"), productionID{}("1634387050"), originalPrd{}()]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(".Set"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("SetItem"), symbol'Kywd'{}(), idem{}(), comm{}(), assoc{}(), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(194,18,194,176)"), format{}("%1%n%2"), productionID{}("1326393666"), originalPrd{}(), function{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), cellName{}("k"), maincell{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("6"), contentStartColumn{}("15"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,15,6,52)"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(289,19,289,101)"), productionID{}("2113748097"), originalPrd{}(), function{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("categoryChar"), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(590,21,590,80)"), productionID{}("1171802656"), originalPrd{}(), function{}()]
+  symbol Lbl'-LT-'state'-GT-'{}(SortMap{}) : SortStateCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), cellName{}("state"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("6"), contentStartColumn{}("15"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(6,15,6,52)"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}()]
+  symbol Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(585,19,585,82)"), productionID{}("810267739"), originalPrd{}(), function{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Base2String"), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(572,21,572,92)"), productionID{}("272678513"), originalPrd{}(), function{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(404,18,404,74)"), productionID{}("1139814130"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(586,19,586,82)"), productionID{}("1916575798"), originalPrd{}(), function{}()]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [function{}(), predicate{}("KResult"), originalPrd{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCellOpt"), originalPrd{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lblproject'Coln'Exp{}(SortK{}) : SortExp{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(457,18,457,56)"), productionID{}("1272883899"), originalPrd{}(), function{}()]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("substrString"), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(561,21,561,99)"), productionID{}("429075478"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'KResult{}(SortK{}) : SortKResult{} [function{}(), projection{}(), originalPrd{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smtlib{}("smt_seq_nil"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(267,19,267,146)"), productionID{}("1551629761"), originalPrd{}(), function{}()]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,18,134,91)"), productionID{}("884860061"), originalPrd{}(), function{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("directionalityChar"), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(591,21,591,86)"), productionID{}("1391624125"), originalPrd{}(), function{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(219,20,219,94)"), productionID{}("352367347"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,18,392,131)"), productionID{}("1823541245"), originalPrd{}(), function{}()]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'UndsUnds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,66)"), productionID{}("462526099"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(588,19,588,82)"), productionID{}("685558284"), originalPrd{}(), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("smt_seq_len"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,18,292,121)"), productionID{}("629454893"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Cell{}(SortK{}) : SortCell{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Int2String"), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(571,21,571,103)"), productionID{}("1863374262"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("<"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(410,19,410,147)"), productionID{}("770010802"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(397,18,397,146)"), productionID{}("716487794"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(SortBool{}, SortS0, SortS0) : SortS0 [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), smt-hook{}("ite"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(826,16,826,124)"), productionID{}("771418758"), poly{}("0, 2, 3"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'UndsUnds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,93)"), productionID{}("403174823"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("mod"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(387,18,387,95)"), productionID{}("2052910813"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), symbol'Kywd'{}(), smt-hook{}("and"), boolOperation{}(), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,19,315,189)"), productionID{}("1222768327"), originalPrd{}(), function{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_min"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(401,18,401,102)"), productionID{}("246273275"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(".Map"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("_|->_"), symbol'Kywd'{}(), comm{}(), assoc{}(), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(104,18,104,172)"), format{}("%1%n%2"), productionID{}("1515877023"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smt-hook{}("="), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(805,19,805,156)"), productionID{}("1267556427"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,93)"), productionID{}("1572256205"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(111,18,111,144)"), productionID{}("370475881"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("div"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(386,18,386,95)"), productionID{}("93740343"), originalPrd{}(), function{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(578,21,578,124)"), productionID{}("1062186835"), originalPrd{}(), function{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("lengthString"), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(557,18,557,84)"), productionID{}("1835073088"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("-"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(390,18,390,154)"), productionID{}("1534694976"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), symbol'Kywd'{}(), smt-hook{}("+"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(389,18,389,178)"), productionID{}("1107412069"), originalPrd{}(), function{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(458,16,458,56)"), productionID{}("1816725203"), originalPrd{}(), function{}()]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smtlib{}("smt_seq_elem"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(270,19,270,136)"), productionID{}("1383519982"), originalPrd{}(), function{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(207,18,207,146)"), productionID{}("1899600175"), originalPrd{}(), function{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(406,18,406,108)"), productionID{}("597307515"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'GeneratedTopCellFragment{}(SortK{}) : SortGeneratedTopCellFragment{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("rfindChar"), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(565,18,565,90)"), productionID{}("808228639"), originalPrd{}(), function{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(454,18,454,72)"), productionID{}("1515833950"), originalPrd{}(), function{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,19,281,78)"), productionID{}("2142565033"), originalPrd{}(), function{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(SortId{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Id2String"), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(781,21,781,89)"), productionID{}("2083999882"), originalPrd{}(), function{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(577,21,577,107)"), productionID{}("711540569"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(555,19,555,88)"), productionID{}("1138697171"), originalPrd{}(), function{}()]
+  symbol LblisStateCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCell"), originalPrd{}()]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("rfindString"), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(563,18,563,86)"), productionID{}("1363560175"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("mod"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(384,18,384,146)"), productionID{}("1732238286"), originalPrd{}(), function{}()]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("findString"), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(562,18,562,85)"), productionID{}("1944798106"), originalPrd{}(), function{}()]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(SortString{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Id"), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(782,17,782,84)"), productionID{}("611520720"), originalPrd{}(), function{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smt-hook{}("not"), boolOperation{}(), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(314,19,314,176)"), productionID{}("1193471756"), originalPrd{}(), function{}()]
+  symbol Lbl'UndsColnEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), equalEqualK{}(), klabel{}("_:=K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(818,19,818,96)"), productionID{}("1758056825"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("xor"), boolOperation{}(), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(317,19,317,116)"), productionID{}("403170294"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("or"), boolOperation{}(), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(319,19,319,118)"), productionID{}("253601149"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(399,18,399,140)"), productionID{}("1314838582"), originalPrd{}(), function{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("FloatFormat"), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(568,21,568,113)"), productionID{}("2061543916"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), prefer{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(122,18,122,104)"), productionID{}("959629210"), originalPrd{}(), function{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Base"), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(573,21,573,92)"), productionID{}("88646218"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(119,20,119,138)"), productionID{}("1649320501"), originalPrd{}(), function{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_max"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,18,402,102)"), productionID{}("1947185929"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(".List"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("ListItem"), symbol'Kywd'{}(), assoc{}(), smtlib{}("smt_seq_concat"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(265,19,265,192)"), format{}("%1%n%2"), productionID{}("1552326679"), originalPrd{}(), function{}()]
+  symbol LblisStateCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("StateCellOpt"), originalPrd{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), constructor{}(), cellName{}("generatedCounter"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}(), topcell{}()]
+  hooked-symbol Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(375,18,375,133)"), productionID{}("1551945522"), originalPrd{}(), function{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("div"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,18,383,148)"), productionID{}("438589491"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("*"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(380,18,380,157)"), productionID{}("1074263646"), originalPrd{}(), function{}()]
+  symbol LblinitStateCell{}() : SortStateCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("="), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(322,19,322,98)"), productionID{}("648786246"), originalPrd{}(), function{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(141,19,141,79)"), productionID{}("116669570"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(213,19,213,85)"), productionID{}("947553027"), originalPrd{}(), function{}()]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(576,21,576,122)"), productionID{}("1128132589"), originalPrd{}(), function{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,18,204,88)"), productionID{}("1204481453"), originalPrd{}(), function{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,86)"), productionID{}("136393487"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(553,21,553,139)"), productionID{}("899543194"), originalPrd{}(), function{}()]
+  symbol Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(SortK{}) : SortKItem{} [originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}()]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,19,286,98)"), productionID{}("1783568981"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("(mod (^ #1 #2) #3)"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(378,18,378,112)"), productionID{}("1862383967"), originalPrd{}(), function{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortKCellOpt{}, SortStateCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Float"), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(569,21,569,93)"), productionID{}("897848096"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("and"), boolOperation{}(), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(316,19,316,120)"), productionID{}("1439394198"), originalPrd{}(), function{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(210,19,210,106)"), productionID{}("1766869737"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,18,395,142)"), productionID{}("1038677529"), originalPrd{}(), function{}()]
+  hooked-symbol LblnewUUID'Unds'STRING'Unds'{}() : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), impure{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(593,21,593,67)"), productionID{}("79782883"), originalPrd{}(), function{}()]
+  symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}()]
+  symbol Lbl'UndsColnSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), notEqualEqualK{}(), klabel{}("_:/=K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(819,19,819,100)"), productionID{}("223693919"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(152,19,152,91)"), productionID{}("126189538"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,18,129,120)"), productionID{}("603305436"), originalPrd{}(), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(149,18,149,103)"), productionID{}("548554586"), originalPrd{}(), function{}()]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("chrChar"), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(558,21,558,69)"), productionID{}("2032891036"), originalPrd{}(), function{}()]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,18,137,91)"), productionID{}("454884231"), originalPrd{}(), function{}()]
+  symbol Lblis'Hash'KVariable{}(SortK{}) : SortBool{} [function{}(), predicate{}("#KVariable"), originalPrd{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(581,19,581,94)"), productionID{}("1396431506"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("distinct"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(323,19,323,105)"), productionID{}("120360571"), originalPrd{}(), function{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(415,19,415,52)"), productionID{}("398457879"), originalPrd{}(), function{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(SortFloat{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Float2String"), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(567,21,567,105)"), productionID{}("426960147"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Id{}(SortK{}) : SortId{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(216,18,216,80)"), productionID{}("684566052"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}(">="), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(411,19,411,151)"), productionID{}("1603177117"), originalPrd{}(), function{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}()]
+  symbol LblisExp{}(SortK{}) : SortBool{} [function{}(), predicate{}("Exp"), originalPrd{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), notEqualEqualK{}(), smt-hook{}("distinct"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(806,19,806,170)"), productionID{}("1585239756"), originalPrd{}(), function{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), predicate{}("Float"), originalPrd{}()]
+  symbol Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(SortExp{}, SortExp{}) : SortExp{} [functional{}(), constructor{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,39,9,58)"), productionID{}("1740223770"), originalPrd{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(196,18,196,122)"), productionID{}("643290333"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("=>"), boolOperation{}(), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,19,320,119)"), productionID{}("26540753"), originalPrd{}(), function{}()]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("findChar"), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(564,18,564,89)"), productionID{}("811597470"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [function{}(), projection{}(), originalPrd{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [function{}(), originalPrd{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [function{}(), predicate{}("Id"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}(">"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(412,19,412,147)"), productionID{}("1464191502"), originalPrd{}(), function{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("ordChar"), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,18,559,69)"), productionID{}("602423811"), originalPrd{}(), function{}()]
+  symbol LblnoStateCell{}() : SortStateCellOpt{} [cellOptAbsent{}("StateCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(579,18,579,132)"), productionID{}("2144665602"), originalPrd{}(), function{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(K0:SortId{}, K1:SortInt{}, K2:SortExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(X0:SortId{}, X1:SortInt{}, X2:SortExp{}), Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(Y0:SortId{}, Y1:SortInt{}, Y2:SortExp{})), Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(\and{SortId{}} (X0:SortId{}, Y0:SortId{}), \and{SortInt{}} (X1:SortInt{}, Y1:SortInt{}), \and{SortExp{}} (X2:SortExp{}, Y2:SortExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(X0:SortId{}, X1:SortInt{}, X2:SortExp{}), Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(X0:SortId{}, X1:SortInt{}, X2:SortExp{}), Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortStateCell{}, SortCell{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortKCell{}, K1:SortGeneratedCounterCell{}, K2:SortStateCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}, X2:SortStateCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortKCell{}, Y1:SortGeneratedCounterCell{}, Y2:SortStateCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}), \and{SortStateCell{}} (X2:SortStateCell{}, Y2:SortStateCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStateCell{}, SortKItem{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(K0:SortExp{}, K1:SortExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}), Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{})), Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(\and{SortExp{}} (X0:SortExp{}, Y0:SortExp{}), \and{SortExp{}} (X1:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortExp{}} (\and{SortExp{}} (Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}), Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCell{}, \equals{SortStateCell{}, R} (Val:SortStateCell{}, Lbl'-LT-'state'-GT-'{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{}\implies{SortStateCell{}} (\and{SortStateCell{}} (Lbl'-LT-'state'-GT-'{}(X0:SortMap{}), Lbl'-LT-'state'-GT-'{}(Y0:SortMap{})), Lbl'-LT-'state'-GT-'{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, inj{SortStateCell{}, SortStateCellOpt{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortStateCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKResult{}, SortKItem{}} (From:SortKResult{}))) [subsort{SortKResult{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCell{}, SortKItem{}} (From:SortCell{}))) [subsort{SortCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R, SortS0} \exists{R} (Val:SortS0, \equals{SortS0, R} (Val:SortS0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(K0:SortBool{}, K1:SortS0, K2:SortS0))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortGeneratedTopCell{}, SortCell{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortKCell{}, SortCell{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortExp{}, SortKItem{}} (From:SortExp{}))) [subsort{SortExp{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Id{}(K0:SortId{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, inj{SortInt{}, SortExp{}} (From:SortInt{}))) [subsort{SortInt{}, SortExp{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStateCellOpt{}, SortKItem{}} (From:SortStateCellOpt{}))) [subsort{SortStateCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortInt{}, SortKResult{}} (From:SortInt{}))) [subsort{SortInt{}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKItem{}} (\and{SortKItem{}} (Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{}), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(Y0:SortK{})), Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortStateCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortStateCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortStateCellOpt{}} (X1:SortStateCellOpt{}, Y1:SortStateCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, inj{SortKItem{}, SortK{}} (From:SortKItem{}))) [subsort{SortKItem{}, SortK{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortExp{}, \equals{SortExp{}, R} (Val:SortExp{}, Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(K0:SortExp{}, K1:SortExp{}))) [functional{}()] // functional
+  axiom{}\implies{SortExp{}} (\and{SortExp{}} (Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}), Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(Y0:SortExp{}, Y1:SortExp{})), Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(\and{SortExp{}} (X0:SortExp{}, Y0:SortExp{}), \and{SortExp{}} (X1:SortExp{}, Y1:SortExp{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, LblnoStateCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortKCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, \exists{SortGeneratedTopCell{}} (X2:SortStateCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortKCell{}, X1:SortGeneratedCounterCell{}, X2:SortStateCell{})))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortStateCell{}} (\exists{SortStateCell{}} (X0:SortMap{}, Lbl'-LT-'state'-GT-'{}(X0:SortMap{})), \bottom{SortStateCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortInt{}, inj{SortInt{}, SortKResult{}} (Val:SortInt{})), \bottom{SortKResult{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortK{}} (Val:SortGeneratedTopCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCell{}, inj{SortKCell{}, SortK{}} (Val:SortKCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortList{}, inj{SortList{}, SortK{}} (Val:SortList{})), \or{SortK{}} (\exists{SortK{}} (Val:SortInt{}, inj{SortInt{}, SortK{}} (Val:SortInt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortK{}} (Val:SortKCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSet{}, inj{SortSet{}, SortK{}} (Val:SortSet{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortK{}} (Val:SortStateCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortBool{}, inj{SortBool{}, SortK{}} (Val:SortBool{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKResult{}, inj{SortKResult{}, SortK{}} (Val:SortKResult{})), \or{SortK{}} (\exists{SortK{}} (Val:SortExp{}, inj{SortExp{}, SortK{}} (Val:SortExp{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \or{SortK{}} (\exists{SortK{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortK{}} (Val:SortStateCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortFloat{}, inj{SortFloat{}, SortK{}} (Val:SortFloat{})), \or{SortK{}} (\exists{SortK{}} (Val:SortCell{}, inj{SortCell{}, SortK{}} (Val:SortCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortId{}, inj{SortId{}, SortK{}} (Val:SortId{})), \or{SortK{}} (\exists{SortK{}} (Val:SortString{}, inj{SortString{}, SortK{}} (Val:SortString{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMap{}, inj{SortMap{}, SortK{}} (Val:SortMap{})), \or{SortK{}} (\exists{SortK{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortK{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortK{}}())))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortExp{}} (\exists{SortExp{}} (X0:SortExp{}, \exists{SortExp{}} (X1:SortExp{}, Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}))), \or{SortExp{}} (\exists{SortExp{}} (X0:SortId{}, \exists{SortExp{}} (X1:SortInt{}, \exists{SortExp{}} (X2:SortExp{}, Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(X0:SortId{}, X1:SortInt{}, X2:SortExp{})))), \or{SortExp{}} (\exists{SortExp{}} (X0:SortExp{}, \exists{SortExp{}} (X1:SortExp{}, Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(X0:SortExp{}, X1:SortExp{}))), \or{SortExp{}} (\exists{SortExp{}} (Val:SortInt{}, inj{SortInt{}, SortExp{}} (Val:SortInt{})), \bottom{SortExp{}}())))) [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortKItem{}} (Val:SortStateCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortExp{}, inj{SortExp{}, SortKItem{}} (Val:SortExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortKItem{}} (Val:SortStateCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \bottom{SortKItem{}}()))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortStateCellOpt{}} (LblnoStateCell{}(), \or{SortStateCellOpt{}} (\exists{SortStateCellOpt{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortStateCellOpt{}} (Val:SortStateCell{})), \bottom{SortStateCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortCell{}} (Val:SortGeneratedTopCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortCell{}} (Val:SortStateCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
+  axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortKCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortStateCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+
+// rules
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__TEST__Exp_Exp0_`(inj{Exp,KItem}(K0))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__TEST__Exp_Exp`(K0,HOLE))~>DotVar1),_0,_1) requires #token("true","Bool") ensures #token("true","Bool") [cool() org.kframework.attributes.Location(Location(9,16,9,35)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1634387050) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,16,9,35)"), productionID{}("1634387050")]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `project:StateCell`(inj{StateCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortStateCell{},R} (
+        Lblproject'Coln'StateCell{}(kseq{}(inj{SortStateCell{}, SortKItem{}}(VarK:SortStateCell{}),dotk{}())),
+        VarK:SortStateCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisId{}(kseq{}(inj{SortId{}, SortKItem{}}(VarId:SortId{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,_12,_13,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(620) org.kframework.attributes.Location(Location(620,8,620,49)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},Var'Unds'12:SortString{},Var'Unds'13:SortString{},\dv{SortInt{}}("0")),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("620"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(620,8,620,49)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_4,#token("true","Bool") #as _89)=>_89 requires _89 ensures _89 [contentStartColumn(8) contentStartLine(349) org.kframework.attributes.Location(Location(349,8,349,33)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'89:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'4:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'89:SortBool{})),
+        Var'Unds'89:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'89:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("349"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,8,349,33)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_9)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(354) org.kframework.attributes.Location(Location(354,8,354,40)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'9:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("354"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,8,354,40)")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(_0,Cell,_1))=>Cell requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblgetGeneratedCounterCell{}(Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'0:SortKCell{},VarCell:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})),
+        VarCell:SortGeneratedCounterCell{}),
+      \top{R}()))
+  []
+
+// rule `is#KVariable`(inj{#KVariable,KItem}(#KVariable))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Hash'KVariable:Sort'Hash'KVariable{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_=/=Int__INT-COMMON__Int_Int`(I1,I2)=>`notBool_`(`_==Int__INT-COMMON__Int_Int`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(451) org.kframework.attributes.Location(Location(451,8,451,53)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("451"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(451,8,451,53)")]
+
+// rule `project:Exp`(inj{Exp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortExp{},R} (
+        Lblproject'Coln'Exp{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK:SortExp{}),dotk{}())),
+        VarK:SortExp{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `notBool_`(#token("true","Bool") #as _93)=>#token("false","Bool") requires _93 ensures _93 [contentStartColumn(8) contentStartLine(325) org.kframework.attributes.Location(Location(325,8,325,29)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'93:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'93:SortBool{})),
+        \dv{SortBool{}}("false")),
+      \equals{SortBool{},R}(
+        Var'Unds'93:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("325"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(325,8,325,29)")]
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblinitGeneratedCounterCell{}(),
+        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisK{}(VarK:SortK{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,_18)=>Source requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(612) org.kframework.attributes.Location(Location(612,8,613,57)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},Var'Unds'18:SortString{}),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("612"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(612,8,613,57)")]
+
+// rule `_andBool_`(#token("true","Bool") #as _66,B)=>B requires _66 ensures _66 [contentStartColumn(8) contentStartLine(328) org.kframework.attributes.Location(Location(328,8,328,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'66:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'66:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'66:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("328"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(328,8,328,37)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(326) org.kframework.attributes.Location(Location(326,8,326,29)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("326"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(326,8,326,29)")]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortFloat{},R} (
+        Lblproject'Coln'Float{}(kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())),
+        VarK:SortFloat{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source))) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(609) org.kframework.attributes.Location(Location(609,8,611,66)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("609"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(609,8,611,66)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(_14,#token("\"\"","String"),_15)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(602) org.kframework.attributes.Location(Location(602,8,602,33)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'14:SortString{},\dv{SortString{}}(""),Var'Unds'15:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("602"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(602,8,602,33)")]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortList{},R} (
+        Lblproject'Coln'List{}(kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())),
+        VarK:SortList{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isStateCell(inj{StateCell,KItem}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(kseq{}(inj{SortStateCell{}, SortKItem{}}(VarStateCell:SortStateCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_-__TEST__Exp_Exp1_`(inj{Exp,KItem}(K1))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_-__TEST__Exp_Exp`(HOLE,K1))~>DotVar1),_0,_1) requires #token("true","Bool") ensures #token("true","Bool") [cool() org.kframework.attributes.Location(Location(9,39,9,58)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1740223770) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,39,9,58)"), productionID{}("1740223770")]
+
+// rule `_==String__STRING__String_String`(S1,S2)=>`_==K_`(inj{String,KItem}(S1),inj{String,KItem}(S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(583) org.kframework.attributes.Location(Location(583,8,583,49)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortString{}, SortKItem{}}(VarS1:SortString{}),dotk{}()),kseq{}(inj{SortString{}, SortKItem{}}(VarS2:SortString{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("583"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(583,8,583,49)")]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(_16,#token("\"\"","String"),_17)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(600) org.kframework.attributes.Location(Location(600,8,600,32)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'16:SortString{},\dv{SortString{}}(""),Var'Unds'17:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("600"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(600,8,600,32)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(338) org.kframework.attributes.Location(Location(338,8,338,38)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("338"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(338,8,338,38)")]
+
+// rule `_<=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(595) org.kframework.attributes.Location(Location(595,8,595,63)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("595"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(595,8,595,63)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING__String`(ToCount)),`lengthString(_)_STRING__String`(Source)),ToCount)) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(606) org.kframework.attributes.Location(Location(606,8,607,60)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToCount:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("606"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(606,8,607,60)")]
+
+// rule `_>String__STRING__String_String`(S1,S2)=>`_<String__STRING__String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(596) org.kframework.attributes.Location(Location(596,8,596,52)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("596"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(596,8,596,52)")]
+
+// rule `is#KVariable`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:Sort'Hash'KVariable{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Unds'1:Sort'Hash'KVariable{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(346) org.kframework.attributes.Location(Location(346,8,346,32)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("346"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(346,8,346,32)")]
+
+// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(824) org.kframework.attributes.Location(Location(824,8,824,43)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:SortBool{},VarK2:SortBool{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK1:SortBool{}),dotk{}()),kseq{}(inj{SortBool{}, SortKItem{}}(VarK2:SortBool{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("824"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(824,8,824,43)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool") #as _103,_6)=>_103 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(335) org.kframework.attributes.Location(Location(335,8,335,36)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'103:SortBool{}),Var'Unds'6:SortBool{}),
+        Var'Unds'103:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("335"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(335,8,335,36)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`int_=_;__TEST__Id_Int_Exp`(X,I,E))~>DotVar1),DotVar0,`<state>`(`_Map_`(`.Map`(.KList),DotVar2)))=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(E)~>DotVar1),DotVar0,`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),inj{Int,KItem}(I)),DotVar2))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(16) org.kframework.attributes.Location(Location(16,6,16,82)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lblint'UndsEqlsUndsSClnUndsUnds'TEST'UndsUnds'Id'Unds'Int'Unds'Exp{}(VarX:SortId{},VarI:SortInt{},VarE:SortExp{})),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),VarDotVar2:SortMap{})))), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarE:SortExp{}),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),inj{SortInt{}, SortKItem{}}(VarI:SortInt{})),VarDotVar2:SortMap{})))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("16"), contentStartColumn{}("6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(16,6,16,82)")]
+
+// rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortId{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'0:SortId{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisId{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCell{},R} (
+        Lblproject'Coln'GeneratedTopCell{}(kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarK:SortGeneratedTopCell{}),dotk{}())),
+        VarK:SortGeneratedTopCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(340) org.kframework.attributes.Location(Location(340,8,340,38)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("340"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(340,8,340,38)")]
+
+// rule `freshId(_)_ID-SYNTAX__Int`(I)=>`String2Id(_)_ID-SYNTAX__String`(`_+String__STRING__String_String`(#token("\"_\"","String"),`Int2String(_)_STRING__Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(791) org.kframework.attributes.Location(Location(791,8,791,62)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortId{},R} (
+        LblfreshId'LParUndsRParUnds'ID-SYNTAX'UndsUnds'Int{}(VarI:SortInt{}),
+        LblString2Id'LParUndsRParUnds'ID-SYNTAX'UndsUnds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{})))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("791"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(791,8,791,62)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(341) org.kframework.attributes.Location(Location(341,8,341,57)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("341"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,8,341,57)")]
+
+// rule `project:StateCellOpt`(inj{StateCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortStateCellOpt{},R} (
+        Lblproject'Coln'StateCellOpt{}(kseq{}(inj{SortStateCellOpt{}, SortKItem{}}(VarK:SortStateCellOpt{}),dotk{}())),
+        VarK:SortStateCellOpt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING__String_String_String_Int`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source)),ToReplace,Replacement,`_-Int__INT-COMMON__Int_Int`(Count,#token("1","Int")))) requires `_>Int__INT-COMMON__Int_Int`(Count,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(616) org.kframework.attributes.Location(Location(616,8,619,30)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},VarCount:SortInt{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("616"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(616,8,619,30)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_-__TEST__Exp_Exp0_`(inj{Exp,KItem}(K0))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_-__TEST__Exp_Exp`(K0,HOLE))~>DotVar1),_0,_1) requires #token("true","Bool") ensures #token("true","Bool") [cool() org.kframework.attributes.Location(Location(9,39,9,58)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1740223770) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,39,9,58)"), productionID{}("1740223770")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__TEST__Exp_Exp`(HOLE,K1))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__TEST__Exp_Exp1_`(inj{Exp,KItem}(K1))~>DotVar1),_0,_1) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{Exp,KItem}(HOLE)))) ensures #token("true","Bool") [heat() org.kframework.attributes.Location(Location(9,16,9,35)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1634387050) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,16,9,35)"), productionID{}("1634387050")]
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'1:SortGeneratedTopCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_divInt__INT-COMMON__Int_Int`(I1,I2)=>`_/Int__INT-COMMON__Int_Int`(`_-Int__INT-COMMON__Int_Int`(I1,`_modInt__INT-COMMON__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(439) org.kframework.attributes.Location(Location(439,8,440,23)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("439"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(439,8,440,23)")]
+
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortCell{}, SortKItem{}}(Var'Unds'1:SortCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isExp(inj{Exp,KItem}(Exp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisExp{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarExp:SortExp{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        Lblproject'Coln'KCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())),
+        VarK:SortKCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortMap{},R} (
+        Lblproject'Coln'Map{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())),
+        VarK:SortMap{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `replaceAll(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING__String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(621) org.kframework.attributes.Location(Location(621,8,621,154)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("621"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(621,8,621,154)")]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(kseq{}(VarKItem:SortKItem{},dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isStateCellOpt(inj{StateCellOpt,KItem}(StateCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(kseq{}(inj{SortStateCellOpt{}, SortKItem{}}(VarStateCellOpt:SortStateCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_2,#token("false","Bool") #as _109)=>_109 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(336) org.kframework.attributes.Location(Location(336,8,336,36)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'2:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'109:SortBool{})),
+        Var'Unds'109:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("336"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,8,336,36)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(_5,#token("true","Bool") #as _85)=>_85 requires _85 ensures _85 [contentStartColumn(8) contentStartLine(344) org.kframework.attributes.Location(Location(344,8,344,34)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'85:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'5:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'85:SortBool{})),
+        Var'Unds'85:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'85:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("344"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(344,8,344,34)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__TEST__Exp_Exp1_`(inj{Exp,KItem}(K1))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__TEST__Exp_Exp`(HOLE,K1))~>DotVar1),_0,_1) requires #token("true","Bool") ensures #token("true","Bool") [cool() org.kframework.attributes.Location(Location(9,16,9,35)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1634387050) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [cool{}(), strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,16,9,35)"), productionID{}("1634387050")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblproject'Coln'Bool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())),
+        VarK:SortBool{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'0:SortSet{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_8,#token("true","Bool") #as _105)=>_105 requires _105 ensures _105 [contentStartColumn(8) contentStartLine(355) org.kframework.attributes.Location(Location(355,8,355,39)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'105:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'8:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'105:SortBool{})),
+        Var'Unds'105:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'105:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("355"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(355,8,355,39)")]
+
+// rule `freshInt(_)_INT__Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(455) org.kframework.attributes.Location(Location(455,8,455,28)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI:SortInt{}),
+        VarI:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("455"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(455,8,455,28)")]
+
+// rule isExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortExp{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortExp{}, SortKItem{}}(Var'Unds'1:SortExp{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisExp{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(B,#token("true","Bool") #as _99)=>B requires _99 ensures _99 [contentStartColumn(8) contentStartLine(329) org.kframework.attributes.Location(Location(329,8,329,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'99:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'99:SortBool{})),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'99:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("329"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(329,8,329,37)")]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(447) org.kframework.attributes.Location(Location(447,8,447,57)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI1:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("447"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(447,8,447,57)")]
+
+// rule `_dividesInt__INT-COMMON__Int_Int`(I1,I2)=>`_==Int__INT-COMMON__Int_Int`(`_%Int__INT-COMMON__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(452) org.kframework.attributes.Location(Location(452,8,452,58)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("452"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(452,8,452,58)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(351) org.kframework.attributes.Location(Location(351,8,351,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("351"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(351,8,351,37)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_-__TEST__Exp_Exp`(HOLE,K1))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_-__TEST__Exp_Exp1_`(inj{Exp,KItem}(K1))~>DotVar1),_0,_1) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{Exp,KItem}(HOLE)))) ensures #token("true","Bool") [heat() org.kframework.attributes.Location(Location(9,39,9,58)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1740223770) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarHOLE:SortExp{},VarK1:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp1'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK1:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,39,9,58)"), productionID{}("1740223770")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON__Int_Int`(`rfindString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(601) org.kframework.attributes.Location(Location(601,8,601,182)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("601"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(601,8,601,182)")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_11,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(829) org.kframework.attributes.Location(Location(829,8,829,67)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},Var'Unds'11:SortK{},VarB2:SortK{}),
+        VarB2:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("829"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(829,8,829,67)")]
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'0:SortGeneratedCounterCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'0:SortGeneratedTopCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(448) org.kframework.attributes.Location(Location(448,8,448,57)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI2:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("448"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(448,8,448,57)")]
+
+// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKResult{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKResult{}, SortKItem{}}(Var'Unds'1:SortKResult{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool") #as _64,_7)=>_64 requires _64 ensures _64 [contentStartColumn(8) contentStartLine(348) org.kframework.attributes.Location(Location(348,8,348,33)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'64:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'64:SortBool{}),Var'Unds'7:SortBool{}),
+        Var'Unds'64:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'64:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("348"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,8,348,33)")]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initKCell(Init),initGeneratedCounterCell(.KList),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCell{},R} (
+        LblinitGeneratedTopCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'generatedTop'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}(),LblinitStateCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule isKResult(inj{KResult,KItem}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(kseq{}(inj{SortKResult{}, SortKItem{}}(VarKResult:SortKResult{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_-__TEST__Exp_Exp`(inj{Int,Exp}(A),inj{Int,Exp}(B)))~>DotVar1),DotVar0,`<state>`(`_Map_`(`_|->_`(_20,inj{Int,KItem}(C)),DotVar2)) #as _299)=>`<generatedTop>`(`<k>`(inj{Int,KItem}(`_-Int__INT-COMMON__Int_Int`(#token("0","Int"),C))~>DotVar1),DotVar0,_299) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(14) org.kframework.attributes.Location(Location(14,6,14,78)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(VarA:SortInt{}),inj{SortInt{}, SortExp{}}(VarB:SortInt{}))),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},\and{SortStateCell{}}(Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(Var'Unds'20:SortKItem{},inj{SortInt{}, SortKItem{}}(VarC:SortInt{})),VarDotVar2:SortMap{})),Var'Unds'299:SortStateCell{}))), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("0"),VarC:SortInt{})),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},Var'Unds'299:SortStateCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("14"), contentStartColumn{}("6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(14,6,14,78)")]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)))) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(599) org.kframework.attributes.Location(Location(599,8,599,431)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("599"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(599,8,599,431)")]
+
+// rule `_modInt__INT-COMMON__Int_Int`(I1,I2)=>`_%Int__INT-COMMON__Int_Int`(`_+Int_`(`_%Int__INT-COMMON__Int_Int`(I1,`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(442) org.kframework.attributes.Location(Location(442,5,445,23)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), concrete{}(), contentStartLine{}("442"), contentStartColumn{}("5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(442,5,445,23)")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(822) org.kframework.attributes.Location(Location(822,8,822,45)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("822"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,8,822,45)")]
+
+// rule isCell(inj{Cell,KItem}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `project:Cell`(inj{Cell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortCell{},R} (
+        Lblproject'Coln'Cell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarK:SortCell{}),dotk{}())),
+        VarK:SortCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__TEST__Exp_Exp`(inj{Int,Exp}(A),inj{Int,Exp}(B)))~>DotVar1),DotVar0,`<state>`(`_Map_`(`_|->_`(_19,inj{Int,KItem}(C)),DotVar2)) #as _263)=>`<generatedTop>`(`<k>`(inj{Int,KItem}(C)~>DotVar1),DotVar0,_263) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(6) contentStartLine(13) org.kframework.attributes.Location(Location(13,6,13,71)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(inj{SortInt{}, SortExp{}}(VarA:SortInt{}),inj{SortInt{}, SortExp{}}(VarB:SortInt{}))),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},\and{SortStateCell{}}(Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(Var'Unds'19:SortKItem{},inj{SortInt{}, SortKItem{}}(VarC:SortInt{})),VarDotVar2:SortMap{})),Var'Unds'263:SortStateCell{}))), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarC:SortInt{}),VarDotVar1:SortK{})),VarDotVar0:SortGeneratedCounterCell{},Var'Unds'263:SortStateCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("13"), contentStartColumn{}("6"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,6,13,71)")]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lblproject'Coln'Int{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())),
+        VarK:SortInt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_+__TEST__Exp_Exp`(K0,HOLE))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_+__TEST__Exp_Exp0_`(inj{Exp,KItem}(K0))~>DotVar1),_0,_1) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{Exp,KItem}(HOLE)))) ensures #token("true","Bool") [heat() org.kframework.attributes.Location(Location(9,16,9,35)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1634387050) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,16,9,35)"), productionID{}("1634387050")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(345) org.kframework.attributes.Location(Location(345,8,345,32)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("345"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,8,345,32)")]
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'1:SortMap{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCellFragment{},R} (
+        Lblproject'Coln'GeneratedTopCellFragment{}(kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarK:SortGeneratedTopCellFragment{}),dotk{}())),
+        VarK:SortGeneratedTopCellFragment{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_-Int__INT-COMMON__Int_Int`(`_modInt__INT-COMMON__Int_Int`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(437) org.kframework.attributes.Location(Location(437,8,437,164)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("437"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(437,8,437,164)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool") #as _101,_0)=>_101 requires _101 ensures _101 [contentStartColumn(8) contentStartLine(343) org.kframework.attributes.Location(Location(343,8,343,34)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'101:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'101:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'101:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'101:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("343"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(343,8,343,34)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(604) org.kframework.attributes.Location(Location(604,8,605,59)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        \dv{SortInt{}}("0")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("604"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(604,8,605,59)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool") #as _87,B)=>B requires _87 ensures _87 [contentStartColumn(8) contentStartLine(353) org.kframework.attributes.Location(Location(353,8,353,36)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'87:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'87:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'87:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("353"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(353,8,353,36)")]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'1:SortKConfigVar{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(358) org.kframework.attributes.Location(Location(358,8,358,57)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("358"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,8,358,57)")]
+
+// rule `_=/=String__STRING__String_String`(S1,S2)=>`notBool_`(`_==String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(582) org.kframework.attributes.Location(Location(582,8,582,65)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("582"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(582,8,582,65)")]
+
+// rule isStateCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortStateCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStateCellOpt{}, SortKItem{}}(Var'Unds'0:SortStateCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule initKCell(Init)=>`<k>`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'k'-GT-'{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule initStateCell(.KList)=>`<state>`(`.Map`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortStateCell{},R} (
+        LblinitStateCell{}(),
+        Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCellOpt{},R} (
+        Lblproject'Coln'KCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())),
+        VarK:SortKCellOpt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:KResult`(inj{KResult,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKResult{},R} (
+        Lblproject'Coln'KResult{}(kseq{}(inj{SortKResult{}, SortKItem{}}(VarK:SortKResult{}),dotk{}())),
+        VarK:SortKResult{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'0:SortList{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(#token("false","Bool") #as _75,_3)=>_75 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(330) org.kframework.attributes.Location(Location(330,8,330,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'75:SortBool{}),Var'Unds'3:SortBool{}),
+        Var'Unds'75:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("330"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(330,8,330,37)")]
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'0:SortKCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(Var'Unds'0:SortKItem{},dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool") #as _111,K)=>K requires _111 ensures _111 [contentStartColumn(8) contentStartLine(333) org.kframework.attributes.Location(Location(333,8,333,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'111:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'111:SortBool{}),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'111:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("333"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,8,333,37)")]
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'1:SortString{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortSet{},R} (
+        Lblproject'Coln'Set{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())),
+        VarK:SortSet{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(356) org.kframework.attributes.Location(Location(356,8,356,45)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("356"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(356,8,356,45)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(339) org.kframework.attributes.Location(Location(339,8,339,38)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("339"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,8,339,38)")]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'0:SortInt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_andBool_`(_1,#token("false","Bool") #as _91)=>_91 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(331) org.kframework.attributes.Location(Location(331,8,331,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'1:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'91:SortBool{})),
+        Var'Unds'91:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("331"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(331,8,331,37)")]
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'0:SortBool{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_==Int__INT-COMMON__Int_Int`(I1,I2)=>`_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(450) org.kframework.attributes.Location(Location(450,8,450,40)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI1:SortInt{}),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(VarI2:SortInt{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("450"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(450,8,450,40)")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_10)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(828) org.kframework.attributes.Location(Location(828,8,828,59)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},VarB1:SortK{},Var'Unds'10:SortK{}),
+        VarB1:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("828"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(828,8,828,59)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool") #as _113)=>K requires _113 ensures _113 [contentStartColumn(8) contentStartLine(334) org.kframework.attributes.Location(Location(334,8,334,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'113:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'113:SortBool{})),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'113:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("334"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,8,334,37)")]
+
+// rule `<generatedTop>`(`<k>`(inj{Exp,KItem}(`_-__TEST__Exp_Exp`(K0,HOLE))~>DotVar1),_0,_1)=>`<generatedTop>`(`<k>`(inj{Exp,KItem}(HOLE)~>`#freezer_-__TEST__Exp_Exp0_`(inj{Exp,KItem}(K0))~>DotVar1),_0,_1) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{Exp,KItem}(HOLE)))) ensures #token("true","Bool") [heat() org.kframework.attributes.Location(Location(9,39,9,58)) org.kframework.attributes.Source(Source(/home/dwightguth/test/./test.k)) productionID(1740223770) strict()]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(Lbl'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp{}(VarK0:SortExp{},VarHOLE:SortExp{})),VarDotVar1:SortK{})),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarHOLE:SortExp{}),kseq{}(Lbl'Hash'freezer'Unds'-'UndsUnds'TEST'UndsUnds'Exp'Unds'Exp0'Unds'{}(kseq{}(inj{SortExp{}, SortKItem{}}(VarK0:SortExp{}),dotk{}())),VarDotVar1:SortK{}))),Var'Unds'0:SortGeneratedCounterCell{},Var'Unds'1:SortStateCell{})))
+  [strict{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,39,9,58)"), productionID{}("1740223770")]
+
+// rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortId{},R} (
+        Lblproject'Coln'Id{}(kseq{}(inj{SortId{}, SortKItem{}}(VarK:SortId{}),dotk{}())),
+        VarK:SortId{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'0:SortKCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblproject'Coln'String{}(kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())),
+        VarK:SortString{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'0:SortFloat{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_modInt__INT-COMMON__Int_Int`(`_>>Int__INT-COMMON__Int_Int`(I,IDX),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(435) org.kframework.attributes.Location(Location(435,8,435,85)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("435"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(435,8,435,85)")]
+
+// rule isStateCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortStateCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortStateCell{}, SortKItem{}}(Var'Unds'0:SortStateCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisStateCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(350) org.kframework.attributes.Location(Location(350,8,350,37)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("350"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(350,8,350,37)")]
+
+// rule `_>=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(597) org.kframework.attributes.Location(Location(597,8,597,63)) org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("597"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(597,8,597,63)")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,18,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/test/./test.k)")]

--- a/test/test19.out.kore
+++ b/test/test19.out.kore
@@ -1,0 +1,1 @@
+Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),Lbl'-LT-'state'-GT-'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(\dv{SortId{}}("x")),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))


### PR DESCRIPTION
Substantially improves sharing of set/map choice operations using the indirectbr instruction. Also includes a minor fix for booleans, which put together allow the C/C++ linking semantics to link successfully.