### PR TITLE
remove meta level from parser

### DIFF
--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -19,9 +19,9 @@ private:
   llvm::LLVMContext &Ctx;
   bool isAnywhereOwise;
 
-  llvm::Value *createHook(KOREObjectCompositePattern *hookAtt, KOREObjectCompositePattern *pattern);
-  llvm::Value *createFunctionCall(std::string name, KOREObjectCompositePattern *pattern, bool sret, bool fastcc);
-  llvm::Value *notInjectionCase(KOREObjectCompositePattern *constructor, llvm::Value *val);
+  llvm::Value *createHook(KORECompositePattern *hookAtt, KORECompositePattern *pattern);
+  llvm::Value *createFunctionCall(std::string name, KORECompositePattern *pattern, bool sret, bool fastcc);
+  llvm::Value *notInjectionCase(KORECompositePattern *constructor, llvm::Value *val);
 public:
   CreateTerm(
     llvm::StringMap<llvm::Value *> &Substitution,
@@ -61,9 +61,9 @@ public:
    in the llvm backend. */
 std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Context);
 
-llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition, const KOREObjectSymbol *symbol);
+llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol);
 llvm::Value *getBlockHeader(llvm::Module *Module, KOREDefinition *definition,
-    const KOREObjectSymbol *symbol, llvm::Type *BlockType);
+    const KORESymbol *symbol, llvm::Type *BlockType);
 
 /* returns the llvm::Type corresponding to the type of the result of calling createTerm
    on the specified pattern. */

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -14,7 +14,7 @@ void finalizeDebugInfo(void);
 
 void initDebugFunction(std::string name, std::string linkageName, llvm::DISubroutineType *type, KOREDefinition *definition, llvm::Function *func);
 
-void initDebugAxiom(std::map<std::string, KOREObjectCompositePattern *> const& att);
+void initDebugAxiom(std::map<std::string, KORECompositePattern *> const& att);
 void initDebugParam(llvm::Function *func, unsigned argNo, std::string name, ValueType type);
 void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable *var);
 

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -48,7 +48,7 @@ class DecisionCase {
 private:
   /* constructor to switch on. if null, this is a wildcard match.
      if equal to \\dv, we are matching on a bool or mint literal. */
-  KOREObjectSymbol *constructor;
+  KORESymbol *constructor;
   /* the names to bind the children of this pattern to. */
   std::vector<std::string> bindings;
   /* the literal int to match on. must have a bit width equal to the
@@ -59,16 +59,16 @@ private:
 
 public:
   DecisionCase(
-    KOREObjectSymbol *constructor, 
+    KORESymbol *constructor, 
     std::vector<std::string> bindings,
     DecisionNode *child) :
       constructor(constructor),
       bindings(bindings),
       child(child) {}
-  DecisionCase(KOREObjectSymbol *dv, llvm::APInt literal, DecisionNode *child) :
+  DecisionCase(KORESymbol *dv, llvm::APInt literal, DecisionNode *child) :
     constructor(dv), literal(literal), child(child) {}
 
-  KOREObjectSymbol *getConstructor() const { return constructor; }
+  KORESymbol *getConstructor() const { return constructor; }
   const std::vector<std::string> &getBindings() const { return bindings; }
   void addBinding(std::string name) { bindings.push_back(name); }
   llvm::APInt getLiteral() const { return literal; }
@@ -128,13 +128,13 @@ public:
 class MakePatternNode : public DecisionNode {
 private:
   std::string name;
-  KOREObjectPattern *pattern;
+  KOREPattern *pattern;
   std::vector<std::string> uses;
   DecisionNode *child;
 
   MakePatternNode(
     const std::string &name,
-    KOREObjectPattern *pattern,
+    KOREPattern *pattern,
     std::vector<std::string> &uses,
     DecisionNode *child) :
       name(name),
@@ -145,7 +145,7 @@ private:
 public:
   static MakePatternNode *Create(
       const std::string &name,
-      KOREObjectPattern *pattern,
+      KOREPattern *pattern,
       std::vector<std::string> &uses,
       DecisionNode *child) {
     return new MakePatternNode(name, pattern, uses, child);
@@ -380,8 +380,8 @@ public:
 /* construct the function that evaluates the specified function symbol
    according to the specified decision tree and returns the result of the
    function. */
-void makeEvalFunction(KOREObjectSymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt);
-void makeAnywhereFunction(KOREObjectSymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt);
+void makeEvalFunction(KORESymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt);
+void makeAnywhereFunction(KORESymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt);
 
 void makeStepFunction(KOREDefinition *definition, llvm::Module *module, DecisionNode *dt);
 void makeStepFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *module, PartialStep res);

--- a/include/kllvm/codegen/DecisionParser.h
+++ b/include/kllvm/codegen/DecisionParser.h
@@ -12,7 +12,7 @@ class DecisionNode;
 
 struct Residual {
   std::string occurrence;
-  KOREObjectPattern *pattern;
+  KOREPattern *pattern;
 };
 
 struct PartialStep {
@@ -20,9 +20,9 @@ struct PartialStep {
   std::vector<Residual> residuals;
 };
 
-DecisionNode *parseYamlDecisionTreeFromString(std::string yaml, const std::map<std::string, KOREObjectSymbol *> &syms, const std::map<std::string, KOREObjectCompositeSort *> &sorts);
-DecisionNode *parseYamlDecisionTree(std::string filename, const std::map<std::string, KOREObjectSymbol *> &syms, const std::map<std::string, KOREObjectCompositeSort *> &sorts);
-PartialStep parseYamlSpecialDecisionTree(std::string filename, const std::map<std::string, KOREObjectSymbol *> &syms, const std::map<std::string, KOREObjectCompositeSort *> &sorts);
+DecisionNode *parseYamlDecisionTreeFromString(std::string yaml, const std::map<std::string, KORESymbol *> &syms, const std::map<std::string, KORECompositeSort *> &sorts);
+DecisionNode *parseYamlDecisionTree(std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<std::string, KORECompositeSort *> &sorts);
+PartialStep parseYamlSpecialDecisionTree(std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<std::string, KORECompositeSort *> &sorts);
 
 }
 

--- a/include/kllvm/parser/KOREParserDriver.h
+++ b/include/kllvm/parser/KOREParserDriver.h
@@ -9,24 +9,17 @@ class KOREDefinition;
 class KOREModule;
 class KOREDeclaration;
 class KOREModuleImportDeclaration;
-class KOREObjectCompositeSortDeclaration;
+class KORECompositeSortDeclaration;
 class KOREAxiomDeclaration;
-class KOREObjectSymbolDeclaration;
-class KOREMetaSymbolDeclaration;
-class KOREObjectAliasDeclaration;
-class KOREMetaAliasDeclaration;
+class KORESymbolDeclaration;
+class KOREAliasDeclaration;
 class KOREPattern;
-class KOREObjectPattern;
-class KOREMetaPattern;
-class KOREObjectCompositePattern;
-class KOREMetaCompositePattern;
-class KOREObjectSort;
-class KOREMetaSort;
-class KOREObjectCompositeSort;
-class KOREObjectSortVariable;
-class KOREMetaSortVariable;
-class KOREObjectVariablePattern;
-class KOREMetaVariablePattern;
+class KOREPattern;
+class KORECompositePattern;
+class KORESort;
+class KORECompositeSort;
+class KORESortVariable;
+class KOREVariablePattern;
 } // end namespace kllvm
 
 namespace kllvm {
@@ -37,16 +30,14 @@ private:
   KOREDefinition *currentDefinition                = nullptr;
   KOREModule *currentModule                        = nullptr;
   KOREDeclaration *currentDeclaration              = nullptr;
-  KOREObjectCompositePattern *currentObjectPattern = nullptr;
-  KOREMetaCompositePattern *currentMetaPattern     = nullptr;
-  KOREObjectCompositeSort *currentObjectSort       = nullptr;
+  KORECompositePattern *currentObjectPattern = nullptr;
+  KORECompositeSort *currentObjectSort       = nullptr;
 
   enum State {
     ParsingDefinition,
     ParsingDeclaration,
     ParsingModule,
     ParsingObjectPattern,
-    ParsingMetaPattern,
     ParsingObjectSort,
   };
 
@@ -56,10 +47,10 @@ private:
   inline void pushState(State state) { StateStack.push(state); }
   inline void popState() { StateStack.pop(); }
 
-  std::stack<KOREObjectCompositeSort *> SortStack;
+  std::stack<KORECompositeSort *> SortStack;
 
-  inline KOREObjectCompositeSort *getCurrentSort() { return SortStack.top(); }
-  inline void pushSort(KOREObjectCompositeSort *sort) { SortStack.push(sort); }
+  inline KORECompositeSort *getCurrentSort() { return SortStack.top(); }
+  inline void pushSort(KORECompositeSort *sort) { SortStack.push(sort); }
   inline void popSort() { SortStack.pop(); }
 
   std::stack<KOREPattern *> PatternStack;
@@ -80,46 +71,32 @@ public:
 
   void
   startObjectSortDeclaration(const std::string &Name, bool isHooked = false);
-  KOREObjectCompositeSortDeclaration *finishObjectSortDeclaration();
+  KORECompositeSortDeclaration *finishObjectSortDeclaration();
 
   void startAxiomDeclaration();
   KOREAxiomDeclaration *finishAxiomDeclaration(KOREPattern *Pattern);
 
   void
   startObjectSymbolDeclaration(const std::string &Name, bool isHooked = false);
-  KOREObjectSymbolDeclaration *
-  finishObjectSymbolDeclaration(KOREObjectSort *Sort);
-
-  void startMetaSymbolDeclaration(const std::string &Name);
-  KOREMetaSymbolDeclaration *
-  finishMetaSymbolDeclaration(KOREMetaSort *Sort);
+  KORESymbolDeclaration *
+  finishObjectSymbolDeclaration(KORESort *Sort);
 
   void startObjectAliasDeclaration(const std::string &Name);
-  KOREObjectAliasDeclaration *
-  finishObjectAliasDeclaration(KOREObjectSort *Sort, KOREObjectPattern *Pattern);
-
-  void startMetaAliasDeclaration(const std::string &Name);
-  KOREMetaAliasDeclaration *
-  finishMetaAliasDeclaration(KOREMetaSort *Sort, KOREMetaPattern *Pattern);
+  KOREAliasDeclaration *
+  finishObjectAliasDeclaration(KORESort *Sort, KOREPattern *Pattern);
 
   void startObjectPattern(const std::string &Name);
-  KOREObjectCompositePattern *finishObjectPattern();
-
-  void startMetaPattern(const std::string &Name);
-  KOREMetaCompositePattern *finishMetaPattern();
+  KORECompositePattern *finishObjectPattern();
 
   void startObjectSort(const std::string &Name);
-  KOREObjectCompositeSort *finishObjectSort();
+  KORECompositeSort *finishObjectSort();
 
   void addModule(KOREModule *Module);
   void addDeclaration(KOREDeclaration *Declaration);
-  void addObjectSortVariable(KOREObjectSortVariable *SortVariable);
-  void addMetaSortVariable(KOREMetaSortVariable *SortVariable);
+  void addObjectSortVariable(KORESortVariable *SortVariable);
   void addPattern(KOREPattern *Pattern);
-  void addObjectSort(KOREObjectSort *Sort);
-  void addMetaSort(KOREMetaSort *Sort);
-  void addObjectVariable(KOREObjectVariablePattern *Variable);
-  void addMetaVariable(KOREMetaVariablePattern *Variable);
+  void addObjectSort(KORESort *Sort);
+  void addObjectVariable(KOREVariablePattern *Variable);
 };
 
 } // end namespace parser

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -9,19 +9,19 @@ size_t kllvm::hash_value(const kllvm::KORESort &s) {
   return HashSort{}(s);
 }
 
-bool KOREObjectSortVariable::operator==(const KOREObjectSort &other) const {
-  if (auto var = dynamic_cast<const KOREObjectSortVariable *>(&other)) {
+bool KORESortVariable::operator==(const KORESort &other) const {
+  if (auto var = dynamic_cast<const KORESortVariable *>(&other)) {
     return var->name == name;
   }
   return false;
 }
 
-void KOREObjectCompositeSort::addArgument(KOREObjectSort *Argument) {
+void KORECompositeSort::addArgument(KORESort *Argument) {
   arguments.push_back(Argument);
 }
 
-bool KOREObjectCompositeSort::operator==(const KOREObjectSort &other) const {
-  if (auto sort = dynamic_cast<const KOREObjectCompositeSort *>(&other)) {
+bool KORECompositeSort::operator==(const KORESort &other) const {
+  if (auto sort = dynamic_cast<const KORECompositeSort *>(&other)) {
     if (sort->name != name || sort->arguments.size() != arguments.size()) {
       return false;
     }
@@ -33,9 +33,9 @@ bool KOREObjectCompositeSort::operator==(const KOREObjectSort &other) const {
   return false;
 }
 
-KOREObjectSort *KOREObjectCompositeSort::substitute(const std::unordered_map<KOREObjectSortVariable, KOREObjectSort *, HashSort> &subst) {
+KORESort *KORECompositeSort::substitute(const std::unordered_map<KORESortVariable, KORESort *, HashSort> &subst) {
   bool dirty = false;
-  std::vector<KOREObjectSort *> newArgs;
+  std::vector<KORESort *> newArgs;
   for (auto arg : arguments) {
     auto newArg = arg->substitute(subst);
     if (newArg != arg) {
@@ -44,14 +44,14 @@ KOREObjectSort *KOREObjectCompositeSort::substitute(const std::unordered_map<KOR
     newArgs.push_back(newArg);
   }
   if (dirty) {
-    KOREObjectCompositeSort *retval = Create(name);
+    KORECompositeSort *retval = Create(name);
     retval->arguments = newArgs;
     return retval;
   }
   return this;
 }
 
-ValueType KOREObjectCompositeSort::getCategory(KOREDefinition *definition) {
+ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
   if (category.cat != SortCategory::Uncomputed)
     return category;
   std::string name = getHook(definition);
@@ -59,18 +59,18 @@ ValueType KOREObjectCompositeSort::getCategory(KOREDefinition *definition) {
   return category;
 }
 
-std::string KOREObjectCompositeSort::getHook(KOREDefinition *definition) {
+std::string KORECompositeSort::getHook(KOREDefinition *definition) {
   auto &att = definition->getSortDeclarations().at(this->getName())->getAttributes();
   if (!att.count("hook")) {
     return "STRING.String";
   }
-  KOREObjectCompositePattern *hookAtt = att.at("hook");
+  KORECompositePattern *hookAtt = att.at("hook");
   assert(hookAtt->getArguments().size() == 1);
-  auto strPattern = dynamic_cast<KOREMetaStringPattern *>(hookAtt->getArguments()[0]);
+  auto strPattern = dynamic_cast<KOREStringPattern *>(hookAtt->getArguments()[0]);
   return strPattern->getContents();
 }
 
-ValueType KOREObjectCompositeSort::getCategory(std::string name) {
+ValueType KORECompositeSort::getCategory(std::string name) {
   SortCategory category;
   uint64_t bits = 0;
   if (name == "MAP.Map") category = SortCategory::Map;
@@ -91,19 +91,19 @@ ValueType KOREObjectCompositeSort::getCategory(std::string name) {
   return {category, bits};
 }
 
-void KOREObjectSymbol::addArgument(KOREObjectSort *Argument) {
+void KORESymbol::addArgument(KORESort *Argument) {
   arguments.push_back(Argument);
 }
 
-void KOREObjectSymbol::addFormalArgument(KOREObjectSort *Argument) {
+void KORESymbol::addFormalArgument(KORESort *Argument) {
   formalArguments.push_back(Argument);
 }
 
-void KOREObjectSymbol::addSort(KOREObjectSort *Sort) {
+void KORESymbol::addSort(KORESort *Sort) {
   sort = Sort;
 }
 
-bool KOREObjectSymbol::operator==(KOREObjectSymbol other) const {
+bool KORESymbol::operator==(KORESymbol other) const {
   if (name != other.name || arguments.size() != other.arguments.size()) {
     return false;
   }
@@ -113,10 +113,10 @@ bool KOREObjectSymbol::operator==(KOREObjectSymbol other) const {
   return true;
 }
 
-std::string KOREObjectSymbol::layoutString(KOREDefinition *definition) const {
+std::string KORESymbol::layoutString(KOREDefinition *definition) const {
   std::string result;
   for (auto arg : arguments) {
-    auto sort = dynamic_cast<KOREObjectCompositeSort *>(arg);
+    auto sort = dynamic_cast<KORECompositeSort *>(arg);
     ValueType cat = sort->getCategory(definition);
     switch(cat.cat) {
     case SortCategory::Map:
@@ -155,7 +155,7 @@ std::string KOREObjectSymbol::layoutString(KOREDefinition *definition) const {
   return result;
 }
 
-bool KOREObjectSymbol::isConcrete() const {
+bool KORESymbol::isConcrete() const {
   for (auto sort : arguments) {
     if (!sort->isConcrete()) {
       return false;
@@ -164,7 +164,7 @@ bool KOREObjectSymbol::isConcrete() const {
   return true;
 }
 
-bool KOREObjectSymbol::isPolymorphic() const {
+bool KORESymbol::isPolymorphic() const {
   for (auto sort : arguments) {
     if (sort->isConcrete()) {
       return false;
@@ -178,14 +178,14 @@ static std::unordered_set<std::string> BUILTINS{
   "\\ceil", "\\floor", "\\equals", "\\in", "\\top", "\\bottom", "\\dv",
   "\\rewrites", "\\next"};
 
-bool KOREObjectSymbol::isBuiltin() const {
+bool KORESymbol::isBuiltin() const {
   return BUILTINS.count(name);
 }
 
-void KOREObjectSymbol::instantiateSymbol(KOREObjectSymbolDeclaration *decl) {
-  std::vector<KOREObjectSort *> instantiated;
+void KORESymbol::instantiateSymbol(KORESymbolDeclaration *decl) {
+  std::vector<KORESort *> instantiated;
   int i = 0;
-  std::unordered_map<KOREObjectSortVariable, KOREObjectSort *, HashSort> vars;
+  std::unordered_map<KORESortVariable, KORESort *, HashSort> vars;
   for (auto var : decl->getObjectSortVariables()) {
     vars.emplace(*var, formalArguments[i++]);
   }
@@ -198,30 +198,22 @@ void KOREObjectSymbol::instantiateSymbol(KOREObjectSymbolDeclaration *decl) {
   arguments = instantiated;
 }
 
-void KOREMetaSymbol::addArgument(KOREMetaSort *Argument) {
-  arguments.push_back(Argument);
-}
-
-void KOREMetaSymbol::addSort(KOREMetaSort *Sort) {
-  sort = Sort;
-}
-
-std::string KOREObjectVariable::getName() const {
+std::string KOREVariable::getName() const {
   return name;
 }
 
-std::string KOREObjectVariablePattern::getName() const {
+std::string KOREVariablePattern::getName() const {
   return name->getName();
 }
 
-void KOREObjectCompositePattern::addArgument(KOREPattern *Argument) {
+void KORECompositePattern::addArgument(KOREPattern *Argument) {
   arguments.push_back(Argument);
 }
 
-void KOREObjectCompositePattern::markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &map) {
+void KORECompositePattern::markSymbols(std::map<std::string, std::vector<KORESymbol *>> &map) {
   if (!constructor->isBuiltin()) {
     if (!map.count(constructor->getName())) {
-      map.emplace(constructor->getName(), std::vector<KOREObjectSymbol *>{});
+      map.emplace(constructor->getName(), std::vector<KORESymbol *>{});
     }
     map.at(constructor->getName()).push_back(constructor);
   }
@@ -230,30 +222,14 @@ void KOREObjectCompositePattern::markSymbols(std::map<std::string, std::vector<K
   }
 }
 
-void KOREObjectCompositePattern::markVariables(std::map<std::string, KOREObjectVariablePattern *> &map) {
-  for (KOREPattern *arg : arguments) {
-    arg->markVariables(map);
-  }
-}
-
-void KOREMetaCompositePattern::addArgument(KOREPattern *Argument) {
-  arguments.push_back(Argument);
-}
-
-void KOREMetaCompositePattern::markSymbols(std::map<std::string, std::vector<KOREObjectSymbol *>> &map) {
-  for (KOREPattern *arg : arguments) {
-    arg->markSymbols(map);
-  }
-}
-
-void KOREMetaCompositePattern::markVariables(std::map<std::string, KOREObjectVariablePattern *> &map) {
+void KORECompositePattern::markVariables(std::map<std::string, KOREVariablePattern *> &map) {
   for (KOREPattern *arg : arguments) {
     arg->markVariables(map);
   }
 }
 
 void KOREDeclaration::addAttribute(KOREPattern *Attribute) {
-  if (auto constructor = dynamic_cast<KOREObjectCompositePattern *>(Attribute)) {
+  if (auto constructor = dynamic_cast<KORECompositePattern *>(Attribute)) {
     attributes.insert({constructor->getConstructor()->getName(), constructor});
     return;
   }
@@ -261,12 +237,8 @@ void KOREDeclaration::addAttribute(KOREPattern *Attribute) {
 }
 
 void
-KOREDeclaration::addObjectSortVariable(KOREObjectSortVariable *SortVariable) {
+KOREDeclaration::addObjectSortVariable(KORESortVariable *SortVariable) {
   objectSortVariables.push_back(SortVariable);
-}
-
-void KOREDeclaration::addMetaSortVariable(KOREMetaSortVariable *SortVariable) {
-  metaSortVariables.push_back(SortVariable);
 }
 
 void KOREAxiomDeclaration::addPattern(KOREPattern *Pattern) {
@@ -287,9 +259,9 @@ bool KOREAxiomDeclaration::isRequired() {
 }
 
 bool KOREAxiomDeclaration::isTopAxiom() {
-  if (auto top = dynamic_cast<KOREObjectCompositePattern *>(pattern)) {
+  if (auto top = dynamic_cast<KORECompositePattern *>(pattern)) {
     if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto bottomPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+      if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0])) {
         if (bottomPattern->getConstructor()->getName() == "\\bottom" && bottomPattern->getArguments().empty()) {
           return true;
         }
@@ -305,35 +277,35 @@ bool KOREAxiomDeclaration::isTopAxiom() {
 }
 
 KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
-  if (auto top = dynamic_cast<KOREObjectCompositePattern *>(pattern)) {
+  if (auto top = dynamic_cast<KORECompositePattern *>(pattern)) {
     if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1])) {
         if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto bottomPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+          if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0])) {
             if (bottomPattern->getConstructor()->getName() == "\\bottom" && bottomPattern->getArguments().empty()) {
-              if (auto andPattern2 = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[1])) {
+              if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1])) {
                 if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
-                  if (auto rewrites = dynamic_cast<KOREObjectCompositePattern *>(andPattern2->getArguments()[1])) {
+                  if (auto rewrites = dynamic_cast<KORECompositePattern *>(andPattern2->getArguments()[1])) {
                     if (rewrites->getConstructor()->getName() == "\\rewrites" && rewrites->getArguments().size() == 2) {
                       return rewrites->getArguments()[1];
                     }
                   }
                 } else if (andPattern2->getConstructor()->getName() == "\\rewrites" && andPattern2->getArguments().size() == 2) {
-                  if (auto andPattern3 = dynamic_cast<KOREObjectCompositePattern *>(andPattern2->getArguments()[1])) {
+                  if (auto andPattern3 = dynamic_cast<KORECompositePattern *>(andPattern2->getArguments()[1])) {
                     if (andPattern3->getConstructor()->getName() == "\\and" && andPattern3->getArguments().size() == 2) {
                       return andPattern3->getArguments()[1];
                     }
                   }
                 }
               }
-            } else if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+            } else if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0])) {
               if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
                 return equals->getArguments()[1];
               }
             }
           }
         } else if (andPattern->getConstructor()->getName() == "\\rewrites" && andPattern->getArguments().size() == 2) {
-          if (auto andPattern2 = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[1])) {
+          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1])) {
             if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
               return andPattern2->getArguments()[1];
             }
@@ -341,9 +313,9 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
         }
       }
     } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1])) {
         if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto rewrites = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[1])) {
+          if (auto rewrites = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1])) {
             if (rewrites->getConstructor()->getName() == "\\rewrites" && rewrites->getArguments().size() == 2) {
               return rewrites->getArguments()[1];
             }
@@ -353,7 +325,7 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
     } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
       return top->getArguments()[1];
     } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1])) {
         if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
           return andPattern->getArguments()[1];
         }
@@ -365,11 +337,11 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
 }
 
 KOREPattern *KOREAxiomDeclaration::getRequires() const {
-  if (auto top = dynamic_cast<KOREObjectCompositePattern *>(pattern)) {
+  if (auto top = dynamic_cast<KORECompositePattern *>(pattern)) {
     if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+      if (auto equals = dynamic_cast<KORECompositePattern *>(top->getArguments()[0])) {
         if (equals->getConstructor()->getName() == "\\and" && equals->getArguments().size() == 2) {
-          equals = dynamic_cast<KOREObjectCompositePattern *>(equals->getArguments()[1]);
+          equals = dynamic_cast<KORECompositePattern *>(equals->getArguments()[1]);
           assert(equals);
         }
         if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
@@ -378,9 +350,9 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
           return nullptr;
         } else if (equals->getConstructor()->getName() == "\\bottom" && equals->getArguments().empty()) {
           // strategy axiom hack
-          if (auto trueTop = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[1])) {
+          if (auto trueTop = dynamic_cast<KORECompositePattern *>(top->getArguments()[1])) {
             if (trueTop->getConstructor()->getName() == "\\and" && trueTop->getArguments().size() == 2) {
-              if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(trueTop->getArguments()[0])) {
+              if (auto equals = dynamic_cast<KORECompositePattern *>(trueTop->getArguments()[0])) {
                 if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
                   return equals->getArguments()[0];
                 } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
@@ -388,9 +360,9 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
                 }
               }
             } else if (trueTop->getConstructor()->getName() == "\\rewrites" && trueTop->getArguments().size() == 2) {
-              if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(trueTop->getArguments()[0])) {
+              if (auto andPattern = dynamic_cast<KORECompositePattern *>(trueTop->getArguments()[0])) {
                 if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-                  if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+                  if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0])) {
                     if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
                       return equals->getArguments()[0];
                     } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
@@ -404,7 +376,7 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
         }
       }
     } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {
-      if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+      if (auto equals = dynamic_cast<KORECompositePattern *>(top->getArguments()[0])) {
         if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
           return equals->getArguments()[0];
         } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
@@ -414,9 +386,9 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
     } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
       return nullptr;
     } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KOREObjectCompositePattern *>(top->getArguments()[0])) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0])) {
         if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto equals = dynamic_cast<KOREObjectCompositePattern *>(andPattern->getArguments()[0])) {
+          if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0])) {
             if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
               return equals->getArguments()[0];
             } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
@@ -433,28 +405,20 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
 
 
 void
-KOREObjectAliasDeclaration::addVariable(KOREObjectVariablePattern *Variable) {
+KOREAliasDeclaration::addVariable(KOREVariablePattern *Variable) {
   boundVariables.push_back(Variable);
 }
 
-void KOREObjectAliasDeclaration::addPattern(KOREObjectPattern *Pattern) {
+void KOREAliasDeclaration::addPattern(KOREPattern *Pattern) {
   pattern = Pattern;
 }
 
-void KOREMetaAliasDeclaration::addVariable(KOREMetaVariablePattern *Variable) {
-  boundVariables.push_back(Variable);
-}
-
-void KOREMetaAliasDeclaration::addPattern(KOREMetaPattern *Pattern) {
-  pattern = Pattern;
-}
-
-bool KOREObjectSymbolDeclaration::isAnywhere() {
+bool KORESymbolDeclaration::isAnywhere() {
   return getAttributes().count("anywhere");
 }
 
 void KOREModule::addAttribute(KOREPattern *Attribute) {
-  if (auto constructor = dynamic_cast<KOREObjectCompositePattern *>(Attribute)) {
+  if (auto constructor = dynamic_cast<KORECompositePattern *>(Attribute)) {
     attributes.insert({constructor->getConstructor()->getName(), constructor});
     return;
   }
@@ -468,11 +432,11 @@ void KOREModule::addDeclaration(KOREDeclaration *Declaration) {
 void KOREDefinition::addModule(KOREModule *Module) {
   modules.push_back(Module);
   for (auto decl : Module->getDeclarations()) {
-    if (auto sortDecl = dynamic_cast<KOREObjectCompositeSortDeclaration *>(decl)) {
+    if (auto sortDecl = dynamic_cast<KORECompositeSortDeclaration *>(decl)) {
       sortDeclarations.insert({sortDecl->getName(), sortDecl});
-      auto sort = KOREObjectCompositeSort::Create(sortDecl->getName());
+      auto sort = KORECompositeSort::Create(sortDecl->getName());
       hookedSorts[sort->getHook(this)] = sort;
-    } else if (auto symbolDecl = dynamic_cast<KOREObjectSymbolDeclaration *>(decl)) {
+    } else if (auto symbolDecl = dynamic_cast<KORESymbolDeclaration *>(decl)) {
       symbolDeclarations.insert({symbolDecl->getSymbol()->getName(), symbolDecl});
     } else if (auto axiom = dynamic_cast<KOREAxiomDeclaration *>(decl)) {
       axioms.push_back(axiom);
@@ -481,7 +445,7 @@ void KOREDefinition::addModule(KOREModule *Module) {
 }
 
 void KOREDefinition::addAttribute(KOREPattern *Attribute) {
-  if (auto constructor = dynamic_cast<KOREObjectCompositePattern *>(Attribute)) {
+  if (auto constructor = dynamic_cast<KORECompositePattern *>(Attribute)) {
     attributes.insert({constructor->getConstructor()->getName(), constructor});
     return;
   }
@@ -489,14 +453,14 @@ void KOREDefinition::addAttribute(KOREPattern *Attribute) {
 }
 
 void KOREDefinition::preprocess() {
-  auto symbols = std::map<std::string, std::vector<KOREObjectSymbol *>>{};
+  auto symbols = std::map<std::string, std::vector<KORESymbol *>>{};
   unsigned nextOrdinal = 0;
   for (auto iter = symbolDeclarations.begin(); iter != symbolDeclarations.end(); ++iter) {
     auto decl = *iter;
     if (decl.second->getAttributes().count("freshGenerator")) {
       auto sort = decl.second->getSymbol()->sort;
       if (sort->isConcrete()) {
-        freshFunctions[dynamic_cast<KOREObjectCompositeSort *>(sort)->getName()] = decl.second->getSymbol();
+        freshFunctions[dynamic_cast<KORECompositeSort *>(sort)->getName()] = decl.second->getSymbol();
       }
     }
   }
@@ -513,34 +477,34 @@ void KOREDefinition::preprocess() {
   for (auto moditer = modules.begin(); moditer != modules.end(); ++moditer) {
     auto declarations = (*moditer)->getDeclarations();
     for (auto iter = declarations.begin(); iter != declarations.end(); ++iter) {
-      KOREObjectSymbolDeclaration * decl = dynamic_cast<KOREObjectSymbolDeclaration *>(*iter);
+      KORESymbolDeclaration * decl = dynamic_cast<KORESymbolDeclaration *>(*iter);
       if (decl == nullptr) {
         continue;
       }
       if (decl->isHooked() && decl->getObjectSortVariables().empty()) {
-        KOREObjectSymbol * symbol = decl->getSymbol();
-        symbols.emplace(symbol->getName(), std::vector<KOREObjectSymbol *>{symbol});
+        KORESymbol * symbol = decl->getSymbol();
+        symbols.emplace(symbol->getName(), std::vector<KORESymbol *>{symbol});
       }
     }
   }
   for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
     auto entry = *iter;
     for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KOREObjectSymbol *symbol = *iter;
+      KORESymbol *symbol = *iter;
       auto decl = symbolDeclarations.at(symbol->getName());
       symbol->instantiateSymbol(decl);
     }
   }
   uint32_t nextSymbol = 0;
   uint16_t nextLayout = 1;
-  auto instantiations = std::unordered_map<KOREObjectSymbol, uint32_t, HashSymbol>{};
+  auto instantiations = std::unordered_map<KORESymbol, uint32_t, HashSymbol>{};
   auto layouts = std::unordered_map<std::string, uint16_t>{};
   auto variables = std::unordered_map<std::string, std::pair<uint32_t, uint32_t>>{};
   for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
     auto entry = *iter;
     uint32_t firstTag = nextSymbol;
     for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KOREObjectSymbol *symbol = *iter;
+      KORESymbol *symbol = *iter;
       if (symbol->isConcrete()) {
         if (!instantiations.count(*symbol)) {
           instantiations.emplace(*symbol, nextSymbol++);
@@ -566,7 +530,7 @@ void KOREDefinition::preprocess() {
     auto entry = *iter;
     auto range = variables.at(entry.first);
     for (auto iter = entry.second.begin(); iter != entry.second.end(); ++iter) {
-      KOREObjectSymbol *symbol = *iter;
+      KORESymbol *symbol = *iter;
       if (!symbol->isConcrete()) {
         if (symbol->isPolymorphic()) {
           symbol->firstTag = range.first;
@@ -582,21 +546,16 @@ void KOREDefinition::preprocess() {
 }
 
 // Pretty printer
-void KOREObjectSortVariable::print(std::ostream &Out, unsigned indent) const {
+void KORESortVariable::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << name;
 }
 
-void KOREMetaSortVariable::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "#" << name;
-}
-
-void KOREObjectCompositeSort::print(std::ostream &Out, unsigned indent) const {
+void KORECompositeSort::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << name << "{";
   bool isFirst = true;
-  for (const KOREObjectSort *Argument : arguments) {
+  for (const KORESort *Argument : arguments) {
     if (!isFirst)
       Out << ",";
     Argument->print(Out);
@@ -605,20 +564,15 @@ void KOREObjectCompositeSort::print(std::ostream &Out, unsigned indent) const {
   Out << "}";
 }
 
-void KOREMetaCompositeSort::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "#" << name << "{}";
-}
-
-void KOREObjectSymbol::print(std::ostream &Out, unsigned indent) const {
+void KORESymbol::print(std::ostream &Out, unsigned indent) const {
   print(Out, indent, true);
 }
 
-void KOREObjectSymbol::print(std::ostream &Out, unsigned indent, bool formal) const {
+void KORESymbol::print(std::ostream &Out, unsigned indent, bool formal) const {
   std::string Indent(indent, ' ');
   Out << Indent << name << "{";
   bool isFirst = true;
-  for (const KOREObjectSort *Argument : (formal ? formalArguments : arguments)) {
+  for (const KORESort *Argument : (formal ? formalArguments : arguments)) {
     if (!isFirst)
       Out << ", ";
     Argument->print(Out);
@@ -627,39 +581,13 @@ void KOREObjectSymbol::print(std::ostream &Out, unsigned indent, bool formal) co
   Out << "}";
 }
 
-void KOREMetaSymbol::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "#" << name << "{";
-  bool isFirst = true;
-  for (const KOREMetaSort *Argument : arguments) {
-    if (!isFirst)
-      Out << ",";
-    Argument->print(Out);
-    isFirst = false;
-  }
-  Out << "}";
-}
-
-void KOREObjectVariable::print(std::ostream &Out, unsigned indent) const {
+void KOREVariable::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << name;
 }
 
-void KOREMetaVariable::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "#" << name;
-}
-
 void
-KOREObjectVariablePattern::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent;
-  name->print(Out);
-  Out << " : ";
-  sort->print(Out);
-}
-
-void KOREMetaVariablePattern::print(std::ostream &Out, unsigned indent) const {
+KOREVariablePattern::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent;
   name->print(Out);
@@ -668,7 +596,7 @@ void KOREMetaVariablePattern::print(std::ostream &Out, unsigned indent) const {
 }
 
 void
-KOREObjectCompositePattern::print(std::ostream &Out, unsigned indent) const {
+KORECompositePattern::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent;
   constructor->print(Out);
@@ -681,35 +609,6 @@ KOREObjectCompositePattern::print(std::ostream &Out, unsigned indent) const {
     isFirst = false;
   }
   Out << ")";
-}
-
-void KOREMetaCompositePattern::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent;
-  constructor->print(Out);
-  Out << "(";
-  bool isFirst = true;
-  for (const KOREPattern *Argument : arguments) {
-    if (!isFirst)
-      Out << ",";
-    Argument->print(Out);
-    isFirst = false;
-  }
-  Out << ")";
-}
-
-static std::string escapeChar(char c) {
-  std::string result;
-  if (c == '\'' || c == '\\' || !isprint(c)) {
-    result.push_back('\\');
-    char code[3];
-    snprintf(code, 3, "%02x", (unsigned char)c);
-    result.push_back(code[0]);
-    result.push_back(code[1]);
-  } else {
-    result.push_back(c);
-  }
-  return result;
 }
 
 static std::string escapeString(const std::string &str) {
@@ -728,18 +627,13 @@ static std::string escapeString(const std::string &str) {
   return result;
 }
 
-void KOREMetaStringPattern::print(std::ostream &Out, unsigned indent) const {
+void KOREStringPattern::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << "\"" << escapeString(contents) << "\"";
 }
 
-void KOREMetaCharPattern::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "\'" << escapeChar(contents) << "\'";
-}
-
 static void printAttributeList(
-  std::ostream &Out, const std::map<std::string, KOREObjectCompositePattern *> attributes,
+  std::ostream &Out, const std::map<std::string, KORECompositePattern *> attributes,
   unsigned indent = 0) {
 
   std::string Indent(indent, ' ');
@@ -757,13 +651,7 @@ static void printAttributeList(
 void KOREDeclaration::printSortVariables(std::ostream &Out) const {
   Out << "{";
   bool isFirst = true;
-  for (const KOREObjectSortVariable *Variable : objectSortVariables) {
-    if (!isFirst)
-      Out << ",";
-    Variable->print(Out);
-    isFirst = false;
-  }
-  for (const KOREMetaSortVariable *Variable : metaSortVariables) {
+  for (const KORESortVariable *Variable : objectSortVariables) {
     if (!isFirst)
       Out << ",";
     Variable->print(Out);
@@ -772,7 +660,7 @@ void KOREDeclaration::printSortVariables(std::ostream &Out) const {
   Out << "}";
 }
 
-void KOREObjectCompositeSortDeclaration::print(
+void KORECompositeSortDeclaration::print(
   std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << (_isHooked ? "hooked-sort " : "sort ") << sortName;
@@ -782,14 +670,14 @@ void KOREObjectCompositeSortDeclaration::print(
 }
 
 void
-KOREObjectSymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
+KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << (_isHooked ? "hooked-symbol " : "symbol ")
       << symbol->getName();
   printSortVariables(Out);
   Out << "(";
   bool isFirst = true;
-  for (const KOREObjectSort *Argument : symbol->getArguments()) {
+  for (const KORESort *Argument : symbol->getArguments()) {
     if (!isFirst)
       Out << ",";
     Argument->print(Out);
@@ -802,32 +690,13 @@ KOREObjectSymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
 }
 
 void
-KOREMetaSymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "symbol " << symbol->getName();
-  printSortVariables(Out);
-  Out << "(";
-  bool isFirst = true;
-  for (const KOREMetaSort *Argument : symbol->getArguments()) {
-    if (!isFirst)
-      Out << ",";
-    Argument->print(Out);
-    isFirst = false;
-  }
-  Out << ") : ";
-  symbol->getSort()->print(Out);
-  Out << " ";
-  printAttributeList(Out, attributes);
-}
-
-void
-KOREObjectAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
+KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << "alias " << symbol->getName();
   printSortVariables(Out);
   Out << "(";
   bool isFirst = true;
-  for (const KOREObjectSort *Argument : symbol->getArguments()) {
+  for (const KORESort *Argument : symbol->getArguments()) {
     if (!isFirst)
       Out << ",";
     Argument->print(Out);
@@ -839,38 +708,7 @@ KOREObjectAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   printSortVariables(Out);
   Out << "(";
   isFirst = true;
-  for (const KOREObjectVariablePattern *Variable : boundVariables) {
-    if (!isFirst)
-      Out << ",";
-    Variable->print(Out);
-    isFirst = false;
-  }
-  Out << ") := ";
-  pattern->print(Out);
-  Out << " ";
-  printAttributeList(Out, attributes);
-}
-
-void
-KOREMetaAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
-  std::string Indent(indent, ' ');
-  Out << Indent << "alias " << symbol->getName();
-  printSortVariables(Out);
-  Out << "(";
-  bool isFirst = true;
-  for (const KOREMetaSort *Argument : symbol->getArguments()) {
-    if (!isFirst)
-      Out << ",";
-    Argument->print(Out);
-    isFirst = false;
-  }
-  Out << ") : ";
-  symbol->getSort()->print(Out);
-  Out << " where " << symbol->getName();
-  printSortVariables(Out);
-  Out << "(";
-  isFirst = true;
-  for (const KOREMetaVariablePattern *Variable : boundVariables) {
+  for (const KOREVariablePattern *Variable : boundVariables) {
     if (!isFirst)
       Out << ",";
     Variable->print(Out);

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -71,23 +71,23 @@ void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable 
 static std::string SOURCE_ATT = "org'Stop'kframework'Stop'attributes'Stop'Source";
 static std::string LOCATION_ATT = "org'Stop'kframework'Stop'attributes'Stop'Location";
 
-void initDebugAxiom(std::map<std::string, KOREObjectCompositePattern *> const& att) {
+void initDebugAxiom(std::map<std::string, KORECompositePattern *> const& att) {
   if (!Dbg) return;
   if (!att.count(SOURCE_ATT)) {
     resetDebugLoc();
     return;
   }
-  KOREObjectCompositePattern *sourceAtt = att.at(SOURCE_ATT);
+  KORECompositePattern *sourceAtt = att.at(SOURCE_ATT);
   assert(sourceAtt->getArguments().size() == 1);
-  auto strPattern = dynamic_cast<KOREMetaStringPattern *>(sourceAtt->getArguments()[0]);
+  auto strPattern = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0]);
   std::string source = strPattern->getContents();
   if (!att.count(LOCATION_ATT)) {
     resetDebugLoc();
     return;
   }
-  KOREObjectCompositePattern *locationAtt = att.at(LOCATION_ATT);
+  KORECompositePattern *locationAtt = att.at(LOCATION_ATT);
   assert(locationAtt->getArguments().size() == 1);
-  auto strPattern2 = dynamic_cast<KOREMetaStringPattern *>(locationAtt->getArguments()[0]);
+  auto strPattern2 = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0]);
   std::string location = strPattern2->getContents();
   source = source.substr(7, source.length() - 8);
   size_t first_comma = location.find_first_of(',');

--- a/lib/parser/KOREParserDriver.cpp
+++ b/lib/parser/KOREParserDriver.cpp
@@ -47,14 +47,14 @@ KOREModuleImportDeclaration *KOREParserDriver::finishModuleImportDeclaration() {
 void KOREParserDriver::startObjectSortDeclaration(
   const std::string &Name, bool isHooked) {
   currentDeclaration =
-    KOREObjectCompositeSortDeclaration::Create(Name, isHooked);
+    KORECompositeSortDeclaration::Create(Name, isHooked);
   pushState(ParsingDeclaration);
 }
 
-KOREObjectCompositeSortDeclaration *
+KORECompositeSortDeclaration *
 KOREParserDriver::finishObjectSortDeclaration() {
-  KOREObjectCompositeSortDeclaration *ParsedDeclaration =
-    static_cast<KOREObjectCompositeSortDeclaration *>(currentDeclaration);
+  KORECompositeSortDeclaration *ParsedDeclaration =
+    static_cast<KORECompositeSortDeclaration *>(currentDeclaration);
   currentDeclaration = nullptr;
   popState();
   return ParsedDeclaration;
@@ -78,29 +78,14 @@ KOREParserDriver::finishAxiomDeclaration(KOREPattern *Pattern) {
 void KOREParserDriver::startObjectSymbolDeclaration(
   const std::string &Name, bool isHooked) {
   currentDeclaration =
-    KOREObjectSymbolDeclaration::Create(Name, isHooked);
+    KORESymbolDeclaration::Create(Name, isHooked);
   pushState(ParsingDeclaration);
 }
 
-KOREObjectSymbolDeclaration *
-KOREParserDriver::finishObjectSymbolDeclaration(KOREObjectSort *Sort) {
-  KOREObjectSymbolDeclaration *ParsedDeclaration =
-    static_cast<KOREObjectSymbolDeclaration *>(currentDeclaration);
-  ParsedDeclaration->getSymbol()->addSort(Sort);
-  currentDeclaration = nullptr;
-  popState();
-  return ParsedDeclaration;
-}
-
-void KOREParserDriver::startMetaSymbolDeclaration(const std::string &Name) {
-  currentDeclaration = KOREMetaSymbolDeclaration::Create(Name);
-  pushState(ParsingDeclaration);
-}
-
-KOREMetaSymbolDeclaration *
-KOREParserDriver::finishMetaSymbolDeclaration(KOREMetaSort *Sort) {
-  KOREMetaSymbolDeclaration *ParsedDeclaration =
-    static_cast<KOREMetaSymbolDeclaration *>(currentDeclaration);
+KORESymbolDeclaration *
+KOREParserDriver::finishObjectSymbolDeclaration(KORESort *Sort) {
+  KORESymbolDeclaration *ParsedDeclaration =
+    static_cast<KORESymbolDeclaration *>(currentDeclaration);
   ParsedDeclaration->getSymbol()->addSort(Sort);
   currentDeclaration = nullptr;
   popState();
@@ -108,30 +93,14 @@ KOREParserDriver::finishMetaSymbolDeclaration(KOREMetaSort *Sort) {
 }
 
 void KOREParserDriver::startObjectAliasDeclaration(const std::string &Name) {
-  currentDeclaration = KOREObjectAliasDeclaration::Create(Name);
+  currentDeclaration = KOREAliasDeclaration::Create(Name);
   pushState(ParsingDeclaration);
 }
 
-KOREObjectAliasDeclaration *KOREParserDriver::finishObjectAliasDeclaration(
-  KOREObjectSort *Sort, KOREObjectPattern *Pattern) {
-  KOREObjectAliasDeclaration *ParsedDeclaration =
-    static_cast<KOREObjectAliasDeclaration *>(currentDeclaration);
-  ParsedDeclaration->getSymbol()->addSort(Sort);
-  ParsedDeclaration->addPattern(Pattern);
-  currentDeclaration = nullptr;
-  popState();
-  return ParsedDeclaration;
-}
-
-void KOREParserDriver::startMetaAliasDeclaration(const std::string &Name) {
-  currentDeclaration = KOREMetaAliasDeclaration::Create(Name);
-  pushState(ParsingDeclaration);
-}
-
-KOREMetaAliasDeclaration *KOREParserDriver::finishMetaAliasDeclaration(
-  KOREMetaSort *Sort, KOREMetaPattern *Pattern) {
-  KOREMetaAliasDeclaration *ParsedDeclaration =
-    static_cast<KOREMetaAliasDeclaration *>(currentDeclaration);
+KOREAliasDeclaration *KOREParserDriver::finishObjectAliasDeclaration(
+  KORESort *Sort, KOREPattern *Pattern) {
+  KOREAliasDeclaration *ParsedDeclaration =
+    static_cast<KOREAliasDeclaration *>(currentDeclaration);
   ParsedDeclaration->getSymbol()->addSort(Sort);
   ParsedDeclaration->addPattern(Pattern);
   currentDeclaration = nullptr;
@@ -141,44 +110,28 @@ KOREMetaAliasDeclaration *KOREParserDriver::finishMetaAliasDeclaration(
 
 void KOREParserDriver::startObjectPattern(const std::string &Name) {
   pushPattern(currentObjectPattern);
-  currentObjectPattern = KOREObjectCompositePattern::Create(Name);
+  currentObjectPattern = KORECompositePattern::Create(Name);
   pushState(ParsingObjectPattern);
 }
 
-KOREObjectCompositePattern *KOREParserDriver::finishObjectPattern() {
-  KOREObjectCompositePattern *ParsedObjectPattern = currentObjectPattern;
+KORECompositePattern *KOREParserDriver::finishObjectPattern() {
+  KORECompositePattern *ParsedObjectPattern = currentObjectPattern;
   currentObjectPattern =
-    static_cast<KOREObjectCompositePattern *>(getCurrentPattern());
+    static_cast<KORECompositePattern *>(getCurrentPattern());
   popPattern();
   popState();
 
   return ParsedObjectPattern;
 }
 
-void KOREParserDriver::startMetaPattern(const std::string &Name) {
-  pushPattern(currentMetaPattern);
-  currentMetaPattern = KOREMetaCompositePattern::Create(Name);
-  pushState(ParsingMetaPattern);
-}
-
-KOREMetaCompositePattern *KOREParserDriver::finishMetaPattern() {
-  KOREMetaCompositePattern *ParsedMetaPattern = currentMetaPattern;
-  currentMetaPattern =
-    static_cast<KOREMetaCompositePattern *>(getCurrentPattern());
-  popPattern();
-  popState();
-
-  return ParsedMetaPattern;
-}
-
 void KOREParserDriver::startObjectSort(const std::string &Name) {
   pushSort(currentObjectSort);
-  currentObjectSort = KOREObjectCompositeSort::Create(Name);
+  currentObjectSort = KORECompositeSort::Create(Name);
   pushState(ParsingObjectSort);
 }
 
-KOREObjectCompositeSort *KOREParserDriver::finishObjectSort() {
-  KOREObjectCompositeSort *ParsedObjectSort = currentObjectSort;
+KORECompositeSort *KOREParserDriver::finishObjectSort() {
+  KORECompositeSort *ParsedObjectSort = currentObjectSort;
   currentObjectSort = getCurrentSort();
   popSort();
   popState();
@@ -195,13 +148,8 @@ void KOREParserDriver::addDeclaration(KOREDeclaration *Declaration) {
 }
 
 void
-KOREParserDriver::addObjectSortVariable(KOREObjectSortVariable *SortVariable) {
+KOREParserDriver::addObjectSortVariable(KORESortVariable *SortVariable) {
   currentDeclaration->addObjectSortVariable(SortVariable);
-}
-
-void
-KOREParserDriver::addMetaSortVariable(KOREMetaSortVariable *SortVariable) {
-  currentDeclaration->addMetaSortVariable(SortVariable);
 }
 
 void KOREParserDriver::addPattern(KOREPattern *Pattern) {
@@ -218,19 +166,16 @@ void KOREParserDriver::addPattern(KOREPattern *Pattern) {
   case ParsingObjectPattern:
     currentObjectPattern->addArgument(Pattern);
     break;
-  case ParsingMetaPattern:
-    currentMetaPattern->addArgument(Pattern);
-    break;
   default:
     abort();
     break;
   }
 }
 
-void KOREParserDriver::addObjectSort(KOREObjectSort *Sort) {
+void KOREParserDriver::addObjectSort(KORESort *Sort) {
   switch (getCurrentState()) {
   case ParsingDeclaration:
-    static_cast<KOREObjectSymbolAliasDeclaration *>(currentDeclaration)->getSymbol()->addArgument(Sort);
+    static_cast<KORESymbolAliasDeclaration *>(currentDeclaration)->getSymbol()->addArgument(Sort);
     break;
   case ParsingObjectPattern:
     currentObjectPattern->getConstructor()->addFormalArgument(Sort);
@@ -244,27 +189,7 @@ void KOREParserDriver::addObjectSort(KOREObjectSort *Sort) {
   }
 }
 
-void KOREParserDriver::addMetaSort(KOREMetaSort *Sort) {
-  switch (getCurrentState()) {
-  case ParsingDeclaration:
-    static_cast<KOREMetaSymbolAliasDeclaration *>(currentDeclaration)->getSymbol()->addArgument(Sort);
-    break;
-  case ParsingMetaPattern:
-    currentMetaPattern->getConstructor()->addArgument(Sort);
-    break;
-  default:
-    abort();
-    break;
-  }
-}
-
 void
-KOREParserDriver::addObjectVariable(KOREObjectVariablePattern *Variable) {
-  static_cast<KOREObjectAliasDeclaration *>(currentDeclaration)->addVariable(Variable);
+KOREParserDriver::addObjectVariable(KOREVariablePattern *Variable) {
+  static_cast<KOREAliasDeclaration *>(currentDeclaration)->addVariable(Variable);
 }
-
-void
-KOREParserDriver::addMetaVariable(KOREMetaVariablePattern *Variable) {
-  static_cast<KOREMetaAliasDeclaration *>(currentDeclaration)->addVariable(Variable);
-}
-

--- a/lib/parser/KOREScanner.l
+++ b/lib/parser/KOREScanner.l
@@ -70,26 +70,6 @@ yyin = in;
   return KOREParser::token::OBJECTID;
 }
 
-"#"{ident} {
-  lval->build<std::string>(yytext + 1);
-  return KOREParser::token::METAID;
-}
-
-"#\\"{ident} {
-  lval->build<std::string>(yytext + 1);
-  return KOREParser::token::METAID;
-}
-
-"#`"{ident} {
-  lval->build<std::string>(yytext + 1);
-  return KOREParser::token::METAID;
-}
-
-"'"[[:print:]]"'" {
-  lval->build<char>(yytext[1]);
-  return KOREParser::token::CHAR;
-}
-
 "\""            { stringBuffer.clear(); BEGIN(STR);           }
 <STR>[^\"\n\\]* { stringBuffer.append(yytext);                }
 <STR>"\\n"       { stringBuffer.push_back('\n'); loc->lines(); }
@@ -146,7 +126,6 @@ int KOREScanner::scan() {
     std::string lexeme;
     switch (token) {
     case KOREParser::token::OBJECTID:
-    case KOREParser::token::METAID:
     case KOREParser::token::STRING:
       lexeme = sem.as<std::string>();
       sem.destroy<std::string>();

--- a/runtime/configurationparser/ConfigurationParser.cpp
+++ b/runtime/configurationparser/ConfigurationParser.cpp
@@ -17,15 +17,15 @@ extern "C" {
 }
 
 static void *allocatePatternAsConfiguration(const KOREPattern *Pattern) {
-  const auto constructor = dynamic_cast<const KOREObjectCompositePattern *>(Pattern);
+  const auto constructor = dynamic_cast<const KORECompositePattern *>(Pattern);
   assert(constructor);
 
-  const KOREObjectSymbol *symbol = constructor->getConstructor();
+  const KORESymbol *symbol = constructor->getConstructor();
   assert(symbol->isConcrete() && "found sort variable in initial configuration");
   if (symbol->getName() == "\\dv") {
-    const auto sort = dynamic_cast<KOREObjectCompositeSort *>(symbol->getFormalArguments()[0]);
+    const auto sort = dynamic_cast<KORECompositeSort *>(symbol->getFormalArguments()[0]);
     const auto strPattern =
-      dynamic_cast<KOREMetaStringPattern *>(constructor->getArguments()[0]);
+      dynamic_cast<KOREStringPattern *>(constructor->getArguments()[0]);
     std::string contents = strPattern->getContents();
     return getToken(sort->getName().c_str(), contents.size(), contents.c_str());
   }
@@ -91,7 +91,7 @@ block *parseConfiguration(const char *filename) {
 
   // We expect the initial configuration as an attribute named "initial-configuration"
   assert(definition->getAttributes().count("initial-configuration"));
-  const KOREObjectCompositePattern *InitialConfigurationAttribute =
+  const KORECompositePattern *InitialConfigurationAttribute =
     definition->getAttributes().at("initial-configuration");
   assert(InitialConfigurationAttribute->getArguments().size() > 0);
   const KOREPattern *InitialConfiguration =

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -19,7 +19,7 @@
 using namespace kllvm;
 using namespace kllvm::parser;
 
-std::string getFilename(std::map<std::string, std::string> index, char **argv, KOREObjectSymbolDeclaration *decl) {
+std::string getFilename(std::map<std::string, std::string> index, char **argv, KORESymbolDeclaration *decl) {
   return argv[3] + std::string("/") + index.at(decl->getSymbol()->getName());
 }
 

--- a/unittests/compiler/asttest.cpp
+++ b/unittests/compiler/asttest.cpp
@@ -7,33 +7,33 @@ using namespace kllvm;
 BOOST_AUTO_TEST_SUITE(ASTTest)
 
 BOOST_AUTO_TEST_CASE(substitute) {
-  std::unordered_map<KOREObjectSortVariable, KOREObjectSort *, HashSort> subst;
-  auto var = KOREObjectSortVariable::Create("foo");
-  auto composite = KOREObjectCompositeSort::Create("bar");
-  auto poly = KOREObjectCompositeSort::Create("baz");
+  std::unordered_map<KORESortVariable, KORESort *, HashSort> subst;
+  auto var = KORESortVariable::Create("foo");
+  auto composite = KORECompositeSort::Create("bar");
+  auto poly = KORECompositeSort::Create("baz");
   poly->addArgument(var);
   subst[*var] = composite;
   BOOST_CHECK_EQUAL(var->substitute(subst), composite);
   BOOST_CHECK_EQUAL(composite->substitute(subst), composite);
-  auto expected = KOREObjectCompositeSort::Create("baz");
+  auto expected = KORECompositeSort::Create("baz");
   expected->addArgument(composite);
   BOOST_CHECK_EQUAL(*poly->substitute(subst), *expected);
 }
 
 BOOST_AUTO_TEST_CASE(instantiate) {
-  auto decl = KOREObjectSymbolDeclaration::Create("sym");
-  auto var = KOREObjectSortVariable::Create("foo");
+  auto decl = KORESymbolDeclaration::Create("sym");
+  auto var = KORESortVariable::Create("foo");
   decl->addObjectSortVariable(var);
-  auto poly = KOREObjectCompositeSort::Create("baz");
-  auto composite = KOREObjectCompositeSort::Create("bar");
+  auto poly = KORECompositeSort::Create("baz");
+  auto composite = KORECompositeSort::Create("bar");
   poly->addArgument(var);
   decl->getSymbol()->addArgument(poly);
   decl->getSymbol()->addArgument(composite);
   decl->getSymbol()->addSort(poly);
-  auto sym = KOREObjectSymbol::Create("sym");
+  auto sym = KORESymbol::Create("sym");
   sym->addFormalArgument(composite);
   sym->instantiateSymbol(decl);
-  auto expected = KOREObjectCompositeSort::Create("baz");
+  auto expected = KORECompositeSort::Create("baz");
   expected->addArgument(composite);
   BOOST_CHECK_EQUAL(*sym->getSort(), *expected);
   BOOST_CHECK_EQUAL(sym->getArguments().size(), 2);


### PR DESCRIPTION
This is the first of two refactorings to the parser I am making in order to ensure that memory associated with KOREDefinition etc is freed after calls to parseConfiguration. Here we delete the meta level stuff because it is no longer a part of the syntax of KORE.