### PR TITLE
use reflection and annotations to give heuristics names

### DIFF
--- a/matching/src/main/java/org/kframework/backend/llvm/matching/NamedHeuristic.java
+++ b/matching/src/main/java/org/kframework/backend/llvm/matching/NamedHeuristic.java
@@ -1,0 +1,12 @@
+package org.kframework.backend.llvm.matching;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@interface NamedHeuristic {
+  public char name();
+}

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Heuristics.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Heuristics.scala
@@ -44,6 +44,7 @@ object Heuristic {
   }
 }
 
+@NamedHeuristic(name='_')
 object DefaultHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -101,6 +102,7 @@ object DefaultHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='f')
 object FHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -116,6 +118,7 @@ object FHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='d')
 object DHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -124,6 +127,7 @@ object DHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='b')
 object BHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -137,6 +141,7 @@ object BHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='a')
 object AHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -149,6 +154,7 @@ object AHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='l')
 object LHeuristic extends Heuristic {
   val needsMatrix: Boolean = true
 
@@ -175,6 +181,7 @@ object LHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='r')
 object RHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -201,6 +208,7 @@ object RHeuristic extends Heuristic {
   }
 }
 
+@NamedHeuristic(name='q')
 object QHeuristic extends Heuristic {
   val needsMatrix: Boolean = false
 
@@ -228,17 +236,21 @@ sealed trait PseudoHeuristic extends Heuristic {
   def computeScoreForKey(c: AbstractColumn, key: Option[Pattern[Option[Occurrence]]]): Double = 0.0
 }
 
+@NamedHeuristic(name='N')
 object NPseudoHeuristic extends PseudoHeuristic {
   override def breakTies(cols: Seq[MatrixColumn]): MatrixColumn = {
     cols(0)
   }
 }
 
+@NamedHeuristic(name='L')
 object LPseudoHeuristic extends PseudoHeuristic {
   override def breakTies(cols: Seq[MatrixColumn]): MatrixColumn = {
     cols.minBy(_.column.fringe.occurrence.size)
   }
 }
+
+@NamedHeuristic(name='R')
 object RPseudoHeuristic extends PseudoHeuristic {
   override def breakTies(cols: Seq[MatrixColumn]): MatrixColumn = {
     cols.reverse.minBy(_.column.fringe.occurrence.size)

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -171,20 +171,26 @@ object Parser {
     })
   }
 
+  val heuristicMap: Map[Char, Heuristic] = {
+    import scala.reflect.runtime.universe
+
+    val heuristicType = universe.typeOf[Heuristic]
+    val heuristicClass = heuristicType.typeSymbol.asClass
+    val pseudoHeuristicType = universe.typeOf[PseudoHeuristic]
+    val pseudoHeuristicClass = pseudoHeuristicType.typeSymbol.asClass
+    val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
+    val classes = heuristicClass.knownDirectSubclasses.filter(!_.asClass.isTrait) ++ pseudoHeuristicClass.knownDirectSubclasses
+    classes.map(c => {
+        val name = c.annotations.head.tree.children.tail.head.children.tail.collect({ case universe.Literal(universe.Constant(id: Char)) => id }).head
+        val symbol = c.asClass.module.asModule
+        val moduleMirror = runtimeMirror.reflectModule(symbol)
+        val obj = moduleMirror.instance.asInstanceOf[Heuristic]
+        name -> obj
+      }).toMap
+  }
+
   def parseHeuristic(heuristic: Char): Heuristic = {
-    heuristic match {
-      case 'f' => FHeuristic
-      case 'd' => DHeuristic
-      case 'b' => BHeuristic
-      case 'a' => AHeuristic
-      case 'l' => LHeuristic
-      case 'r' => RHeuristic
-      case 'q' => QHeuristic
-      case '_' => DefaultHeuristic
-      case 'N' => NPseudoHeuristic
-      case 'L' => LPseudoHeuristic
-      case 'R' => RPseudoHeuristic
-    }
+    heuristicMap(heuristic)
   }
 
   def parseHeuristics(heuristics: String): Seq[Heuristic] = {


### PR DESCRIPTION
Ready for review. We cut some corners when we're checking the reflection. Namely, we don't check that the annotation is a NamedHeuristic and we assume heuristics always have exactly one annotation, but since it's a sealed trait, this is basically fine unless we at some point need to violate those properties.

Good news is, code will now crash if you forget to give a heuristic a name.