### PR TITLE
use koreCollect to "free" all memory

### DIFF
--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -33,6 +33,7 @@ extern "C" {
   void migrate_set(void *s);
   void migrate_collection_node(void **nodePtr);
   void setKoreMemoryFunctionsForGMP(void);
+  void koreCollect(void**, uint8_t, layoutitem *);
 }
 
 #endif // RUNTIME_COLLECT_H

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -8,7 +8,6 @@
 #include "runtime/alloc.h"
 #include "runtime/header.h"
 #include "runtime/arena.h"
-#include "runtime/collect.h"
 
 extern "C" {
 
@@ -46,10 +45,6 @@ void koreAllocSwap(bool swapOld) {
   if (swapOld) {
     arenaSwapAndClear(&oldspace);
   }
-}
-
-void freeAllKoreMem() {
-  koreCollect(nullptr, 0, nullptr);
 }
 
 void setKoreMemoryFunctionsForGMP() {

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -8,6 +8,7 @@
 #include "runtime/alloc.h"
 #include "runtime/header.h"
 #include "runtime/arena.h"
+#include "runtime/collect.h"
 
 extern "C" {
 
@@ -48,10 +49,7 @@ void koreAllocSwap(bool swapOld) {
 }
 
 void freeAllKoreMem() {
-  freeAllMemory();
-  arenaReset(&youngspace);
-  arenaReset(&oldspace);
-  arenaReset(&alwaysgcspace);
+  koreCollect(nullptr, 0, nullptr);
 }
 
 void setKoreMemoryFunctionsForGMP() {

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -282,4 +282,8 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
   is_gc = false;
 }
 
+void freeAllKoreMem() {
+  koreCollect(nullptr, 0, nullptr);
+}
+
 }


### PR DESCRIPTION
freeAllKoreMem doesn't work with the latest garbage collection algorithm because it broke the hack that allowed us to allocate the empty collections with malloc. However, freeAllKoreMem was itself essentially a hack for use in kevm-vm to get around the fact that garbage collection was not yet complete and did not collect everything. So instead, we simply call koreCollect from freeAllKoreMem with the empty list of roots. This will free everything /except/ the collection nodes implicitly reached from static variables in immer, because we still treat them as roots due to the call to migrateRoots.