### PR TITLE
don't embed gdb code on Mac OS

### DIFF
--- a/runtime/configurationparser/ConfigurationPrinter.cpp
+++ b/runtime/configurationparser/ConfigurationPrinter.cpp
@@ -193,4 +193,6 @@ string *printConfigurationToString(block *subject) {
 .popsection \n\
 ");
 
+#ifndef __APPLE__
 DEFINE_GDB_PY_SCRIPT(INSTALL_PREFIX "/lib/kllvm/gdb/interpreter-gdb.py")
+#endif


### PR DESCRIPTION
GDB doesn't really work on Mac OS anyway so it doesn't help much to have this code. But it doesn't compile on Mac OS so we disable it.