### PR TITLE
update tree_stats

### DIFF
--- a/matching/tree_stats.py
+++ b/matching/tree_stats.py
@@ -2,39 +2,66 @@
 
 import yaml
 import sys
+from yaml import CLoader as Loader
 
 node_count = 0
 node_depth = 0
-num_actions = 9
+num_actions = 0
 sum_depth = 0
 
-def count_nodes(data, depth):
-  global node_count, node_depth, sum_depth, num_actions
-  node_count += 1
-  if node_depth < depth:
-    node_depth = depth
-  if isinstance(data, dict):
-    if "next" in data:
-      count_nodes(data["next"], depth+1)
-    elif "specializations" in data:
-      for case in data["specializations"]:
-        count_nodes(case[1], depth+1)
-      count_nodes(data["default"], depth+1)
-    elif "action" in data:
-      num_actions += 1
-      sum_depth += depth
-  elif data == "fail" or data == None: pass
-  else:
-    print(type(data))
-    raise AssertionError
-  
+blank_result  = {"count": 0, "shared_count": 0, "max_depth": 0, "num_actions": 0, "sum_depth": 0}
+leaf_result   = {"count": 0, "shared_count": 0, "max_depth": 1, "num_actions": 0, "sum_depth": 0}
+action_result = {"count": 1, "shared_count": 1, "max_depth": 1, "num_actions": 1, "sum_depth": 1}
+
+def count_nodes_shared(data):
+    if isinstance(data, dict):
+      if "result" in data:
+        result = dict(data["result"])
+        result["shared_count"] = 0
+        return result
+      if "next" in data:
+        result = dict(count_nodes_shared(data["next"]))
+        result["count"] += 1
+        result["shared_count"] += 1
+        result["max_depth"] += 1
+        result["sum_depth"] += result["num_actions"]
+        data["result"] = result
+        return result
+      elif "specializations" in data:
+        result = dict(blank_result)
+        for case in data["specializations"]:
+          case_result = count_nodes_shared(case[1])
+          result["count"] += case_result["count"]
+          result["shared_count"] += case_result["shared_count"]
+          result["max_depth"] = max(case_result["max_depth"] + 1, result["max_depth"])
+          result["num_actions"] += case_result["num_actions"]
+          result["sum_depth"] += case_result["sum_depth"] + case_result["num_actions"]
+        case_result = count_nodes_shared(data["default"])
+        result["count"] += case_result["count"] + 1
+        result["shared_count"] += case_result["shared_count"] + 1
+        result["max_depth"] = max(case_result["max_depth"] + 1, result["max_depth"])
+        result["num_actions"] += case_result["num_actions"]
+        result["sum_depth"] += case_result["sum_depth"] + case_result["num_actions"]
+        data["result"] = result
+        return result
+      elif "action" in data:
+        data["result"] = action_result
+        return action_result
+    elif data == "fail":
+      return leaf_result
+    elif data == None:
+      return blank_result
+    else:
+      print(type(data))
+      raise AssertionError
 
 with open(sys.argv[1], 'r') as stream:
   try:
-    doc = yaml.safe_load(stream)
-    count_nodes(doc, 1)
-    print("Size: " + str(node_count))
-    print("Max path length: " + str(node_depth))
-    print("Average path length: " + str(sum_depth / num_actions))
+    doc = yaml.load(stream, Loader=Loader)
+    result = count_nodes_shared(doc)
+    print("Size: " + "{:,}".format(result["count"]))
+    print("Shared size: " + "{:,}".format(result["shared_count"]))
+    print("Max path length: " + str(result["max_depth"]))
+    print("Average path length: " + str(result["sum_depth"] / result["num_actions"]))
   except yaml.YAMLError as exc:
     print(exc)


### PR DESCRIPTION
We now compute everything much faster in large trees with lots of sharing, and we also compute the shared size (ie, not counting shared nodes more than once). We also don't count failure nodes in the size.