### PR TITLE
Generate useless clause and non exhaustive function warnings

### DIFF
--- a/matching/src/main/config/checkstyle-java.xml
+++ b/matching/src/main/config/checkstyle-java.xml
@@ -23,17 +23,16 @@
     <module name="IllegalThrows">
       <property name="illegalClassNames" value="java.lang.Exception, java.lang.Throwable" />
     </module>
-    <module name="FileContentsHolder" />
+    <module name="SuppressionCommentFilter">
+      <property name="offCommentFormat" value="DISABLE EXCEPTION CHECKSTYLE" />
+      <property name="onCommentFormat" value="ENABLE EXCEPTION CHECKSTYLE" />
+      <property name="checkFormat" value="IllegalCatch|IllegalThrows" />
+    </module>
   </module>
   <module name="FileTabCharacter" />
   <module name="RegexpMultiline">
     <property name="format" value="(?s:((\r)|([ \t\x0B\f]$)).*)" />
     <property name="message" value="File has non-Unix line endings or trailing whitespace" />
-  </module>
-  <module name="SuppressionCommentFilter">
-    <property name="offCommentFormat" value="DISABLE EXCEPTION CHECKSTYLE" />
-    <property name="onCommentFormat" value="ENABLE EXCEPTION CHECKSTYLE" />
-    <property name="checkFormat" value="IllegalCatch|IllegalThrows" />
   </module>
 <!--<module name="NewlineAtEndOfFile" />-->
 </module>

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
@@ -65,6 +65,9 @@ case class HasNoKey(isSet: Boolean, key: Option[Pattern[Option[Occurrence]]]) ex
     def element(k: Pattern[String], v: Pattern[String]): Pattern[String] = {
       SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, Seq(k, v))
     }
+    def setElement(k: Pattern[String]): Pattern[String] = {
+      SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, Seq(k))
+    }
     val unit: Pattern[String] = SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "unit").get, Seq())
     def concat(m1: Pattern[String], m2: Pattern[String]): Pattern[String] = {
       SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "concat").get, Seq(m1, m2))
@@ -73,8 +76,14 @@ case class HasNoKey(isSet: Boolean, key: Option[Pattern[Option[Occurrence]]]) ex
     child match {
       case MapP(keys, values, frame, ctr, orig) => 
         MapP(wildcard +: keys, wildcard +: values, frame, ctr, concat(element(wildcard, wildcard), orig))
+      case SetP(elems, frame, ctr, orig) => 
+        SetP(wildcard +: elems, frame, ctr, concat(setElement(wildcard), orig))
       case WildcardP() | VariableP(_, _) =>
-        MapP(Seq(wildcard), Seq(wildcard), Some(child), Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, concat(element(wildcard, wildcard), child))
+        if (isSet) {
+          SetP(Seq(wildcard), Some(child), Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, concat(setElement(wildcard), child))
+        } else {
+          MapP(Seq(wildcard), Seq(wildcard), Some(child), Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, concat(element(wildcard, wildcard), child))
+        }
     }
   }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
@@ -56,7 +56,7 @@ case class HasKey(isSet: Boolean, element: SymbolOrAlias, key: Option[Pattern[Op
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
-case class HasNoKey(key: Option[Pattern[Option[Occurrence]]]) extends Constructor {
+case class HasNoKey(isSet: Boolean, key: Option[Pattern[Option[Occurrence]]]) extends Constructor {
   def name = "0"
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean = key.isDefined && pat == key.get
   def expand(f: Fringe): Option[Seq[Fringe]] = Some(Seq(f))

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Constructor.scala
@@ -1,18 +1,26 @@
 package org.kframework.backend.llvm.matching
 
-import org.kframework.backend.llvm.matching.pattern.Pattern
+import org.kframework.backend.llvm.matching.pattern._
 import org.kframework.parser.kore.SymbolOrAlias
 
 sealed trait Constructor {
   def name: String
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean
   def expand(f: Fringe): Option[Seq[Fringe]]
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String]
 }
 
 case class Empty() extends Constructor {
   def name = "0"
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean = true
   def expand(f: Fringe): Option[Seq[Fringe]] = Some(Seq())
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = {
+    val symbol = Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "unit").get
+    f.sortInfo.category match {
+      case SetS() => SetP(Seq(), None, symbol, SymbolP(symbol, Seq()))
+      case MapS() => MapP(Seq(), Seq(), None, symbol, SymbolP(symbol, Seq()))
+    }
+  }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
@@ -20,6 +28,7 @@ case class NonEmpty() extends Constructor {
   def name: String = ???
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean = true
   def expand(f: Fringe): Option[Seq[Fringe]] = Some(Seq(f))
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = children(0)
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
@@ -43,6 +52,7 @@ case class HasKey(isSet: Boolean, element: SymbolOrAlias, key: Option[Pattern[Op
         }
     }
   }
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = ???
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
@@ -50,6 +60,15 @@ case class HasNoKey(key: Option[Pattern[Option[Occurrence]]]) extends Constructo
   def name = "0"
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean = key.isDefined && pat == key.get
   def expand(f: Fringe): Option[Seq[Fringe]] = Some(Seq(f))
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = {
+    val child = children(0)
+    child match {
+      case MapP(keys, values, frame, ctr, orig) => 
+        MapP(WildcardP[String]() +: keys, WildcardP[String]() +: values, frame, ctr, orig)
+      case WildcardP() | VariableP(_, _) =>
+        MapP(Seq(WildcardP[String]()), Seq(WildcardP[String]()), Some(child), Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, null)
+    }
+  }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
@@ -59,6 +78,9 @@ case class ListC(element: SymbolOrAlias, length: Int) extends Constructor {
   def expand(f: Fringe): Option[Seq[Fringe]] = {
     val sort = f.symlib.signatures(element)._1.head
     Some((0 until length).map(i => new Fringe(f.symlib, sort, Num(i, f.occurrence), false)))
+  }
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = {
+    ListP(children, None, Seq(), Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, null)
   }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
@@ -74,6 +96,9 @@ case class SymbolC(sym: SymbolOrAlias) extends Constructor {
       Some(sorts.zipWithIndex.map(t => new Fringe(f.symlib, t._1, Num(t._2, f.occurrence), sym.ctr == "inj")))
     }
   }
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = {
+    SymbolP(sym, children)
+  }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 
@@ -81,5 +106,8 @@ case class LiteralC(literal: String) extends Constructor {
   def name: String = literal
   def isBest(pat: Pattern[Option[Occurrence]]): Boolean = true
   def expand(f: Fringe): Option[Seq[Fringe]] = Some(Seq())
+  def contract(f: Fringe, children: Seq[Pattern[String]]): Pattern[String] = {
+    LiteralP(literal, f.sortInfo.category)
+  }
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -3,6 +3,7 @@ package org.kframework.backend.llvm.matching
 import org.kframework.backend.llvm.matching.dt.DecisionTree
 import org.kframework.backend.llvm.matching.pattern.{Pattern => P, SymbolP, LiteralP, VariableP, AsP, OrP, ListP, MapP, SetP, WildcardP, SortCategory}
 import org.kframework.parser.kore._
+import org.kframework.utils.errorsystem.KException
 
 object Generator {
 
@@ -135,8 +136,12 @@ object Generator {
     new Matrix(symlib, cols, actions).expand
   }
   
-  def mkDecisionTree(symlib: Parser.SymLib, mod: Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort]) : DecisionTree = {
+  def mkDecisionTree(symlib: Parser.SymLib, mod: Definition, axioms: IndexedSeq[AxiomInfo], sorts: Seq[Sort], name: SymbolOrAlias, kem: KException => scala.Unit) : DecisionTree = {
     val matrix = genClauseMatrix(symlib, mod, axioms, sorts)
+    matrix.checkUsefulness(kem)
+    if (!symlib.isHooked(name) && Parser.hasAtt(symlib.signatures(name)._3, "functional")) {
+      matrix.checkExhaustiveness(name.ctr, kem)
+    }
     matrix.compile
   }
 

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -125,9 +125,10 @@ object Generator {
       sorts: Seq[Sort]) :
       Matrix = {
     val actions = axioms.map(a => {
+      val lhsVars = a.rewrite.getLeftHandSide.flatMap(genVars(_)).map(_.name)
       val rhsVars = genVars(a.rewrite.getRightHandSide)
       val scVars = a.sideCondition.map(genVars(_))
-      new Action(a.ordinal, rhsVars.map(_.name).sorted.distinct, scVars.map(_.map(_.name).sorted.distinct), (rhsVars ++ scVars.getOrElse(Seq())).filter(_.name.startsWith("Var'Bang'")).map(v => (v.name, v.sort)), a.rewrite.getLeftHandSide.size, a.priority, a.source, a.location)
+      new Action(a.ordinal, rhsVars.map(_.name).sorted.distinct, scVars.map(_.map(_.name).sorted.distinct), (rhsVars ++ scVars.getOrElse(Seq())).filter(_.name.startsWith("Var'Bang'")).map(v => (v.name, v.sort)), a.rewrite.getLeftHandSide.size, a.priority, a.source, a.location, lhsVars.toSet.size != lhsVars.size)
     })
     val patterns = axioms.map(a => genPatterns(mod, symlib, a.rewrite.getLeftHandSide)).transpose
     val cols = (sorts, patterns).zipped.toIndexedSeq

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -127,7 +127,7 @@ object Generator {
     val actions = axioms.map(a => {
       val rhsVars = genVars(a.rewrite.getRightHandSide)
       val scVars = a.sideCondition.map(genVars(_))
-      new Action(a.ordinal, rhsVars.map(_.name).sorted.distinct, scVars.map(_.map(_.name).sorted.distinct), (rhsVars ++ scVars.getOrElse(Seq())).filter(_.name.startsWith("Var'Bang'")).map(v => (v.name, v.sort)), a.rewrite.getLeftHandSide.size, a.priority)
+      new Action(a.ordinal, rhsVars.map(_.name).sorted.distinct, scVars.map(_.map(_.name).sorted.distinct), (rhsVars ++ scVars.getOrElse(Seq())).filter(_.name.startsWith("Var'Bang'")).map(v => (v.name, v.sort)), a.rewrite.getLeftHandSide.size, a.priority, a.source, a.location)
     })
     val patterns = axioms.map(a => genPatterns(mod, symlib, a.rewrite.getLeftHandSide)).transpose
     val cols = (sorts, patterns).zipped.toIndexedSeq

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Generator.scala
@@ -140,7 +140,7 @@ object Generator {
     val matrix = genClauseMatrix(symlib, mod, axioms, sorts)
     matrix.checkUsefulness(kem)
     if (!symlib.isHooked(name) && Parser.hasAtt(symlib.signatures(name)._3, "functional")) {
-      matrix.checkExhaustiveness(name.ctr, kem)
+      matrix.checkExhaustiveness(name, kem)
     }
     matrix.compile
   }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -269,7 +269,7 @@ object SortInfo {
   }
 }
 
-case class Action(val ordinal: Int, val rhsVars: Seq[String], val scVars: Option[Seq[String]], val freshConstants: Seq[(String, Sort)], val arity: Int, val priority: Int, source: Option[Source], location: Option[Location]) {
+case class Action(val ordinal: Int, val rhsVars: Seq[String], val scVars: Option[Seq[String]], val freshConstants: Seq[(String, Sort)], val arity: Int, val priority: Int, source: Option[Source], location: Option[Location], nonlinear: Boolean) {
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -761,7 +761,9 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
   def checkUsefulness(kem: KException => Unit): Unit = {
     for (rowIx <- rows.indices) {
       if (rowUseless(rowIx)) {
-        kem(new KException(KException.ExceptionType.WARNING, KException.KExceptionGroup.COMPILER, "Potentially useless rule detected.", clauses(rowIx).action.source.getOrElse(null), clauses(rowIx).action.location.getOrElse(null)))
+        if (clauses(rowIx).action.source.isDefined && clauses(rowIx).action.location.isDefined) {
+          kem(new KException(KException.ExceptionType.WARNING, KException.KExceptionGroup.COMPILER, "Potentially useless rule detected.", clauses(rowIx).action.source.get, clauses(rowIx).action.location.get))
+        }
       }
     }
   }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -247,7 +247,7 @@ case class Fringe(val symlib: Parser.SymLib, val sort: Sort, val occurrence: Occ
 }
 
 class SortInfo private(sort: Sort, symlib: Parser.SymLib) {
-  val constructors = symlib.symbolsForSort.getOrElse(sort, Seq())
+  val constructors = symlib.constructorsForSort.getOrElse(sort, Seq())
   private val rawInjections = constructors.filter(_.ctr == "inj")
   private val injMap = rawInjections.map(b => (b, rawInjections.filter(a => symlib.isSubsorted(a.params.head, b.params.head)))).toMap
   private val rawOverloads = constructors.filter(symlib.overloads.contains)

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -1,5 +1,6 @@
 package org.kframework.backend.llvm.matching
 
+import org.kframework.attributes.{Location,Source}
 import org.kframework.parser.kore.{Sort,CompoundSort,SymbolOrAlias}
 import org.kframework.parser.kore.implementation.{DefaultBuilders => B}
 import org.kframework.backend.llvm.matching.pattern._
@@ -268,7 +269,7 @@ object SortInfo {
   }
 }
 
-case class Action(val ordinal: Int, val rhsVars: Seq[String], val scVars: Option[Seq[String]], val freshConstants: Seq[(String, Sort)], val arity: Int, val priority: Int) {
+case class Action(val ordinal: Int, val rhsVars: Seq[String], val scVars: Option[Seq[String]], val freshConstants: Seq[(String, Sort)], val arity: Int, val priority: Int, source: Option[Source], location: Option[Location]) {
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
 }
 

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -1,5 +1,7 @@
 package org.kframework.backend.llvm.matching
 
+import org.kframework.kore.KORE.{KApply,KList}
+import org.kframework.unparser.ToKast
 import org.kframework.attributes.{Location,Source}
 import org.kframework.parser.kore.{Sort,CompoundSort,SymbolOrAlias}
 import org.kframework.parser.kore.implementation.{DefaultBuilders => B}
@@ -764,7 +766,7 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
     }
   }
 
-  def checkExhaustiveness(name: String, kem: KException => Unit): Unit = {
+  def checkExhaustiveness(name: SymbolOrAlias, kem: KException => Unit): Unit = {
     Matrix.id = 0
     val id = Matrix.id
     if (Matching.logging) {
@@ -778,7 +780,9 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
       if (Matching.logging) {
         System.out.println("Matrix " + id + " is non-exhaustive:\n" + counterexample.get.map(p => new util.Formatter().format("%12.12s", p.toShortString)).mkString(" "))
       }
-      kem(new KException(KException.ExceptionType.WARNING, KException.KExceptionGroup.COMPILER, "Non exhaustive match detected: " ++ name ++ "{}(" ++ counterexample.get.mkString(",") ++ ")"))
+      val k = (fringe zip counterexample.get).map(t => t._2.toK(t._1))
+      val func = KApply(symlib.koreToK(name), KList(k))
+      kem(new KException(KException.ExceptionType.WARNING, KException.KExceptionGroup.COMPILER, "Non exhaustive match detected: " ++ ToKast(func)))
     }
   }
 

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -248,6 +248,7 @@ case class Fringe(val symlib: Parser.SymLib, val sort: Sort, val occurrence: Occ
 
 class SortInfo private(sort: Sort, symlib: Parser.SymLib) {
   val constructors = symlib.constructorsForSort.getOrElse(sort, Seq())
+  val exactConstructors = constructors.filter(_.ctr != "inj")
   private val rawInjections = constructors.filter(_.ctr == "inj")
   private val injMap = rawInjections.map(b => (b, rawInjections.filter(a => symlib.isSubsorted(a.params.head, b.params.head)))).toMap
   private val rawOverloads = constructors.filter(symlib.overloads.contains)
@@ -256,6 +257,7 @@ class SortInfo private(sort: Sort, symlib: Parser.SymLib) {
   val trueInjMap = injMap ++ overloadInjMap
   val category: SortCategory = SortCategory(Parser.getStringAtt(symlib.sortAtt(sort), "hook"))
   val length: Int = category.length(constructors.size)
+  val exactLength: Int = category.length(exactConstructors.size)
   val isCollection: Boolean = {
     category match {
       case MapS() | SetS() => true

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -13,6 +13,10 @@ object Parser {
     getAtt(axiom, att).isDefined
   }
 
+  def hasAtt(att: Attributes, attName: String): Boolean = {
+    att.patterns.find(isAtt(attName, _)).isDefined
+  }
+
   private def getAtt(axiom: AxiomDeclaration, att: String): Option[Pattern] = {
     axiom.att.patterns.find(isAtt(att, _))
   }
@@ -59,8 +63,8 @@ object Parser {
       }).toMap
     }
 
-    val symbolsForSort: Map[Sort, Seq[SymbolOrAlias]] = {
-      signatures.groupBy(_._2._2).mapValues(_.keys.toSeq)
+    val constructorsForSort: Map[Sort, Seq[SymbolOrAlias]] = {
+      signatures.groupBy(_._2._2).mapValues(_.keys.filter(k => !hasAtt(signatures(k)._3, "function")).toSeq)
     }
 
     val sortAtt: Map[Sort, Attributes] = {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -2,6 +2,7 @@ package org.kframework.backend.llvm.matching
 
 import org.kframework.attributes.{Source, Location}
 import org.kframework.parser.kore._
+import org.kframework.parser.kore.parser.KoreToK
 import org.kframework.parser.kore.implementation.{DefaultBuilders => B}
 import java.util
 
@@ -86,6 +87,10 @@ object Parser {
     def isSubsorted(less: Sort, greater: Sort): Boolean = {
       signatures.contains(B.SymbolOrAlias("inj",Seq(less,greater)))
     }
+
+    private val hookAtts: Map[String, String] = sortAtt.filter(_._1.isInstanceOf[CompoundSort]).map(t => (t._1.asInstanceOf[CompoundSort].ctr.substring(4), getStringAtt(t._2, "hook").getOrElse(""))).toMap
+
+    val koreToK = new KoreToK(hookAtts)
   }
 
   private def rulePriority(axiom: AxiomDeclaration): Int = {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -51,6 +51,10 @@ object Parser {
       }
     }
 
+    def isHooked(symbol: SymbolOrAlias): Boolean = {
+      return symbolDecls(symbol.ctr).head.isInstanceOf[HookSymbolDeclaration]
+    }
+
     private def instantiate(s: Seq[Sort], params: Seq[Sort], args: Seq[Sort]): Seq[Sort] = s.map(instantiate(_, params, args))
 
     val signatures: Map[SymbolOrAlias, (Seq[Sort], Sort, Attributes)] = {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/Pattern.scala
@@ -185,9 +185,9 @@ case class MapP[T](keys: Seq[Pattern[T]], values: Seq[Pattern[T]], frame: Option
     } else if (keys.isEmpty) {
       frame.get.signature(clause)
     } else if (frame.isEmpty) {
-      keys.flatMap(key => Seq(HasKey(isSet = false, ctr, clause.canonicalize(key)), HasNoKey(clause.canonicalize(key))))
+      keys.flatMap(key => Seq(HasKey(isSet = false, ctr, clause.canonicalize(key)), HasNoKey(false, clause.canonicalize(key))))
     } else {
-      keys.flatMap(key => Seq(HasKey(isSet = false, ctr, clause.canonicalize(key)), HasNoKey(clause.canonicalize(key)))) ++ frame.get.signature(clause)
+      keys.flatMap(key => Seq(HasKey(isSet = false, ctr, clause.canonicalize(key)), HasNoKey(false, clause.canonicalize(key)))) ++ frame.get.signature(clause)
     }
   }
   def isWildcard: Boolean = keys.isEmpty && values.isEmpty && frame.isDefined && frame.get.isWildcard
@@ -197,9 +197,9 @@ case class MapP[T](keys: Seq[Pattern[T]], values: Seq[Pattern[T]], frame: Option
       case (Empty(), _) => keys.isEmpty && values.isEmpty
       case (HasKey(_, _, _), Some(_)) => true
       case (HasKey(_, _, Some(p)), None) => keys.map(_.canonicalize(clause)).exists(Pattern.mightUnify(p, _))
-      case (HasNoKey(Some(p)), _) => !keys.map(_.canonicalize(clause)).contains(p)
+      case (HasNoKey(_, Some(p)), _) => !keys.map(_.canonicalize(clause)).contains(p)
       case (HasKey(_, _, None), None) => keys.nonEmpty && clause.action.priority <= maxPriority
-      case (HasNoKey(None), _) => keys.nonEmpty && clause.action.priority > maxPriority
+      case (HasNoKey(_, None), _) => keys.nonEmpty && clause.action.priority > maxPriority
     }
   }
   def score(h: Heuristic, f: Fringe, c: Clause, key: Option[Pattern[Option[Occurrence]]], isEmpty: Boolean): Double = h.scoreMap(this, f, c, key, isEmpty)
@@ -220,7 +220,7 @@ case class MapP[T](keys: Seq[Pattern[T]], values: Seq[Pattern[T]], frame: Option
           case -1 => Seq(WildcardP(), WildcardP(), this)
           case i => Seq(values(i), MapP(keys.take(i) ++ keys.takeRight(keys.size - i - 1), values.take(i) ++ values.takeRight(values.size - i - 1), frame, ctr, orig), WildcardP())
         }
-      case HasNoKey(_) | NonEmpty() => Seq(this)
+      case HasNoKey(_, _) | NonEmpty() => Seq(this)
       case HasKey(_, _, None) =>
         if (keys.isEmpty && frame.isDefined) {
           frame.get.expand(ix, isExact, fringes, f, clause, maxPriority)
@@ -299,9 +299,9 @@ case class SetP[T](elements: Seq[Pattern[T]], frame: Option[Pattern[T]], ctr: Sy
     } else if (elements.isEmpty) {
       frame.get.signature(clause)
     } else if (frame.isEmpty) {
-      elements.flatMap(elem => Seq(HasKey(isSet = true, ctr, clause.canonicalize(elem)), HasNoKey(clause.canonicalize(elem))))
+      elements.flatMap(elem => Seq(HasKey(isSet = true, ctr, clause.canonicalize(elem)), HasNoKey(true, clause.canonicalize(elem))))
     } else {
-      elements.flatMap(elem => Seq(HasKey(isSet = true, ctr, clause.canonicalize(elem)), HasNoKey(clause.canonicalize(elem)))) ++ frame.get.signature(clause)
+      elements.flatMap(elem => Seq(HasKey(isSet = true, ctr, clause.canonicalize(elem)), HasNoKey(true, clause.canonicalize(elem)))) ++ frame.get.signature(clause)
     }
   }
   def isWildcard: Boolean = elements.isEmpty && frame.isDefined && frame.get.isWildcard
@@ -311,9 +311,9 @@ case class SetP[T](elements: Seq[Pattern[T]], frame: Option[Pattern[T]], ctr: Sy
       case (Empty(), _) => elements.isEmpty
       case (HasKey(_, _, _), Some(_)) => true
       case (HasKey(_, _, Some(p)), None) => elements.map(_.canonicalize(clause)).exists(Pattern.mightUnify(p, _))
-      case (HasNoKey(Some(p)), _) => !elements.map(_.canonicalize(clause)).contains(p)
+      case (HasNoKey(_, Some(p)), _) => !elements.map(_.canonicalize(clause)).contains(p)
       case (HasKey(_, _, None), None) => elements.nonEmpty && clause.action.priority <= maxPriority
-      case (HasNoKey(None), _) => elements.nonEmpty && clause.action.priority > maxPriority
+      case (HasNoKey(_, None), _) => elements.nonEmpty && clause.action.priority > maxPriority
     }
   }
   def score(h: Heuristic, f: Fringe, c: Clause, key: Option[Pattern[Option[Occurrence]]], isEmpty: Boolean): Double = h.scoreSet(this, f, c, key, isEmpty)
@@ -334,7 +334,7 @@ case class SetP[T](elements: Seq[Pattern[T]], frame: Option[Pattern[T]], ctr: Sy
           case -1 => Seq(WildcardP(), this)
           case i => Seq(SetP(elements.take(i) ++ elements.takeRight(elements.size - i - 1), frame, ctr, orig), WildcardP())
         }
-      case HasNoKey(_) | NonEmpty() => Seq(this)
+      case HasNoKey(_, _) | NonEmpty() => Seq(this)
       case HasKey(_, _, None) =>
         if (elements.isEmpty && frame.isDefined) {
           frame.get.expand(ix, isExact, fringes, f, clause, maxPriority)

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
@@ -105,7 +105,14 @@ case class ListS() extends SortCategory {
   def hasIncompleteSignature(sigma: Seq[Constructor], f: Fringe): Boolean = true
   def missingConstructor(sigma: Seq[Constructor], f: Fringe): Pattern[String] = {
     val maxSize = sigma.map(_.asInstanceOf[ListC].length).max
-    ListP(Seq.fill[Pattern[String]](maxSize+1)(WildcardP()), None, Seq(), sigma.head.asInstanceOf[ListC].element, null)
+    def element(v: Pattern[String]): Pattern[String] = {
+      SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "element").get, Seq(v))
+    }
+    val unit: Pattern[String] = SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "unit").get, Seq())
+    def concat(m1: Pattern[String], m2: Pattern[String]): Pattern[String] = {
+      SymbolP(Parser.getSymbolAtt(f.symlib.sortAtt(f.sort), "concat").get, Seq(m1, m2))
+    }
+    ListP(Seq.fill[Pattern[String]](maxSize+1)(WildcardP()), None, Seq(), sigma.head.asInstanceOf[ListC].element, Seq.fill(maxSize+1)(element(WildcardP())).fold(unit)(concat))
   }
   override def isExpandDefault = true
   def equalityFun = "hook_LIST_eq"

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
@@ -32,7 +32,7 @@ object SortCategory {
 
 case class SymbolS() extends SortCategory {
   def hookAtt = "STRING.String"
-  def hasIncompleteSignature(sigma: Seq[Constructor], f: Fringe): Boolean = sigma.isEmpty || sigma.contains(Empty()) || sigma.size != f.sortInfo.length
+  def hasIncompleteSignature(sigma: Seq[Constructor], f: Fringe): Boolean = sigma.isEmpty || sigma.contains(Empty()) || (!f.isExact && sigma.size != f.sortInfo.length) || (f.isExact && sigma.size != f.sortInfo.exactLength)
   def equalityFun = "hook_KEQUAL_eq"
   // not matching a builtin, therefore construct a regular switch
   // that matches the tag of the block.


### PR DESCRIPTION
We only generate the non exhaustive warnings for functions marked as total with the `functional` attribute. We only generate the useless clause warning if a location exists for the rule (otherwise it was generated by the compiler).

Tested for correctness against IMP and KEVM. Tested that it doesn't crash additionally against MKR-MCD, WASM, and Beacon Chain.