### PR TITLE
Elimination of no-gc allocations for sret parameters

### DIFF
--- a/ciscript
+++ b/ciscript
@@ -58,6 +58,8 @@ llvm-kompile-testing ../test/test-gc-float.kore IMP-FLOAT main -o interpreter
 ./interpreter ../test/test-gc-float-1.kore -1 /dev/stdout | grep -q "Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(dotk{}()).*inj{SortId{}, SortKItem{}}(\\\\dv{SortId{}}(\"x\")),inj{SortFloat{}, SortKItem{}}(\\\\dv{SortFloat{}}(\"0.43466557686937428e209\"))"
 llvm-kompile-testing ../test/test-gc-stringbuffer.kore TEST main -o interpreter
 ./interpreter ../test/test-gc-stringbuffer-1.kore -1 /dev/stdout | diff - ../test/test-gc-stringbuffer-1.out
+llvm-kompile-testing ../test/test-gc-alwaysgc.kore TEST main -o interpreter
+./interpreter ../test/test-gc-alwaysgc-1.kore -1 /dev/stdout | grep -q "Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\\\\dv{SortInt{}}(\"9876\")),dotk{}())),Lbl'-LT-'m'-GT-'{}(.*)),Lbl'-LT-'generatedCounter'-GT-'{}(\\\\dv{SortInt{}}(\"0\")))"
 llvm-kompile-testing ../test/io.kore IO main -o interpreter
 ./interpreter ../test/ioTest1.kore -1 /dev/stdout | grep -q "Lbl'-LT-'k'-GT-'{}(dotk{}())"
 diff io_output1.txt ../test/ioTest1.out

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -21,6 +21,10 @@ void* koreAllocOld(size_t requested);
 void* koreAllocTokenOld(size_t requested);
 // allocates exactly requested bytes into the not garbage-collected arena
 void* koreAllocNoGC(size_t requested);
+// allocates exactly requested bytes into the always garbage-collected arena.
+// objects that can potentially survive a collection (i.e. can be reached from the
+// root during collection) should never be allocated in this arena.
+void* koreAllocAlwaysGC(size_t requested);
 // swaps the two semispace of the young generation as part of garbage collection
 // if the swapOld flag is set, it also swaps the two semispaces of the old generation
 void koreAllocSwap(bool swapOld);

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -52,8 +52,13 @@ void *arenaAlloc(struct arena *, size_t);
 void *arenaResizeLastAlloc(struct arena *, ssize_t);
 
 // Exchanges the current allocation and collection semispaces and clears the new
-// current allocation semispace. It is used before garbage collection.
-void arenaSwapAndReset(struct arena *);
+// current allocation semispace by setting its start back to its first block.
+// It is used before garbage collection.
+void arenaSwapAndClear(struct arena *);
+
+// Clears the current allocation space by setting its start back to its first block.
+// It is used during garbage collection to effectively collect all of the arena.
+void arenaClear(struct arena *);
 
 // Returns the address of the first byte that belongs in the given arena.
 // Returns 0 if nothing has been allocated ever in that arena.

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -441,9 +441,9 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, KOREObjectComposit
     case SortCategory::List:
     case SortCategory::Set: {
       if (!arg->getType()->isPointerTy()) {
-          llvm::AllocaInst *AllocCollection = new llvm::AllocaInst(arg->getType(), 0, "", CurrentBlock);
-          new llvm::StoreInst(arg, AllocCollection, CurrentBlock);
-          args.push_back(AllocCollection);
+        llvm::AllocaInst *AllocCollection = new llvm::AllocaInst(arg->getType(), 0, "", CurrentBlock);
+        new llvm::StoreInst(arg, AllocCollection, CurrentBlock);
+        args.push_back(AllocCollection);
       } else {
         args.push_back(arg);
       }
@@ -470,7 +470,7 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
     break;
   }
   llvm::Value *AllocSret;
- for (int i = 0; i < args.size(); i++) {
+  for (int i = 0; i < args.size(); i++) {
     llvm::Value *arg = args[i];
     types.push_back(arg->getType());
   }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -476,7 +476,7 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
   }
   if (sret) {
     // we don't use alloca here because the tail call optimization pass for llvm doesn't handle correctly functions with alloca
-    AllocSret = allocateTerm(returnType, CurrentBlock, "koreAllocNoGC");
+    AllocSret = allocateTerm(returnType, CurrentBlock, "koreAllocAlwaysGC");
     args.insert(args.begin(), AllocSret);
     types.insert(types.begin(), AllocSret->getType());
     returnType = llvm::Type::getVoidTy(Ctx);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -495,6 +495,7 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
   }
   if (sret) {
     func->arg_begin()->addAttr(llvm::Attribute::StructRet);
+    call->addParamAttr(0, llvm::Attribute::StructRet);
     return AllocSret;
   }
   return call;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -284,7 +284,7 @@ void MakeIteratorNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> subst
   llvm::Value *arg = substitution.lookup(collection);
   args.push_back(arg);
   types.push_back(arg->getType());
-  llvm::Value *AllocSret = allocateTerm(d->Module->getTypeByName("iter"), d->CurrentBlock, "koreAllocNoGC");
+  llvm::Value *AllocSret = allocateTerm(d->Module->getTypeByName("iter"), d->CurrentBlock, "koreAllocAlwaysGC");
   AllocSret->setName(name);
   args.insert(args.begin(), AllocSret);
   types.insert(types.begin(), AllocSret->getType());

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -296,8 +296,9 @@ void MakeIteratorNode::codegen(Decision *d, llvm::StringMap<llvm::Value *> subst
     constant->print(llvm::errs());
     abort();
   }
-  llvm::CallInst::Create(func, args, "", d->CurrentBlock);
+  auto call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
   func->arg_begin()->addAttr(llvm::Attribute::StructRet);
+  call->addParamAttr(0, llvm::Attribute::StructRet);
   substitution[name] = AllocSret;
   child->codegen(d, substitution);
   setCompleted();

--- a/runtime/alloc/alloc.c
+++ b/runtime/alloc/alloc.c
@@ -13,6 +13,7 @@
 REGISTER_ARENA(youngspace, 0);
 REGISTER_ARENA(oldspace, 1);
 REGISTER_ARENA(nogcspace, 2);
+REGISTER_ARENA(alwaysgcspace, 3);
 
 char *youngspace_ptr() {
   return arenaStartPtr(&youngspace);
@@ -40,6 +41,7 @@ char oldspace_collection_id() {
 
 void koreAllocSwap(bool swapOld) {
   arenaSwapAndReset(&youngspace);
+  arenaSwapAndReset(&alwaysgcspace);
   if (swapOld) {
     arenaSwapAndReset(&oldspace);
   }
@@ -50,6 +52,7 @@ void freeAllKoreMem() {
   arenaReset(&youngspace);
   arenaReset(&oldspace);
   arenaReset(&nogcspace);
+  arenaReset(&alwaysgcspace);
 }
 
 void setKoreMemoryFunctionsForGMP() {
@@ -76,6 +79,10 @@ __attribute__ ((always_inline)) void* koreAllocTokenOld(size_t requested) {
 
 __attribute__ ((always_inline)) void* koreAllocNoGC(size_t requested) {
   return arenaAlloc(&nogcspace, requested);
+}
+
+__attribute__ ((always_inline)) void* koreAllocAlwaysGC(size_t requested) {
+  return arenaAlloc(&alwaysgcspace, requested);
 }
 
 void* koreResizeLastAlloc(void* oldptr, size_t newrequest, size_t last_size) {

--- a/runtime/alloc/alloc.c
+++ b/runtime/alloc/alloc.c
@@ -40,10 +40,10 @@ char oldspace_collection_id() {
 }
 
 void koreAllocSwap(bool swapOld) {
-  arenaSwapAndReset(&youngspace);
-  arenaSwapAndReset(&alwaysgcspace);
+  arenaSwapAndClear(&youngspace);
+  arenaClear(&alwaysgcspace);
   if (swapOld) {
-    arenaSwapAndReset(&oldspace);
+    arenaSwapAndClear(&oldspace);
   }
 }
 

--- a/runtime/alloc/arena.c
+++ b/runtime/alloc/arena.c
@@ -142,14 +142,18 @@ void *arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
   return 0;
 }
 
-__attribute__ ((always_inline)) void arenaSwapAndReset(struct arena *Arena) {
+__attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
   char *tmp = Arena->first_block;
   Arena->first_block = Arena->first_collection_block;
   Arena->first_collection_block = tmp;
+  Arena->allocation_semispace_id = ~Arena->allocation_semispace_id;
+  arenaClear(Arena);
+}
+
+__attribute__ ((always_inline)) void arenaClear(struct arena *Arena) {
   Arena->block = Arena->first_block ? Arena->first_block + sizeof(memory_block_header) : 0;
   Arena->block_start = Arena->first_block;
   Arena->block_end = Arena->first_block ? Arena->first_block + BLOCK_SIZE : 0;
-  Arena->allocation_semispace_id = ~Arena->allocation_semispace_id;
 }
 
 __attribute__ ((always_inline)) char *arenaStartPtr(const struct arena *Arena) {

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -383,15 +383,16 @@ std::string floatToString(const floating *f) {
     mpfr_exp_t printed_exp;
     char *str = mpfr_get_str(NULL, &printed_exp, 10, 0, f->f, MPFR_RNDN);
     size_t len = strlen(str);
-    char *newstr = (char *)koreAllocNoGC(len+2);
+    string *newstr = (string *)koreAllocToken(sizeof(string) + len + 2);
+    set_len(newstr, len + 2);
     size_t idx = 0;
     if (str[0] == '-') {
-      newstr[0] = '-';
+      newstr->data[0] = '-';
       idx = 1;
     }
-    newstr[idx] = '0';
-    newstr[idx+1] = '.';
-    strcpy(newstr+idx+2,str+idx);
-    return std::string(newstr) + "e" + std::to_string(printed_exp) + suffix;
+    newstr->data[idx] = '0';
+    newstr->data[idx+1] = '.';
+    strcpy(newstr->data + idx + 2, str + idx);
+    return std::string(newstr->data) + "e" + std::to_string(printed_exp) + suffix;
   }
 }

--- a/test/test-gc-alwaysgc-1.kore
+++ b/test/test-gc-alwaysgc-1.kore
@@ -1,0 +1,4 @@
+[initial-configuration{}(LblinitGeneratedTopCell{}(Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM")),inj{SortPgm{}, SortKItem{}}(Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(\dv{SortInt{}}("10000")),Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(\dv{SortInt{}}("9876")),Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}()))))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$STDIN")),inj{SortString{}, SortKItem{}}(\dv{SortString{}}("")))),Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$IO")),inj{SortString{}, SortKItem{}}(\dv{SortString{}}("on"))))))]
+
+module TMP
+endmodule []

--- a/test/test-gc-alwaysgc.kore
+++ b/test/test-gc-alwaysgc.kore
@@ -1,0 +1,2318 @@
+[topCellInitializer{}(LblinitGeneratedTopCell{}())]
+
+module BASIC-K
+  sort SortK{} []
+  sort SortKItem{} []
+endmodule []
+
+module KSEQ
+  import BASIC-K []
+
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+  symbol dotk{}() : SortK{} []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(dotk{}(),K2:SortK{}),
+      K2:SortK{})
+  []
+
+  axiom{R}
+    \equals{SortK{},R}(
+      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
+      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
+  []
+
+endmodule []
+
+module INJ
+  symbol inj{From,To}(From) : To [sortInjection{}()]
+ 
+  axiom{S1,S2,S3,R} 
+    \equals{S3,R}(
+      inj{S2,S3}(inj{S1,S2}(T:S1)),
+      inj{S1,S3}(T:S1))
+  []
+
+endmodule []
+
+module K
+  import KSEQ []
+  import INJ []
+
+  // Defnitions for reachability aliases
+  // Until we will have `mu` we resort to dummy definitions
+  alias weakExistsFinally{A}(A) : A
+  where weakExistsFinally{A}(X:A) := X:A []
+
+  alias weakAlwaysFinally{A}(A) : A
+  where weakAlwaysFinally{A}(X:A) := X:A []
+
+  // Definitions for CTL aliases
+  // Until we will have `mu` we resort to dummy definitions
+  alias allPathGlobally{A}(A) : A
+  where allPathGlobally{A}(X:A) := X:A []
+
+endmodule []
+
+module TEST
+
+// imports
+  import K []
+
+// sorts
+  sort SortGeneratedTopCell{} []
+  sort SortTCellFragment{} []
+  sort SortKCell{} []
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,3,232,31)")]
+  sort SortPgm{} []
+  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(363,3,363,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.Int")]
+  sort SortTCell{} []
+  sort SortKCellOpt{} []
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(188,3,188,28)")]
+  sort SortMCell{} []
+  sort SortGeneratedCounterCellOpt{} []
+  hooked-sort SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(306,3,306,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("BOOL.Bool")]
+  sort SortKResult{} []
+  sort SortMCellOpt{} []
+  sort SortTCellOpt{} []
+  sort Sort'Hash'KVariable{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(68,3,68,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/kast.k)")]
+  sort SortCmd{} []
+  hooked-sort SortFloat{} [hook{}("FLOAT.Float"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(462,3,462,34)")]
+  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/kast.k)")]
+  sort SortCell{} []
+  hooked-sort SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(543,3,543,37)")]
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(96,3,96,28)")]
+  sort SortGeneratedTopCellFragment{} []
+  sort SortGeneratedCounterCell{} []
+
+// symbols
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(SortBool{}, SortS0, SortS0) : SortS0 [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), smt-hook{}("ite"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(826,16,826,124)"), productionID{}("616207929"), poly{}("0, 2, 3"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smtlib{}("smt_seq_nil"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(267,19,267,146)"), productionID{}("1659840424"), originalPrd{}(), function{}()]
+  symbol Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}() : SortPgm{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), klabel{}(".List{\"_;__TEST\"}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,18,9,31)"), productionID{}("2036775591"), originalPrd{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(106,18,106,128)"), productionID{}("1025001676"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(196,18,196,122)"), productionID{}("2090991873"), originalPrd{}(), function{}()]
+  symbol Lbl'-LT-'T'-GT-'{}(SortKCell{}, SortMCell{}) : SortTCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), cellName{}("T"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("13"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,17,16,21)"), format{}("%1%i%n%2%n%3%d%n%4"), cell{}(), originalPrd{}(), topcell{}()]
+  symbol Lbl'-LT-'T'-GT-'-fragment{}(SortKCellOpt{}, SortMCellOpt{}) : SortTCellFragment{} [cellFragment{}("TCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), constructor{}(), cellName{}("generatedCounter"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'{}(SortTCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [functional{}(), constructor{}(), cellName{}("generatedTop"), format{}("%2"), cell{}(), originalPrd{}(), topcell{}()]
+  symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortTCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [cellFragment{}("GeneratedTopCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), cellName{}("k"), maincell{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("13"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,17,16,21)"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}()]
+  symbol Lbl'-LT-'m'-GT-'{}(SortMap{}) : SortMCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), cellName{}("m"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("13"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(13,17,16,21)"), format{}("%1%i%n%2%d%n%3"), cell{}(), originalPrd{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Base2String"), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(572,21,572,92)"), productionID{}("49222910"), originalPrd{}(), function{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(SortFloat{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Float2String"), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(567,21,567,105)"), productionID{}("1990385139"), originalPrd{}(), function{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING'UndsUnds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("FloatFormat"), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(568,21,568,113)"), productionID{}("1380924218"), originalPrd{}(), function{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Int2String"), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(571,21,571,103)"), productionID{}("693267461"), originalPrd{}(), function{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(275,20,275,98)"), productionID{}("1175371136"), originalPrd{}(), function{}()]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,19,286,98)"), productionID{}("452842611"), originalPrd{}(), function{}()]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smtlib{}("smt_seq_elem"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(270,19,270,136)"), productionID{}("1681303515"), originalPrd{}(), function{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(117,20,117,112)"), productionID{}("1850042097"), originalPrd{}(), function{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(207,18,207,146)"), productionID{}("979291363"), originalPrd{}(), function{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(210,19,210,106)"), productionID{}("1444440224"), originalPrd{}(), function{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(201,18,201,112)"), productionID{}("75470648"), originalPrd{}(), function{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Base"), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(573,21,573,92)"), productionID{}("1997548433"), originalPrd{}(), function{}()]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Float"), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(569,21,569,93)"), productionID{}("1105628551"), originalPrd{}(), function{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("String2Int"), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(570,21,570,91)"), productionID{}("1241480588"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("mod"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(384,18,384,146)"), productionID{}("1070157899"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,18,395,142)"), productionID{}("1917025677"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("*"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(380,18,380,157)"), productionID{}("1705072168"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), symbol'Kywd'{}(), smt-hook{}("+"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(389,18,389,178)"), productionID{}("2118255842"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(553,21,553,139)"), productionID{}("240630125"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("-"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(390,18,390,154)"), productionID{}("192694377"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,18,129,120)"), productionID{}("1582028874"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("div"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(383,18,383,148)"), productionID{}("778720569"), originalPrd{}(), function{}()]
+  symbol Lbl'UndsColnSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), notEqualEqualK{}(), klabel{}("_:/=K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(819,19,819,100)"), productionID{}("795011696"), originalPrd{}(), function{}()]
+  symbol Lbl'UndsColnEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), equalEqualK{}(), klabel{}("_:=K_"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(818,19,818,96)"), productionID{}("2048013503"), originalPrd{}(), function{}()]
+  symbol Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(SortCmd{}, SortPgm{}) : SortPgm{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), right{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(9,18,9,31)"), productionID{}("2036775591"), originalPrd{}()]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,18,393,131)"), productionID{}("474488818"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("<="), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(409,19,409,151)"), productionID{}("1016860054"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(152,19,152,91)"), productionID{}("605101809"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(213,19,213,85)"), productionID{}("782689036"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(586,19,586,82)"), productionID{}("1355887174"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("<"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(410,19,410,147)"), productionID{}("977674685"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(585,19,585,82)"), productionID{}("179779934"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("distinct"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(323,19,323,105)"), productionID{}("89448984"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("distinct"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(414,19,414,162)"), productionID{}("431570856"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), notEqualEqualK{}(), smt-hook{}("distinct"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(806,19,806,170)"), productionID{}("729218894"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(581,19,581,94)"), productionID{}("1066615508"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("="), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(322,19,322,98)"), productionID{}("1868805237"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("="), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(413,19,413,169)"), productionID{}("318353283"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smt-hook{}("="), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(805,19,805,156)"), productionID{}("835146383"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(555,19,555,88)"), productionID{}("851912430"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}(">="), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(411,19,411,151)"), productionID{}("836427078"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(588,19,588,82)"), productionID{}("242282810"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,18,392,131)"), productionID{}("1947020920"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}(">"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(412,19,412,147)"), productionID{}("1322642290"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(587,19,587,82)"), productionID{}("735085430"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(".List"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("ListItem"), symbol'Kywd'{}(), assoc{}(), smtlib{}("smt_seq_concat"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(265,19,265,192)"), format{}("%1%n%2"), productionID{}("1394557075"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(".Map"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("_|->_"), symbol'Kywd'{}(), comm{}(), assoc{}(), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(104,18,104,172)"), format{}("%1%n%2"), productionID{}("888287133"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(".Set"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), element{}("SetItem"), symbol'Kywd'{}(), idem{}(), comm{}(), assoc{}(), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(194,18,194,176)"), format{}("%1%n%2"), productionID{}("2073299099"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'UndsUnds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(277,19,277,93)"), productionID{}("1866229258"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), prefer{}(), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(122,18,122,104)"), productionID{}("877612522"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,121)"), productionID{}("461129530"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(119,20,119,138)"), productionID{}("1265508963"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("(mod (^ #1 #2) #3)"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(378,18,378,112)"), productionID{}("1415630650"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsXor-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("^"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(377,18,377,153)"), productionID{}("661047965"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), symbol'Kywd'{}(), smt-hook{}("and"), boolOperation{}(), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(315,19,315,189)"), productionID{}("322112198"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("and"), boolOperation{}(), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(316,19,316,120)"), productionID{}("87674905"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("div"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(386,18,386,95)"), productionID{}("1828868503"), originalPrd{}(), function{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(415,19,415,52)"), productionID{}("2121199924"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("=>"), boolOperation{}(), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,19,320,119)"), productionID{}("1127338375"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(289,19,289,101)"), productionID{}("1076071888"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,19,143,93)"), productionID{}("1409092880"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("mod"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(387,18,387,95)"), productionID{}("41765385"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("or"), boolOperation{}(), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(318,19,318,158)"), productionID{}("61681175"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("or"), boolOperation{}(), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(319,19,319,118)"), productionID{}("147022238"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), smt-hook{}("xor"), boolOperation{}(), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(317,19,317,116)"), productionID{}("966966167"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(397,18,397,146)"), productionID{}("462773420"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(111,18,111,144)"), productionID{}("2111457497"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), left{}(), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(399,18,399,140)"), productionID{}("108449608"), originalPrd{}(), function{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_abs"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(403,18,403,102)"), productionID{}("43650267"), originalPrd{}(), function{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(406,18,406,108)"), productionID{}("120689887"), originalPrd{}(), function{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("categoryChar"), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(590,21,590,80)"), productionID{}("1027495011"), originalPrd{}(), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(155,20,155,100)"), productionID{}("524223214"), originalPrd{}(), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(219,20,219,94)"), productionID{}("768415370"), originalPrd{}(), function{}()]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING'UndsUnds'Int{}(SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("chrChar"), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(558,21,558,69)"), productionID{}("885002305"), originalPrd{}(), function{}()]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(579,18,579,132)"), productionID{}("1932597611"), originalPrd{}(), function{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("directionalityChar"), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(591,21,591,86)"), productionID{}("1688470144"), originalPrd{}(), function{}()]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(283,19,283,77)"), productionID{}("385739920"), originalPrd{}(), function{}()]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("findChar"), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(564,18,564,89)"), productionID{}("2131597042"), originalPrd{}(), function{}()]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("findString"), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(562,18,562,85)"), productionID{}("909282611"), originalPrd{}(), function{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(454,18,454,72)"), productionID{}("1804126860"), originalPrd{}(), function{}()]
+  symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [function{}(), originalPrd{}()]
+  symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblinitKCell{}(SortMap{}) : SortKCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblinitMCell{}() : SortMCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  symbol LblinitTCell{}(SortMap{}) : SortTCell{} [initializer{}(), function{}(), noThread{}(), originalPrd{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(204,18,204,88)"), productionID{}("1633013890"), originalPrd{}(), function{}()]
+  symbol Lblis'Hash'KVariable{}(SortK{}) : SortBool{} [function{}(), predicate{}("#KVariable"), originalPrd{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [function{}(), predicate{}("Bool"), originalPrd{}()]
+  symbol LblisCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cell"), originalPrd{}()]
+  symbol LblisCmd{}(SortK{}) : SortBool{} [function{}(), predicate{}("Cmd"), originalPrd{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [function{}(), predicate{}("Float"), originalPrd{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCell"), originalPrd{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedCounterCellOpt"), originalPrd{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCell"), originalPrd{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("GeneratedTopCellFragment"), originalPrd{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [function{}(), predicate{}("Int"), originalPrd{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [function{}(), predicate{}("K"), originalPrd{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCell"), originalPrd{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("KCellOpt"), originalPrd{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [function{}(), predicate{}("KConfigVar"), originalPrd{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [function{}(), predicate{}("KItem"), originalPrd{}()]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [function{}(), predicate{}("KResult"), originalPrd{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [function{}(), predicate{}("List"), originalPrd{}()]
+  symbol LblisMCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("MCell"), originalPrd{}()]
+  symbol LblisMCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("MCellOpt"), originalPrd{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [function{}(), predicate{}("Map"), originalPrd{}()]
+  symbol LblisPgm{}(SortK{}) : SortBool{} [function{}(), predicate{}("Pgm"), originalPrd{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [function{}(), predicate{}("Set"), originalPrd{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [function{}(), predicate{}("String"), originalPrd{}()]
+  symbol LblisTCell{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCell"), originalPrd{}()]
+  symbol LblisTCellFragment{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCellFragment"), originalPrd{}()]
+  symbol LblisTCellOpt{}(SortK{}) : SortBool{} [function{}(), predicate{}("TCellOpt"), originalPrd{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,86)"), productionID{}("1407083101"), originalPrd{}(), function{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(141,19,141,79)"), productionID{}("1398241764"), originalPrd{}(), function{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("lengthString"), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(557,18,557,84)"), productionID{}("586358252"), originalPrd{}(), function{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(404,18,404,74)"), productionID{}("849776463"), originalPrd{}(), function{}()]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'UndsUnds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(279,19,279,66)"), productionID{}("1962266146"), originalPrd{}(), function{}()]
+  symbol LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(SortInt{}) : SortCmd{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), klabel{}("makeMap"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,18,8,29)"), productionID{}("1393828949"), originalPrd{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_max"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,18,402,102)"), productionID{}("861623840"), originalPrd{}(), function{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("int_min"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(401,18,401,102)"), productionID{}("1511909371"), originalPrd{}(), function{}()]
+  hooked-symbol LblnewUUID'Unds'STRING'Unds'{}() : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), impure{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(593,21,593,67)"), productionID{}("1262548561"), originalPrd{}(), function{}()]
+  symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [cellOptAbsent{}("GeneratedCounterCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblnoKCell{}() : SortKCellOpt{} [cellOptAbsent{}("KCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblnoMCell{}() : SortMCellOpt{} [cellOptAbsent{}("MCell"), originalPrd{}(), constructor{}(), functional{}()]
+  symbol LblnoTCell{}() : SortTCellOpt{} [cellOptAbsent{}("TCell"), originalPrd{}(), constructor{}(), functional{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), symbol'Kywd'{}(), smt-hook{}("not"), boolOperation{}(), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(314,19,314,176)"), productionID{}("2001321875"), originalPrd{}(), function{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING'UndsUnds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("ordChar"), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(559,18,559,69)"), productionID{}("124734309"), originalPrd{}(), function{}()]
+  symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Cell{}(SortK{}) : SortCell{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Cmd{}(SortK{}) : SortCmd{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Int{}(SortK{}) : SortInt{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'KCell{}(SortK{}) : SortKCell{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'KCellOpt{}(SortK{}) : SortKCellOpt{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'KResult{}(SortK{}) : SortKResult{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'List{}(SortK{}) : SortList{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'MCell{}(SortK{}) : SortMCell{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'MCellOpt{}(SortK{}) : SortMCellOpt{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Map{}(SortK{}) : SortMap{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Pgm{}(SortK{}) : SortPgm{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'Set{}(SortK{}) : SortSet{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'String{}(SortK{}) : SortString{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'TCell{}(SortK{}) : SortTCell{} [function{}(), projection{}(), originalPrd{}()]
+  symbol Lblproject'Coln'TCellFragment{}(SortK{}) : SortTCellFragment{} [function{}(), projection{}(), originalPrd{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(457,18,457,56)"), productionID{}("862916729"), originalPrd{}(), function{}()]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,18,137,91)"), productionID{}("711112124"), originalPrd{}(), function{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(577,21,577,107)"), productionID{}("2142852357"), originalPrd{}(), function{}()]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(576,21,576,122)"), productionID{}("1160850402"), originalPrd{}(), function{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(578,21,578,124)"), productionID{}("93054696"), originalPrd{}(), function{}()]
+  symbol Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(SortInt{}) : SortCmd{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), klabel{}("ret"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(8,33,8,40)"), productionID{}("1088417975"), originalPrd{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("rfindChar"), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(565,18,565,90)"), productionID{}("1415289182"), originalPrd{}(), function{}()]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("rfindString"), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(563,18,563,86)"), productionID{}("46453164"), originalPrd{}(), function{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(407,18,407,118)"), productionID{}("1857173583"), originalPrd{}(), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), smtlib{}("smt_seq_len"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(292,18,292,121)"), productionID{}("7829163"), originalPrd{}(), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(149,18,149,103)"), productionID{}("1289869008"), originalPrd{}(), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(216,18,216,80)"), productionID{}("1631119258"), originalPrd{}(), function{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'UndsUnds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(458,16,458,56)"), productionID{}("790021811"), originalPrd{}(), function{}()]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("substrString"), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(561,21,561,99)"), productionID{}("211090736"), originalPrd{}(), function{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'UndsUnds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(281,19,281,78)"), productionID{}("632071960"), originalPrd{}(), function{}()]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(134,18,134,91)"), productionID{}("1686934746"), originalPrd{}(), function{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'UndsUnds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,19,146,76)"), productionID{}("1812831622"), originalPrd{}(), function{}()]
+  hooked-symbol Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(375,18,375,133)"), productionID{}("570253226"), originalPrd{}(), function{}()]
+
+// generated axioms
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortSet{}, SortKItem{}} (From:SortSet{}))) [subsort{SortSet{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, inj{SortKCell{}, SortKCellOpt{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortTCell{}, SortCell{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortTCell{}, SortKItem{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortMCell{}, SortCell{}} (From:SortMCell{}))) [subsort{SortMCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (From:SortGeneratedCounterCell{}))) [subsort{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKResult{}, SortKItem{}} (From:SortKResult{}))) [subsort{SortKResult{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortPgm{}, SortKItem{}} (From:SortPgm{}))) [subsort{SortPgm{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCell{}, SortKItem{}} (From:SortCell{}))) [subsort{SortCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCmd{}, SortKItem{}} (From:SortCmd{}))) [subsort{SortCmd{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortFloat{}, SortKItem{}} (From:SortFloat{}))) [subsort{SortFloat{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortKCell{}, SortCell{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortCell{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortMCellOpt{}, \equals{SortMCellOpt{}, R} (Val:SortMCellOpt{}, inj{SortMCell{}, SortMCellOpt{}} (From:SortMCell{}))) [subsort{SortMCell{}, SortMCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortTCellOpt{}, \equals{SortTCellOpt{}, R} (Val:SortTCellOpt{}, inj{SortTCell{}, SortTCellOpt{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortTCellOpt{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMap{}, SortKItem{}} (From:SortMap{}))) [subsort{SortMap{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMCellOpt{}, SortKItem{}} (From:SortMCellOpt{}))) [subsort{SortMCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCell{}, SortKItem{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortTCellFragment{}, SortKItem{}} (From:SortTCellFragment{}))) [subsort{SortTCellFragment{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortMCell{}, SortKItem{}} (From:SortMCell{}))) [subsort{SortMCell{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortInt{}, SortKResult{}} (From:SortInt{}))) [subsort{SortInt{}, SortKResult{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortKCellOpt{}, SortKItem{}} (From:SortKCellOpt{}))) [subsort{SortKCellOpt{}, SortKItem{}}()] // subsort
+  axiom{R} \exists{R} (Val:SortK{}, \equals{SortK{}, R} (Val:SortK{}, inj{SortKItem{}, SortK{}} (From:SortKItem{}))) [subsort{SortKItem{}, SortK{}}()] // subsort
+  axiom{R, SortS0} \exists{R} (Val:SortS0, \equals{SortS0, R} (Val:SortS0, Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortS0}(K0:SortBool{}, K1:SortS0, K2:SortS0))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Stop'List{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortPgm{}, \equals{SortPgm{}, R} (Val:SortPgm{}, Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}())) [functional{}()] // functional
+  axiom{}\not{SortPgm{}} (\and{SortPgm{}} (Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}(), Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(Y0:SortCmd{}, Y1:SortPgm{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Stop'Map{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Stop'Set{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCell{}, \equals{SortTCell{}, R} (Val:SortTCell{}, Lbl'-LT-'T'-GT-'{}(K0:SortKCell{}, K1:SortMCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCell{}} (\and{SortTCell{}} (Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortMCell{}), Lbl'-LT-'T'-GT-'{}(Y0:SortKCell{}, Y1:SortMCell{})), Lbl'-LT-'T'-GT-'{}(\and{SortKCell{}} (X0:SortKCell{}, Y0:SortKCell{}), \and{SortMCell{}} (X1:SortMCell{}, Y1:SortMCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortTCellFragment{}, \equals{SortTCellFragment{}, R} (Val:SortTCellFragment{}, Lbl'-LT-'T'-GT-'-fragment{}(K0:SortKCellOpt{}, K1:SortMCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortTCellFragment{}} (\and{SortTCellFragment{}} (Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortMCellOpt{}), Lbl'-LT-'T'-GT-'-fragment{}(Y0:SortKCellOpt{}, Y1:SortMCellOpt{})), Lbl'-LT-'T'-GT-'-fragment{}(\and{SortKCellOpt{}} (X0:SortKCellOpt{}, Y0:SortKCellOpt{}), \and{SortMCellOpt{}} (X1:SortMCellOpt{}, Y1:SortMCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCell{}, \equals{SortGeneratedCounterCell{}, R} (Val:SortGeneratedCounterCell{}, Lbl'-LT-'generatedCounter'-GT-'{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedCounterCell{}} (\and{SortGeneratedCounterCell{}} (Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{}), Lbl'-LT-'generatedCounter'-GT-'{}(Y0:SortInt{})), Lbl'-LT-'generatedCounter'-GT-'{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCell{}, \equals{SortGeneratedTopCell{}, R} (Val:SortGeneratedTopCell{}, Lbl'-LT-'generatedTop'-GT-'{}(K0:SortTCell{}, K1:SortGeneratedCounterCell{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCell{}} (\and{SortGeneratedTopCell{}} (Lbl'-LT-'generatedTop'-GT-'{}(X0:SortTCell{}, X1:SortGeneratedCounterCell{}), Lbl'-LT-'generatedTop'-GT-'{}(Y0:SortTCell{}, Y1:SortGeneratedCounterCell{})), Lbl'-LT-'generatedTop'-GT-'{}(\and{SortTCell{}} (X0:SortTCell{}, Y0:SortTCell{}), \and{SortGeneratedCounterCell{}} (X1:SortGeneratedCounterCell{}, Y1:SortGeneratedCounterCell{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortGeneratedTopCellFragment{}, \equals{SortGeneratedTopCellFragment{}, R} (Val:SortGeneratedTopCellFragment{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(K0:SortTCellOpt{}, K1:SortGeneratedCounterCellOpt{}))) [functional{}()] // functional
+  axiom{}\implies{SortGeneratedTopCellFragment{}} (\and{SortGeneratedTopCellFragment{}} (Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortTCellOpt{}, X1:SortGeneratedCounterCellOpt{}), Lbl'-LT-'generatedTop'-GT-'-fragment{}(Y0:SortTCellOpt{}, Y1:SortGeneratedCounterCellOpt{})), Lbl'-LT-'generatedTop'-GT-'-fragment{}(\and{SortTCellOpt{}} (X0:SortTCellOpt{}, Y0:SortTCellOpt{}), \and{SortGeneratedCounterCellOpt{}} (X1:SortGeneratedCounterCellOpt{}, Y1:SortGeneratedCounterCellOpt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortKCell{}, \equals{SortKCell{}, R} (Val:SortKCell{}, Lbl'-LT-'k'-GT-'{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortMCell{}, \equals{SortMCell{}, R} (Val:SortMCell{}, Lbl'-LT-'m'-GT-'{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{}\implies{SortMCell{}} (\and{SortMCell{}} (Lbl'-LT-'m'-GT-'{}(X0:SortMap{}), Lbl'-LT-'m'-GT-'{}(Y0:SortMap{})), Lbl'-LT-'m'-GT-'{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING'UndsUnds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, LblListItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSet'Coln'difference{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblSet'Coln'in{}(K0:SortKItem{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblSetItem{}(K0:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsAnd'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsStar'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPlus'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'Unds'-Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsColnEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortPgm{}, \equals{SortPgm{}, R} (Val:SortPgm{}, Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(K0:SortCmd{}, K1:SortPgm{}))) [functional{}()] // functional
+  axiom{}\implies{SortPgm{}} (\and{SortPgm{}} (Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(X0:SortCmd{}, X1:SortPgm{}), Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(Y0:SortCmd{}, Y1:SortPgm{})), Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(\and{SortCmd{}} (X0:SortCmd{}, Y0:SortCmd{}), \and{SortPgm{}} (X1:SortPgm{}, Y1:SortPgm{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'K'Unds'{}(K0:SortK{}, K1:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Unds'List'Unds'{}(K1:SortList{},K2:SortList{}),K3:SortList{}),Lbl'Unds'List'Unds'{}(K1:SortList{},Lbl'Unds'List'Unds'{}(K2:SortList{},K3:SortList{}))) [assoc{}()] // associativity
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(K:SortList{},Lbl'Stop'List{}()),K:SortList{}) [unit{}()] // right unit
+  axiom{R}\equals{SortList{}, R} (Lbl'Unds'List'Unds'{}(Lbl'Stop'List{}(),K:SortList{}),K:SortList{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortList{}, \equals{SortList{}, R} (Val:SortList{}, Lbl'Unds'List'Unds'{}(K0:SortList{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),K3:SortMap{}),Lbl'Unds'Map'Unds'{}(K1:SortMap{},Lbl'Unds'Map'Unds'{}(K2:SortMap{},K3:SortMap{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K1:SortMap{},K2:SortMap{}),Lbl'Unds'Map'Unds'{}(K2:SortMap{},K1:SortMap{})) [comm{}()] // commutativity
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(K:SortMap{},Lbl'Stop'Map{}()),K:SortMap{}) [unit{}()] // right unit
+  axiom{R}\equals{SortMap{}, R} (Lbl'Unds'Map'Unds'{}(Lbl'Stop'Map{}(),K:SortMap{}),K:SortMap{}) [unit{}()] // left unit
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),K3:SortSet{}),Lbl'Unds'Set'Unds'{}(K1:SortSet{},Lbl'Unds'Set'Unds'{}(K2:SortSet{},K3:SortSet{}))) [assoc{}()] // associativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K1:SortSet{},K2:SortSet{}),Lbl'Unds'Set'Unds'{}(K2:SortSet{},K1:SortSet{})) [comm{}()] // commutativity
+  axiom{R} \equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},K:SortSet{}),K:SortSet{}) [idem{}()] // idempotency
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(K:SortSet{},Lbl'Stop'Set{}()),K:SortSet{}) [unit{}()] // right unit
+  axiom{R}\equals{SortSet{}, R} (Lbl'Unds'Set'Unds'{}(Lbl'Stop'Set{}(),K:SortSet{}),K:SortSet{}) [unit{}()] // left unit
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'Unds'Set'Unds'{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(K0:SortMap{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(K0:SortMap{}, K1:SortKItem{}, K2:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'UndsUnds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'UndsUnds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'UndsUnds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(K0:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortCmd{}, \equals{SortCmd{}, R} (Val:SortCmd{}, LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortCmd{}} (\and{SortCmd{}} (LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(X0:SortInt{}), LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(Y0:SortInt{})), LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{}\not{SortCmd{}} (\and{SortCmd{}} (LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(X0:SortInt{}), Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(Y0:SortInt{}))) [constructor{}()] // no confusion different constructors
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortGeneratedCounterCellOpt{}, \equals{SortGeneratedCounterCellOpt{}, R} (Val:SortGeneratedCounterCellOpt{}, LblnoGeneratedCounterCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortKCellOpt{}, \equals{SortKCellOpt{}, R} (Val:SortKCellOpt{}, LblnoKCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMCellOpt{}, \equals{SortMCellOpt{}, R} (Val:SortMCellOpt{}, LblnoMCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortTCellOpt{}, \equals{SortTCellOpt{}, R} (Val:SortTCellOpt{}, LblnoTCell{}())) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblnotBool'Unds'{}(K0:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblremoveAll'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Set{}(K0:SortMap{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}, K2:SortString{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortCmd{}, \equals{SortCmd{}, R} (Val:SortCmd{}, Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{}\implies{SortCmd{}} (\and{SortCmd{}} (Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(X0:SortInt{}), Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(Y0:SortInt{})), Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(\and{SortInt{}} (X0:SortInt{}, Y0:SortInt{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'LIST'UndsUnds'List{}(K0:SortList{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'MAP'UndsUnds'Map{}(K0:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lblsize'LParUndsRParUnds'SET'UndsUnds'Set{}(K0:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(K0:SortString{}, K1:SortInt{}, K2:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, LblupdateMap'LParUndsCommUndsRParUnds'MAP'UndsUnds'Map'Unds'Map{}(K0:SortMap{}, K1:SortMap{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'UndsUnds'INT-COMMON'UndsUnds'Int{}(K0:SortInt{}))) [functional{}()] // functional
+  axiom{} \or{SortGeneratedTopCell{}} (\exists{SortGeneratedTopCell{}} (X0:SortTCell{}, \exists{SortGeneratedTopCell{}} (X1:SortGeneratedCounterCell{}, Lbl'-LT-'generatedTop'-GT-'{}(X0:SortTCell{}, X1:SortGeneratedCounterCell{}))), \bottom{SortGeneratedTopCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortTCellFragment{}} (\exists{SortTCellFragment{}} (X0:SortKCellOpt{}, \exists{SortTCellFragment{}} (X1:SortMCellOpt{}, Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortMCellOpt{}))), \bottom{SortTCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
+  axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
+  axiom{} \or{SortPgm{}} (Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}(), \or{SortPgm{}} (\exists{SortPgm{}} (X0:SortCmd{}, \exists{SortPgm{}} (X1:SortPgm{}, Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(X0:SortCmd{}, X1:SortPgm{}))), \bottom{SortPgm{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortInt{}} (\top{SortInt{}}(), \bottom{SortInt{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortTCell{}} (\exists{SortTCell{}} (X0:SortKCell{}, \exists{SortTCell{}} (X1:SortMCell{}, Lbl'-LT-'T'-GT-'{}(X0:SortKCell{}, X1:SortMCell{}))), \bottom{SortTCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortKCellOpt{}} (LblnoKCell{}(), \or{SortKCellOpt{}} (\exists{SortKCellOpt{}} (Val:SortKCell{}, inj{SortKCell{}, SortKCellOpt{}} (Val:SortKCell{})), \bottom{SortKCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \bottom{SortSet{}}() [constructor{}()] // no junk
+  axiom{} \or{SortMCell{}} (\exists{SortMCell{}} (X0:SortMap{}, Lbl'-LT-'m'-GT-'{}(X0:SortMap{})), \bottom{SortMCell{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCellOpt{}} (LblnoGeneratedCounterCell{}(), \or{SortGeneratedCounterCellOpt{}} (\exists{SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortGeneratedCounterCellOpt{}} (Val:SortGeneratedCounterCell{})), \bottom{SortGeneratedCounterCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKResult{}} (\exists{SortKResult{}} (Val:SortInt{}, inj{SortInt{}, SortKResult{}} (Val:SortInt{})), \bottom{SortKResult{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortMCellOpt{}} (LblnoMCell{}(), \or{SortMCellOpt{}} (\exists{SortMCellOpt{}} (Val:SortMCell{}, inj{SortMCell{}, SortMCellOpt{}} (Val:SortMCell{})), \bottom{SortMCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortK{}} (\exists{SortK{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortK{}} (Val:SortTCellFragment{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCell{}, inj{SortKCell{}, SortK{}} (Val:SortKCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortList{}, inj{SortList{}, SortK{}} (Val:SortList{})), \or{SortK{}} (\exists{SortK{}} (Val:SortPgm{}, inj{SortPgm{}, SortK{}} (Val:SortPgm{})), \or{SortK{}} (\exists{SortK{}} (Val:SortInt{}, inj{SortInt{}, SortK{}} (Val:SortInt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortTCell{}, inj{SortTCell{}, SortK{}} (Val:SortTCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortK{}} (Val:SortKCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortSet{}, inj{SortSet{}, SortK{}} (Val:SortSet{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMCell{}, inj{SortMCell{}, SortK{}} (Val:SortMCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortBool{}, inj{SortBool{}, SortK{}} (Val:SortBool{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKResult{}, inj{SortKResult{}, SortK{}} (Val:SortKResult{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMCellOpt{}, inj{SortMCellOpt{}, SortK{}} (Val:SortMCellOpt{})), \or{SortK{}} (\exists{SortK{}} (Val:SortKItem{}, inj{SortKItem{}, SortK{}} (Val:SortKItem{})), \or{SortK{}} (\exists{SortK{}} (Val:SortCmd{}, inj{SortCmd{}, SortK{}} (Val:SortCmd{})), \or{SortK{}} (\exists{SortK{}} (Val:SortFloat{}, inj{SortFloat{}, SortK{}} (Val:SortFloat{})), \or{SortK{}} (\exists{SortK{}} (Val:SortCell{}, inj{SortCell{}, SortK{}} (Val:SortCell{})), \or{SortK{}} (\exists{SortK{}} (Val:SortString{}, inj{SortString{}, SortK{}} (Val:SortString{})), \or{SortK{}} (\exists{SortK{}} (Val:SortMap{}, inj{SortMap{}, SortK{}} (Val:SortMap{})), \bottom{SortK{}}())))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortTCellOpt{}} (LblnoTCell{}(), \or{SortTCellOpt{}} (\exists{SortTCellOpt{}} (Val:SortTCell{}, inj{SortTCell{}, SortTCellOpt{}} (Val:SortTCell{})), \bottom{SortTCellOpt{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortKItem{}} (Val:SortTCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortPgm{}, inj{SortPgm{}, SortKItem{}} (Val:SortPgm{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCell{}, inj{SortTCell{}, SortKItem{}} (Val:SortTCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMCell{}, inj{SortMCell{}, SortKItem{}} (Val:SortMCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMCellOpt{}, inj{SortMCellOpt{}, SortKItem{}} (Val:SortMCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCmd{}, inj{SortCmd{}, SortKItem{}} (Val:SortCmd{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \bottom{SortKItem{}}()))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \bottom{Sort'Hash'KVariable{}}() [constructor{}()] // no junk
+  axiom{} \or{SortCmd{}} (\exists{SortCmd{}} (X0:SortInt{}, LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(X0:SortInt{})), \or{SortCmd{}} (\exists{SortCmd{}} (X0:SortInt{}, Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(X0:SortInt{})), \bottom{SortCmd{}}())) [constructor{}()] // no junk
+  axiom{} \or{SortFloat{}} (\top{SortFloat{}}(), \bottom{SortFloat{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortKConfigVar{}} (\top{SortKConfigVar{}}(), \bottom{SortKConfigVar{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortTCell{}, inj{SortTCell{}, SortCell{}} (Val:SortTCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortMCell{}, inj{SortMCell{}, SortCell{}} (Val:SortMCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
+  axiom{} \or{SortString{}} (\top{SortString{}}(), \bottom{SortString{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
+  axiom{} \bottom{SortMap{}}() [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedTopCellFragment{}} (\exists{SortGeneratedTopCellFragment{}} (X0:SortTCellOpt{}, \exists{SortGeneratedTopCellFragment{}} (X1:SortGeneratedCounterCellOpt{}, Lbl'-LT-'generatedTop'-GT-'-fragment{}(X0:SortTCellOpt{}, X1:SortGeneratedCounterCellOpt{}))), \bottom{SortGeneratedTopCellFragment{}}()) [constructor{}()] // no junk
+  axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
+
+// rules
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,B1,_0)=>B1 requires C ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(828) org.kframework.attributes.Location(Location(828,8,828,59)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        VarC:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},VarB1:SortK{},Var'Unds'0:SortK{}),
+        VarB1:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("828"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(828,8,828,59)")]
+
+// rule `#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(C,_0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(829) org.kframework.attributes.Location(Location(829,8,829,67)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        LblnotBool'Unds'{}(VarC:SortBool{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortK{},R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortK{}}(VarC:SortBool{},Var'Unds'0:SortK{},VarB2:SortK{}),
+        VarB2:SortK{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("829"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(829,8,829,67)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`.List{"_;__TEST__Cmd_Pgm"}_Pgm`(.KList))),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(#token("0","Int"))),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(28) org.kframework.attributes.Location(Location(28,8,28,26)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lbl'Stop'List'LBraQuotUndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm'QuotRBraUnds'Pgm{}()),dotk{}())),VarDotVar1:SortMCell{}),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")),dotk{}())),VarDotVar1:SortMCell{}),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("28"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(28,8,28,26)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`_;__TEST__Cmd_Pgm`(`makeMap(_)_TEST__Int`(I),Cmds))),`<m>`(M)),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(Cmds)),`<m>`(`_[_<-_]_MAP__Map_KItem_KItem`(M,inj{String,KItem}(`Int2String(_)_STRING__Int`(I)),inj{Int,KItem}(I)))),DotVar0) requires `_==Int__INT-COMMON__Int_Int`(I,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(18) org.kframework.attributes.Location(Location(18,8,20,23)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(VarI:SortInt{}),VarCmds:SortPgm{})),dotk{}())),Lbl'-LT-'m'-GT-'{}(VarM:SortMap{})),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(VarCmds:SortPgm{}),dotk{}())),Lbl'-LT-'m'-GT-'{}(Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(VarM:SortMap{},inj{SortString{}, SortKItem{}}(LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{})),inj{SortInt{}, SortKItem{}}(VarI:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("18"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(18,8,20,23)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`_;__TEST__Cmd_Pgm`(`makeMap(_)_TEST__Int`(I),Cmds))),`<m>`(M)),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`_;__TEST__Cmd_Pgm`(`makeMap(_)_TEST__Int`(`_-Int__INT-COMMON__Int_Int`(I,#token("1","Int"))),Cmds))),`<m>`(`_[_<-_]_MAP__Map_KItem_KItem`(M,inj{String,KItem}(`Int2String(_)_STRING__Int`(I)),inj{Int,KItem}(I)))),DotVar0) requires `_>Int__INT-COMMON__Int_Int`(I,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(21) org.kframework.attributes.Location(Location(21,8,23,22)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \equals{SortBool{},SortGeneratedTopCell{}}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(VarI:SortInt{}),VarCmds:SortPgm{})),dotk{}())),Lbl'-LT-'m'-GT-'{}(VarM:SortMap{})),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(LblmakeMap'LParUndsRParUnds'TEST'UndsUnds'Int{}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},\dv{SortInt{}}("1"))),VarCmds:SortPgm{})),dotk{}())),Lbl'-LT-'m'-GT-'{}(Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'MAP'UndsUnds'Map'Unds'KItem'Unds'KItem{}(VarM:SortMap{},inj{SortString{}, SortKItem{}}(LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{})),inj{SortInt{}, SortKItem{}}(VarI:SortInt{})))),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("21"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(21,8,23,22)")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`_;__TEST__Cmd_Pgm`(`ret(_)_TEST__Int`(I),Cmds))),`<m>`(M) #as _7),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(`Map:lookup`(M,inj{String,KItem}(`Int2String(_)_STRING__Int`(I)))),_7),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(25) org.kframework.attributes.Location(Location(25,8,26,22)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+      \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lbl'UndsSClnUndsUnds'TEST'UndsUnds'Cmd'Unds'Pgm{}(Lblret'LParUndsRParUnds'TEST'UndsUnds'Int{}(VarI:SortInt{}),VarCmds:SortPgm{})),dotk{}())),\and{SortMCell{}}(Lbl'-LT-'m'-GT-'{}(VarM:SortMap{}),Var'Unds'7:SortMCell{})),VarDotVar0:SortGeneratedCounterCell{})), \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(LblMap'Coln'lookup{}(VarM:SortMap{},inj{SortString{}, SortKItem{}}(LblInt2String'LParUndsRParUnds'STRING'UndsUnds'Int{}(VarI:SortInt{}))),dotk{}())),Var'Unds'7:SortMCell{}),VarDotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("25"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(25,8,26,22)")]
+
+// rule `_<=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(595) org.kframework.attributes.Location(Location(595,8,595,63)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("595"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(595,8,595,63)")]
+
+// rule `_=/=Bool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(358) org.kframework.attributes.Location(Location(358,8,358,57)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("358"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,8,358,57)")]
+
+// rule `_=/=Int__INT-COMMON__Int_Int`(I1,I2)=>`notBool_`(`_==Int__INT-COMMON__Int_Int`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(451) org.kframework.attributes.Location(Location(451,8,451,53)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("451"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(451,8,451,53)")]
+
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(822) org.kframework.attributes.Location(Location(822,8,822,45)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("822"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,8,822,45)")]
+
+// rule `_=/=String__STRING__String_String`(S1,S2)=>`notBool_`(`_==String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(582) org.kframework.attributes.Location(Location(582,8,582,65)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("582"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(582,8,582,65)")]
+
+// rule `_==Bool__BOOL__Bool_Bool`(K1,K2)=>`_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(824) org.kframework.attributes.Location(Location(824,8,824,43)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK1:SortBool{},VarK2:SortBool{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK1:SortBool{}),dotk{}()),kseq{}(inj{SortBool{}, SortKItem{}}(VarK2:SortBool{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("824"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(824,8,824,43)")]
+
+// rule `_==Int__INT-COMMON__Int_Int`(I1,I2)=>`_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(450) org.kframework.attributes.Location(Location(450,8,450,40)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarI1:SortInt{}),dotk{}()),kseq{}(inj{SortInt{}, SortKItem{}}(VarI2:SortInt{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("450"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(450,8,450,40)")]
+
+// rule `_==String__STRING__String_String`(S1,S2)=>`_==K_`(inj{String,KItem}(S1),inj{String,KItem}(S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(583) org.kframework.attributes.Location(Location(583,8,583,49)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'UndsEqlsEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'UndsEqlsEqls'K'Unds'{}(kseq{}(inj{SortString{}, SortKItem{}}(VarS1:SortString{}),dotk{}()),kseq{}(inj{SortString{}, SortKItem{}}(VarS2:SortString{}),dotk{}()))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("583"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(583,8,583,49)")]
+
+// rule `_>=String__STRING__String_String`(S1,S2)=>`notBool_`(`_<String__STRING__String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(597) org.kframework.attributes.Location(Location(597,8,597,63)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("597"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(597,8,597,63)")]
+
+// rule `_>String__STRING__String_String`(S1,S2)=>`_<String__STRING__String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(596) org.kframework.attributes.Location(Location(596,8,596,52)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds-GT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        Lbl'Unds-LT-'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("596"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(596,8,596,52)")]
+
+// rule `_andBool_`(#token("false","Bool") #as _2,_0)=>_2 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(330) org.kframework.attributes.Location(Location(330,8,330,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'2:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'2:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("330"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(330,8,330,37)")]
+
+// rule `_andBool_`(#token("true","Bool") #as _1,B)=>B requires _1 ensures _1 [contentStartColumn(8) contentStartLine(328) org.kframework.attributes.Location(Location(328,8,328,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("328"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(328,8,328,37)")]
+
+// rule `_andBool_`(B,#token("true","Bool") #as _1)=>B requires _1 ensures _1 [contentStartColumn(8) contentStartLine(329) org.kframework.attributes.Location(Location(329,8,329,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(VarB:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("329"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(329,8,329,37)")]
+
+// rule `_andBool_`(_0,#token("false","Bool") #as _2)=>_2 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(331) org.kframework.attributes.Location(Location(331,8,331,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andBool'Unds'{}(Var'Unds'0:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'2:SortBool{})),
+        Var'Unds'2:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("331"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(331,8,331,37)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("false","Bool") #as _2,_0)=>_2 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(335) org.kframework.attributes.Location(Location(335,8,335,36)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'2:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'2:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("335"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(335,8,335,36)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(#token("true","Bool") #as _1,K)=>K requires _1 ensures _1 [contentStartColumn(8) contentStartLine(333) org.kframework.attributes.Location(Location(333,8,333,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{}),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("333"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,8,333,37)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(K,#token("true","Bool") #as _1)=>K requires _1 ensures _1 [contentStartColumn(8) contentStartLine(334) org.kframework.attributes.Location(Location(334,8,334,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})),
+        VarK:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("334"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,8,334,37)")]
+
+// rule `_andThenBool__BOOL__Bool_Bool`(_0,#token("false","Bool") #as _2)=>_2 requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(336) org.kframework.attributes.Location(Location(336,8,336,36)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'andThenBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'2:SortBool{})),
+        Var'Unds'2:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("336"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,8,336,36)")]
+
+// rule `_divInt__INT-COMMON__Int_Int`(I1,I2)=>`_/Int__INT-COMMON__Int_Int`(`_-Int__INT-COMMON__Int_Int`(I1,`_modInt__INT-COMMON__Int_Int`(I1,I2)),I2) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(439) org.kframework.attributes.Location(Location(439,8,440,23)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'divInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsSlsh'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("439"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(439,8,440,23)")]
+
+// rule `_dividesInt__INT-COMMON__Int_Int`(I1,I2)=>`_==Int__INT-COMMON__Int_Int`(`_%Int__INT-COMMON__Int_Int`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(452) org.kframework.attributes.Location(Location(452,8,452,58)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("452"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(452,8,452,58)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("true","Bool") #as _1,B)=>B requires _1 ensures _1 [contentStartColumn(8) contentStartLine(353) org.kframework.attributes.Location(Location(353,8,353,36)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{}),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("353"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(353,8,353,36)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(356) org.kframework.attributes.Location(Location(356,8,356,45)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        LblnotBool'Unds'{}(VarB:SortBool{})),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("356"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(356,8,356,45)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(_0,#token("true","Bool") #as _2)=>_2 requires _2 ensures _2 [contentStartColumn(8) contentStartLine(355) org.kframework.attributes.Location(Location(355,8,355,39)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{})),
+        Var'Unds'2:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("355"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(355,8,355,39)")]
+
+// rule `_impliesBool__BOOL__Bool_Bool`(#token("false","Bool"),_0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(354) org.kframework.attributes.Location(Location(354,8,354,40)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'impliesBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),Var'Unds'0:SortBool{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("354"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,8,354,40)")]
+
+// rule `_modInt__INT-COMMON__Int_Int`(I1,I2)=>`_%Int__INT-COMMON__Int_Int`(`_+Int_`(`_%Int__INT-COMMON__Int_Int`(I1,`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)),`absInt(_)_INT-COMMON__Int`(I2)) requires `_=/=Int__INT-COMMON__Int_Int`(I2,#token("0","Int")) ensures #token("true","Bool") [concrete() contentStartColumn(5) contentStartLine(442) org.kframework.attributes.Location(Location(442,5,445,23)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'UndsUnds'Int{}(VarI2:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), concrete{}(), contentStartLine{}("442"), contentStartColumn{}("5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(442,5,445,23)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("true","Bool") #as _2,_0)=>_2 requires _2 ensures _2 [contentStartColumn(8) contentStartLine(343) org.kframework.attributes.Location(Location(343,8,343,34)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'2:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("343"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(343,8,343,34)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(346) org.kframework.attributes.Location(Location(346,8,346,32)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("346"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(346,8,346,32)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(_0,#token("true","Bool") #as _2)=>_2 requires _2 ensures _2 [contentStartColumn(8) contentStartLine(344) org.kframework.attributes.Location(Location(344,8,344,34)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{})),
+        Var'Unds'2:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("344"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(344,8,344,34)")]
+
+// rule `_orBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(345) org.kframework.attributes.Location(Location(345,8,345,32)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("345"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,8,345,32)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("true","Bool") #as _2,_0)=>_2 requires _2 ensures _2 [contentStartColumn(8) contentStartLine(348) org.kframework.attributes.Location(Location(348,8,348,33)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{}),Var'Unds'0:SortBool{}),
+        Var'Unds'2:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("348"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,8,348,33)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(351) org.kframework.attributes.Location(Location(351,8,351,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarK:SortBool{},\dv{SortBool{}}("false")),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("351"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(351,8,351,37)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(_0,#token("true","Bool") #as _2)=>_2 requires _2 ensures _2 [contentStartColumn(8) contentStartLine(349) org.kframework.attributes.Location(Location(349,8,349,33)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(Var'Unds'0:SortBool{},\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'2:SortBool{})),
+        Var'Unds'2:SortBool{}),
+      \equals{SortBool{},R}(
+        Var'Unds'2:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("349"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,8,349,33)")]
+
+// rule `_orElseBool__BOOL__Bool_Bool`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(350) org.kframework.attributes.Location(Location(350,8,350,37)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'orElseBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarK:SortBool{}),
+        VarK:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("350"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(350,8,350,37)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(340) org.kframework.attributes.Location(Location(340,8,340,38)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},VarB:SortBool{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("340"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(340,8,340,38)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(339) org.kframework.attributes.Location(Location(339,8,339,38)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB:SortBool{},\dv{SortBool{}}("false")),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("339"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,8,339,38)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(B1,B2)=>`notBool_`(`_==Bool__BOOL__Bool_Bool`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(341) org.kframework.attributes.Location(Location(341,8,341,57)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}),
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(VarB1:SortBool{},VarB2:SortBool{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("341"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,8,341,57)")]
+
+// rule `_xorBool__BOOL__Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(338) org.kframework.attributes.Location(Location(338,8,338,38)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lbl'Unds'xorBool'UndsUnds'BOOL'UndsUnds'Bool'Unds'Bool{}(\dv{SortBool{}}("false"),VarB:SortBool{}),
+        VarB:SortBool{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("338"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(338,8,338,38)")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_modInt__INT-COMMON__Int_Int`(`_>>Int__INT-COMMON__Int_Int`(I,IDX),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(435) org.kframework.attributes.Location(Location(435,8,435,85)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds-GT--GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("435"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(435,8,435,85)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING__String`(ToCount)),`lengthString(_)_STRING__String`(Source)),ToCount)) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(606) org.kframework.attributes.Location(Location(606,8,607,60)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToCount:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("606"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(606,8,607,60)")]
+
+// rule `countAllOccurrences(_,_)_STRING__String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(604) org.kframework.attributes.Location(Location(604,8,605,59)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToCount:SortString{}),
+        \dv{SortInt{}}("0")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("604"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(604,8,605,59)")]
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL__Bool_K_K`(`_==Int__INT-COMMON__Int_Int`(`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)))) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(599) org.kframework.attributes.Location(Location(599,8,599,431)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL'UndsUnds'Bool'Unds'K'Unds'K{SortInt{}}(Lbl'UndsEqlsEqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("599"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(599,8,599,431)")]
+
+// rule `findChar(_,_,_)_STRING__String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(600) org.kframework.attributes.Location(Location(600,8,600,32)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'0:SortString{},\dv{SortString{}}(""),Var'Unds'1:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("600"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(600,8,600,32)")]
+
+// rule `freshInt(_)_INT__Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(455) org.kframework.attributes.Location(Location(455,8,455,28)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblfreshInt'LParUndsRParUnds'INT'UndsUnds'Int{}(VarI:SortInt{}),
+        VarI:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("455"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(455,8,455,28)")]
+
+// rule getGeneratedCounterCell(`<generatedTop>`(DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblgetGeneratedCounterCell{}(Lbl'-LT-'generatedTop'-GT-'{}(VarDotVar0:SortTCell{},VarCell:SortGeneratedCounterCell{})),
+        VarCell:SortGeneratedCounterCell{}),
+      \top{R}()))
+  []
+
+// rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedCounterCell{},R} (
+        LblinitGeneratedCounterCell{}(),
+        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule initGeneratedTopCell(Init)=>`<generatedTop>`(initTCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortGeneratedTopCell{},R} (
+        LblinitGeneratedTopCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'generatedTop'-GT-'{}(LblinitTCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule initKCell(Init)=>`<k>`(inj{Pgm,KItem}(`project:Pgm`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))))) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        LblinitKCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblproject'Coln'Pgm{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),dotk{}()))),
+      \top{R}()))
+  [initializer{}()]
+
+// rule initMCell(.KList)=>`<m>`(`.Map`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortMCell{},R} (
+        LblinitMCell{}(),
+        Lbl'-LT-'m'-GT-'{}(Lbl'Stop'Map{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule initTCell(Init)=>`<T>`(initKCell(Init),initMCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortTCell{},R} (
+        LblinitTCell{}(VarInit:SortMap{}),
+        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitMCell{}())),
+      \top{R}()))
+  [initializer{}()]
+
+// rule `is#KVariable`(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:Sort'Hash'KVariable{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Unds'1:Sort'Hash'KVariable{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule `is#KVariable`(inj{#KVariable,KItem}(#KVariable))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblis'Hash'KVariable{}(kseq{}(inj{Sort'Hash'KVariable{}, SortKItem{}}(Var'Hash'KVariable:Sort'Hash'KVariable{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortBool{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'0:SortBool{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisBool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarBool:SortBool{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortCell{}, SortKItem{}}(Var'Unds'1:SortCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isCell(inj{Cell,KItem}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isCmd(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortCmd{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortCmd{}, SortKItem{}}(Var'Unds'1:SortCmd{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCmd{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isCmd(inj{Cmd,KItem}(Cmd))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisCmd{}(kseq{}(inj{SortCmd{}, SortKItem{}}(VarCmd:SortCmd{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortFloat{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortFloat{}, SortKItem{}}(Var'Unds'1:SortFloat{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisFloat{}(kseq{}(inj{SortFloat{}, SortKItem{}}(VarFloat:SortFloat{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedCounterCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'0:SortGeneratedCounterCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCell{}(kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(VarGeneratedCounterCell:SortGeneratedCounterCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedCounterCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'0:SortGeneratedCounterCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedCounterCellOpt{}(kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(VarGeneratedCounterCellOpt:SortGeneratedCounterCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortGeneratedTopCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(Var'Unds'1:SortGeneratedTopCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCell{}(kseq{}(inj{SortGeneratedTopCell{}, SortKItem{}}(VarGeneratedTopCell:SortGeneratedTopCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortGeneratedTopCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(Var'Unds'0:SortGeneratedTopCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisGeneratedTopCellFragment{}(kseq{}(inj{SortGeneratedTopCellFragment{}, SortKItem{}}(VarGeneratedTopCellFragment:SortGeneratedTopCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortInt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'0:SortInt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisInt{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarInt:SortInt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisK{}(VarK:SortK{}),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCell{}, SortKItem{}}(Var'Unds'1:SortKCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarKCell:SortKCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'1:SortKCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarKCellOpt:SortKCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKConfigVar{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKConfigVar{}, SortKItem{}}(Var'Unds'1:SortKConfigVar{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKConfigVar{}(kseq{}(inj{SortKConfigVar{}, SortKItem{}}(VarKConfigVar:SortKConfigVar{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortKItem{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(Var'Unds'0:SortKItem{},dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKItem{}(kseq{}(VarKItem:SortKItem{},dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortKResult{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortKResult{}, SortKItem{}}(Var'Unds'1:SortKResult{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isKResult(inj{KResult,KItem}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisKResult{}(kseq{}(inj{SortKResult{}, SortKItem{}}(VarKResult:SortKResult{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortList{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortList{}, SortKItem{}}(Var'Unds'0:SortList{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisList{}(kseq{}(inj{SortList{}, SortKItem{}}(VarList:SortList{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isMCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortMCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMCell{}, SortKItem{}}(Var'Unds'1:SortMCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isMCell(inj{MCell,KItem}(MCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMCell{}(kseq{}(inj{SortMCell{}, SortKItem{}}(VarMCell:SortMCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isMCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortMCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMCellOpt{}, SortKItem{}}(Var'Unds'1:SortMCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isMCellOpt(inj{MCellOpt,KItem}(MCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMCellOpt{}(kseq{}(inj{SortMCellOpt{}, SortKItem{}}(VarMCellOpt:SortMCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortMap{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortMap{}, SortKItem{}}(Var'Unds'1:SortMap{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisMap{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarMap:SortMap{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isPgm(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortPgm{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortPgm{}, SortKItem{}}(Var'Unds'0:SortPgm{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisPgm{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isPgm(inj{Pgm,KItem}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisPgm{}(kseq{}(inj{SortPgm{}, SortKItem{}}(VarPgm:SortPgm{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortSet{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'1:SortSet{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisSet{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarSet:SortSet{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortString{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortString{}, SortKItem{}}(Var'Unds'1:SortString{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisString{}(kseq{}(inj{SortString{}, SortKItem{}}(VarString:SortString{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isTCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortTCell{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCell{}, SortKItem{}}(Var'Unds'1:SortTCell{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCell{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCell(inj{TCell,KItem}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCell{}(kseq{}(inj{SortTCell{}, SortKItem{}}(VarTCell:SortTCell{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isTCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'1:SortTCellFragment{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCellFragment{}, SortKItem{}}(Var'Unds'1:SortTCellFragment{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCellFragment(inj{TCellFragment,KItem}(TCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellFragment{}(kseq{}(inj{SortTCellFragment{}, SortKItem{}}(VarTCellFragment:SortTCellFragment{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule isTCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise()]
+  axiom{R} \implies{R} (
+    \and{R} (
+      \not{R} (
+        \or{R} (
+          \exists{R} (Var'Unds'0:SortTCellOpt{},
+            \and{R} (
+              \top{R}(),
+              \and{R} (
+                \ceil{SortK{}, R} (
+                  \and{SortK{}} (
+                    VarK:SortK{},
+                    kseq{}(inj{SortTCellOpt{}, SortKItem{}}(Var'Unds'0:SortTCellOpt{}),dotk{}())
+                )),
+                \top{R} ()
+              )
+          )),
+          \bottom{R}()
+        )
+      ),
+      \top{R}()
+    ),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellOpt{}(VarK:SortK{}),
+        \dv{SortBool{}}("false")),
+      \top{R}()))
+  [owise{}()]
+
+// rule isTCellOpt(inj{TCellOpt,KItem}(TCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") []
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblisTCellOpt{}(kseq{}(inj{SortTCellOpt{}, SortKItem{}}(VarTCellOpt:SortTCellOpt{}),dotk{}())),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  []
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I1 requires `_<=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(447) org.kframework.attributes.Location(Location(447,8,447,57)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI1:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("447"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(447,8,447,57)")]
+
+// rule `minInt(_,_)_INT-COMMON__Int_Int`(I1,I2)=>I2 requires `_>=Int__INT-COMMON__Int_Int`(I1,I2) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(448) org.kframework.attributes.Location(Location(448,8,448,57)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarI1:SortInt{},VarI2:SortInt{}),
+        VarI2:SortInt{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("448"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(448,8,448,57)")]
+
+// rule `notBool_`(#token("true","Bool") #as _1)=>#token("false","Bool") requires _1 ensures _1 [contentStartColumn(8) contentStartLine(325) org.kframework.attributes.Location(Location(325,8,325,29)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})),
+        \dv{SortBool{}}("false")),
+      \equals{SortBool{},R}(
+        Var'Unds'1:SortBool{},
+        \dv{SortBool{}}("true"))))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("325"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(325,8,325,29)")]
+
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(326) org.kframework.attributes.Location(Location(326,8,326,29)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        LblnotBool'Unds'{}(\dv{SortBool{}}("false")),
+        \dv{SortBool{}}("true")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("326"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(326,8,326,29)")]
+
+// rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortBool{},R} (
+        Lblproject'Coln'Bool{}(kseq{}(inj{SortBool{}, SortKItem{}}(VarK:SortBool{}),dotk{}())),
+        VarK:SortBool{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Cell`(inj{Cell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortCell{},R} (
+        Lblproject'Coln'Cell{}(kseq{}(inj{SortCell{}, SortKItem{}}(VarK:SortCell{}),dotk{}())),
+        VarK:SortCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Cmd`(inj{Cmd,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortCmd{},R} (
+        Lblproject'Coln'Cmd{}(kseq{}(inj{SortCmd{}, SortKItem{}}(VarK:SortCmd{}),dotk{}())),
+        VarK:SortCmd{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortFloat{},R} (
+        Lblproject'Coln'Float{}(kseq{}(inj{SortFloat{}, SortKItem{}}(VarK:SortFloat{}),dotk{}())),
+        VarK:SortFloat{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        Lblproject'Coln'Int{}(kseq{}(inj{SortInt{}, SortKItem{}}(VarK:SortInt{}),dotk{}())),
+        VarK:SortInt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCell{},R} (
+        Lblproject'Coln'KCell{}(kseq{}(inj{SortKCell{}, SortKItem{}}(VarK:SortKCell{}),dotk{}())),
+        VarK:SortKCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKCellOpt{},R} (
+        Lblproject'Coln'KCellOpt{}(kseq{}(inj{SortKCellOpt{}, SortKItem{}}(VarK:SortKCellOpt{}),dotk{}())),
+        VarK:SortKCellOpt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:KResult`(inj{KResult,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortKResult{},R} (
+        Lblproject'Coln'KResult{}(kseq{}(inj{SortKResult{}, SortKItem{}}(VarK:SortKResult{}),dotk{}())),
+        VarK:SortKResult{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortList{},R} (
+        Lblproject'Coln'List{}(kseq{}(inj{SortList{}, SortKItem{}}(VarK:SortList{}),dotk{}())),
+        VarK:SortList{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:MCell`(inj{MCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortMCell{},R} (
+        Lblproject'Coln'MCell{}(kseq{}(inj{SortMCell{}, SortKItem{}}(VarK:SortMCell{}),dotk{}())),
+        VarK:SortMCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:MCellOpt`(inj{MCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortMCellOpt{},R} (
+        Lblproject'Coln'MCellOpt{}(kseq{}(inj{SortMCellOpt{}, SortKItem{}}(VarK:SortMCellOpt{}),dotk{}())),
+        VarK:SortMCellOpt{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortMap{},R} (
+        Lblproject'Coln'Map{}(kseq{}(inj{SortMap{}, SortKItem{}}(VarK:SortMap{}),dotk{}())),
+        VarK:SortMap{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Pgm`(inj{Pgm,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortPgm{},R} (
+        Lblproject'Coln'Pgm{}(kseq{}(inj{SortPgm{}, SortKItem{}}(VarK:SortPgm{}),dotk{}())),
+        VarK:SortPgm{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortSet{},R} (
+        Lblproject'Coln'Set{}(kseq{}(inj{SortSet{}, SortKItem{}}(VarK:SortSet{}),dotk{}())),
+        VarK:SortSet{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblproject'Coln'String{}(kseq{}(inj{SortString{}, SortKItem{}}(VarK:SortString{}),dotk{}())),
+        VarK:SortString{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:TCell`(inj{TCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortTCell{},R} (
+        Lblproject'Coln'TCell{}(kseq{}(inj{SortTCell{}, SortKItem{}}(VarK:SortTCell{}),dotk{}())),
+        VarK:SortTCell{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `project:TCellFragment`(inj{TCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection()]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortTCellFragment{},R} (
+        Lblproject'Coln'TCellFragment{}(kseq{}(inj{SortTCellFragment{}, SortKItem{}}(VarK:SortTCellFragment{}),dotk{}())),
+        VarK:SortTCellFragment{}),
+      \top{R}()))
+  [projection{}()]
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING__String_String_String_Int`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source)),ToReplace,Replacement,`_-Int__INT-COMMON__Int_Int`(Count,#token("1","Int")))) requires `_>Int__INT-COMMON__Int_Int`(Count,#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(616) org.kframework.attributes.Location(Location(616,8,619,30)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},VarCount:SortInt{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarCount:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("616"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(616,8,619,30)")]
+
+// rule `replace(_,_,_,_)_STRING__String_String_String_Int`(Source,_0,_1,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(620) org.kframework.attributes.Location(Location(620,8,620,49)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},Var'Unds'0:SortString{},Var'Unds'1:SortString{},\dv{SortInt{}}("0")),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("620"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(620,8,620,49)")]
+
+// rule `replaceAll(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING__String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING__String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(621) org.kframework.attributes.Location(Location(621,8,621,154)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("621"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(621,8,621,154)")]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING__String_String`(`_+String__STRING__String_String`(`substrString(_,_,_)_STRING__String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING__String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING__String`(ToReplace)),`lengthString(_)_STRING__String`(Source))) requires `_>=Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(609) org.kframework.attributes.Location(Location(609,8,611,66)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-GT-Eqls'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{}),
+        Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarSource:SortString{})))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("609"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(609,8,611,66)")]
+
+// rule `replaceFirst(_,_,_)_STRING__String_String_String`(Source,ToReplace,_0)=>Source requires `_<Int__INT-COMMON__Int_Int`(`findString(_,_,_)_STRING__String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(612) org.kframework.attributes.Location(Location(612,8,613,57)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'Unds-LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),\dv{SortInt{}}("0")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortString{},R} (
+        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{},Var'Unds'0:SortString{}),
+        VarSource:SortString{}),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("612"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(612,8,613,57)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON__Int_Int`(`rfindString(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING__String_String_Int`(S1,`substrString(_,_,_)_STRING__String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING__String`(S2)),I)) requires `_=/=String__STRING__String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(601) org.kframework.attributes.Location(Location(601,8,601,182)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires) symbol()])]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
+        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING'UndsUnds'String'Unds'String{}(VarS2:SortString{},\dv{SortString{}}("")),
+        \dv{SortBool{}}("true")),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},VarS2:SortString{},VarI:SortInt{}),
+        LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING'UndsUnds'String{}(VarS2:SortString{})),VarI:SortInt{}))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires) symbol()]"), contentStartLine{}("601"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(601,8,601,182)")]
+
+// rule `rfindChar(_,_,_)_STRING__String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(602) org.kframework.attributes.Location(Location(602,8,602,33)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING'UndsUnds'String'Unds'String'Unds'Int{}(Var'Unds'0:SortString{},\dv{SortString{}}(""),Var'Unds'1:SortInt{}),
+        \dv{SortInt{}}("-1")),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("602"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(602,8,602,33)")]
+
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN)=>`_-Int__INT-COMMON__Int_Int`(`_modInt__INT-COMMON__Int_Int`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON__Int_Int_Int`(I,IDX,LEN),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),LEN)),`_<<Int__INT-COMMON__Int_Int`(#token("1","Int"),`_-Int__INT-COMMON__Int_Int`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [contentStartColumn(8) contentStartLine(437) org.kframework.attributes.Location(Location(437,8,437,164)) org.kframework.attributes.Source(Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)) org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()])]
+  axiom{R} \implies{R} (
+    \top{R}(),
+    \and{R} (
+      \equals{SortInt{},R} (
+        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),
+        Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'Unds'modInt'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'UndsUnds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'UndsUnds'INT-COMMON'UndsUnds'Int'Unds'Int{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
+      \top{R}()))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/evm-semantics/deps/k/k-distribution/target/release/k/include/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions) symbol()]"), contentStartLine{}("437"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(437,8,437,164)")]
+
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1,1,29,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/ubuntu/builds/llvm-backend/./alwaysgc-test.k)")]


### PR DESCRIPTION
This PR eliminates allocations in the not collected arena for sret paremeters of llvm functions generated by the backend. Instead, a new arena is introduced that is always fully collected in every collection and the sret parameters are allocated there when needed. This is OK, since these allocations are not supposed to to be live between steps.

Addresses #45