### PR TITLE
getSorts

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -165,6 +165,10 @@ object Parser {
     defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AxiomDeclaration]).map(_.asInstanceOf[AxiomDeclaration])
   }
 
+  def getSorts(defn: Definition): Seq[Sort] = {
+    defn.modules.flatMap(_.decls).filter(_.isInstanceOf[SortDeclaration]).map(_.asInstanceOf[SortDeclaration].sort)
+  }
+
   def parseTopAxioms(axioms: Seq[(AxiomDeclaration, Int)]) : IndexedSeq[AxiomInfo] = {
     val withOwise = axioms.flatMap(parseAxiomSentence(splitTop, _))
     withOwise.map(_._2).sortWith(_.priority < _.priority).toIndexedSeq
@@ -242,7 +246,7 @@ object Parser {
   def parseSymbols(defn: Definition, heuristics: String) : SymLib = {
     val axioms = getAxioms(defn)
     val symbols = axioms.flatMap(a => parsePatternForSymbols(a.pattern))
-    val allSorts = symbols.flatMap(_.params)
+    val allSorts = getSorts(defn)
     val overloads = getOverloads(axioms)
     new SymLib(symbols, allSorts, defn, overloads, parseHeuristics(heuristics))
   }


### PR DESCRIPTION
We had an issue where we were crashing because we were not computing the SymLib info for a sort unless that sort was used in the signature of one of the symbols used in one of the axioms. So now we compute the list of all sorts directly from the sort declarations in the definition.