### PR TITLE
fix segfault on clang 7

### DIFF
--- a/unittests/runtime-collections/lists.cpp
+++ b/unittests/runtime-collections/lists.cpp
@@ -47,9 +47,9 @@ extern "C" {
 
   void k_hash(block *, void *) {}
 
-  block D0 = {{0}, {}};
+  block D0 = {{0}};
   block * DUMMY0 = &D0;
-  block D1 = {{1}, {}};
+  block D1 = {{1}};
   block * DUMMY1 = &D1;
 }
 

--- a/unittests/runtime-collections/maps.cpp
+++ b/unittests/runtime-collections/maps.cpp
@@ -29,7 +29,7 @@ extern "C" {
   block *hook_LIST_get_long(list *, size_t);
   extern block *DUMMY0;
   extern block *DUMMY1;
-  block D2 = {{1}, {}};
+  block D2 = {{1}};
   block * DUMMY2 = &D2;
 
   size_t hash_k(block * kitem) {


### PR DESCRIPTION
Clang 7 segfaults when you try to initialize a flexible array member with a brace-init-list. I tested this fix and it fixes the segfault while also passing tests.