### PR TITLE
remove spurious phi nodes

### DIFF
--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -34,6 +34,14 @@ void Decision::operator()(DecisionNode *entry, llvm::StringMap<llvm::Value *> su
       }
     }
   }
+  for (auto block = this->CurrentBlock->getParent()->begin(); block != this->CurrentBlock->getParent()->end(); ++block) {
+    if (block->getUniquePredecessor()) {
+      for (auto phi = block->phis().begin(); phi != block->phis().end(); phi = block->phis().begin()) {
+        phi->replaceAllUsesWith(phi->getIncomingValue(0));
+	phi->removeFromParent();
+      }
+    }
+  }
 }
 
 std::set<std::string> DecisionNode::collectVars() {

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -27,7 +27,7 @@ void Decision::operator()(DecisionNode *entry, llvm::StringMap<llvm::Value *> su
       for (llvm::BasicBlock *block : llvm::predecessors(Phi->getParent())) {
         if (Phi->getBasicBlockIndex(block) == -1) {
           undefBlocks.push_back(block);
-	}
+        }
       }
       for (llvm::BasicBlock *block : undefBlocks) {
         Phi->addIncoming(llvm::UndefValue::get(Phi->getType()), block);
@@ -38,7 +38,7 @@ void Decision::operator()(DecisionNode *entry, llvm::StringMap<llvm::Value *> su
     if (block->getUniquePredecessor()) {
       for (auto phi = block->phis().begin(); phi != block->phis().end(); phi = block->phis().begin()) {
         phi->replaceAllUsesWith(phi->getIncomingValue(0));
-	phi->removeFromParent();
+        phi->removeFromParent();
       }
     }
   }


### PR DESCRIPTION
Don't generate phi nodes for basic blocks with only a single predecessor.