### PR TITLE
remove jemalloc.h which is unused

### DIFF
--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -3,7 +3,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include "jemalloc/jemalloc.h"
 
 #include "runtime/arena.h"
 #include "runtime/header.h"


### PR DESCRIPTION
We don't actually need to include jemalloc.h to use the jemalloc implementation of malloc, and we aren't using anything else in that header, so I am removing the include of this header as it seems to break the build on Mac OS Catalina.