### PR TITLE
don't pass type to LoadInst

### DIFF
--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -408,7 +408,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
       break;
     }
     case SortCategory::Int: {
-      llvm::Value *FirstChar = new llvm::LoadInst(llvm::Type::getInt8Ty(Ctx), func->arg_begin()+2, "", CaseBlock);
+      llvm::Value *FirstChar = new llvm::LoadInst(func->arg_begin()+2, "", CaseBlock);
       llvm::Constant *asciiPlus = llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), 43);
       auto icmpFirst = new llvm::ICmpInst(*CaseBlock, llvm::CmpInst::ICMP_EQ, FirstChar, asciiPlus);
       auto IfIsPlus = llvm::BasicBlock::Create(Ctx, "if_is_plus", func);


### PR DESCRIPTION
It seems the overload we were calling before exists in llvm 7 but creates a badref. Hopefully this should fix the debian build.