### PR TITLE
Support llvm 7.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,16 @@
 cmake_minimum_required (VERSION 3.4)
 
 find_program(CMAKE_C_COMPILER clang-8)
+find_program(CMAKE_C_COMPILER clang-7)
 find_program(CMAKE_C_COMPILER clang)
 find_program(CMAKE_CXX_COMPILER clang++-8)
+find_program(CMAKE_CXX_COMPILER clang++-7)
 find_program(CMAKE_CXX_COMPILER clang++)
 find_program(CMAKE_C_COMPILER_AR llvm-ar-8)
+find_program(CMAKE_C_COMPILER_AR llvm-ar-7)
 find_program(CMAKE_C_COMPILER_AR llvm-ar)
 find_program(CMAKE_C_COMPILER_RANLIB llvm-ranlib-8)
+find_program(CMAKE_C_COMPILER_RANLIB llvm-ranlib-7)
 find_program(CMAKE_C_COMPILER_RANLIB llvm-ranlib)
 project (KLLVM CXX C)
 
@@ -100,8 +104,10 @@ install(
 )
 
 find_program(OPT opt-8)
+find_program(OPT opt-7)
 find_program(OPT opt)
 find_program(LLC llc-8)
+find_program(LLC llc-7)
 find_program(LLC llc)
 if(${OPT} STREQUAL "OPT-NOTFOUND")
   message(FATAL_ERROR "Could not find an opt binary. Is llvm installed on your PATH?")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,11 +58,15 @@ endif()
 set(CMAKE_AR "${CMAKE_C_COMPILER_AR}")
 set(CMAKE_RANLIB "${CMAKE_C_COMPILER_RANLIB}")
 
-find_package(LLVM 8 REQUIRED CONFIG)
+find_package(LLVM 8 QUIET CONFIG)
+
+if (NOT LLVM_FOUND)
+  find_package(LLVM 7 REQUIRED CONFIG)
+endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-if (${LLVM_PACKAGE_VERSION} VERSION_LESS 8.0)
-  message(FATAL_ERROR "LLVM 8.0 or newer is required")
+if (${LLVM_PACKAGE_VERSION} VERSION_LESS 7.0.1)
+  message(FATAL_ERROR "LLVM 7.0.1 or newer is required")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/install-rust
+++ b/install-rust
@@ -20,7 +20,7 @@ fi
 
 tar xf rustc-src.tar.gz
 cd rustc-1.34.0-src
-./configure --llvm-root=`llvm-config-8 --prefix 2>/dev/null || llvm-config --prefix` $CONFIGFLAGS
+./configure --llvm-root=`llvm-config-8 --prefix 2>/dev/null || llvm-config-7 --prefix 2>/dev/null || llvm-config --prefix` $CONFIGFLAGS
 ./x.py build
 if [[ "$OSTYPE" == "darwin"* ]]; then
   triple=x86_64-apple-darwin


### PR DESCRIPTION
It looks like the bug in llvm 7 that broke the llvm backend was fixed in llvm 7.0.1, which, while not available on Ubuntu 18.04, is available in Debian Buster, whereas llvm 8 is not. So I'm going to add support for it here.