### PR TITLE
KOREScanner.l: Admit @ in identifiers for set variables

### DIFF
--- a/lib/parser/KOREScanner.l
+++ b/lib/parser/KOREScanner.l
@@ -22,7 +22,7 @@ using namespace kllvm::parser;
 %option nounput
 
 /* Flex macros */
-ident [a-zA-Z][a-zA-Z0-9'-]*
+ident [@a-zA-Z][a-zA-Z0-9'-]*
 
 /* Flex extra states */
 %x COMM STR

--- a/lib/parser/KOREScanner.l
+++ b/lib/parser/KOREScanner.l
@@ -22,7 +22,7 @@ using namespace kllvm::parser;
 %option nounput
 
 /* Flex macros */
-ident [@a-zA-Z][a-zA-Z0-9'-]*
+ident @?[a-zA-Z][a-zA-Z0-9'-]*
 
 /* Flex extra states */
 %x COMM STR


### PR DESCRIPTION
In kframework/kore#922, we begin to use set variables in `prelude.kore`, which requires this small extension to the C++ Kore parser.