### PR TITLE
Slight improvements to Jenkinsfile testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,5 +26,11 @@ pipeline {
         '''
       }
     }
+    stage('Update K Submodule') {
+      when { branch 'master' }
+      steps {
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'dwightguth'), booleanParam(name: 'UPDATE_DEPS_K_LLVM', value: true)], propagate: false, wait: false
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
       }
     }
     stage('Build and Test') {
+      options { timeout(time: 10, unit: 'MINUTES') }
       steps {
         sh '''
           ./ciscript Debug

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,4 +33,15 @@ pipeline {
       }
     }
   }
+  post {
+    unsuccessful {
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          slackSend color: '#cb2431'                                    \
+                    , channel: '#llvm-backend'                          \
+                    , message: "Master build failure: ${env.BUILD_URL}"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
-   Trigger auto-update of LLVM backend submodule on `master` branch.
-   Send slack message on failing `master` branch tests.
-   Global timeout on testing phase.