### PR TITLE
Llvm 9 better version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,12 @@ endif()
 set(CMAKE_AR "${CMAKE_C_COMPILER_AR}")
 set(CMAKE_RANLIB "${CMAKE_C_COMPILER_RANLIB}")
 
-find_package(LLVM REQUIRED CONFIG)
+find_package(LLVM 8 QUIET CONFIG)
+
+if (NOT LLVM_FOUND)
+  find_package(LLVM 7 REQUIRED CONFIG)
+endif()
+
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 if (${LLVM_PACKAGE_VERSION} VERSION_LESS 7.0.1)
   message(FATAL_ERROR "LLVM 7.0.1 or newer is required")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,11 @@ endif()
 set(CMAKE_AR "${CMAKE_C_COMPILER_AR}")
 set(CMAKE_RANLIB "${CMAKE_C_COMPILER_RANLIB}")
 
-find_package(LLVM 8 QUIET CONFIG)
+find_package(LLVM 9 QUIET CONFIG)
+
+if (NOT LLVM_FOUND)
+  find_package(LLVM 8 QUIET CONFIG)
+endif()
 
 if (NOT LLVM_FOUND)
   find_package(LLVM 7 REQUIRED CONFIG)


### PR DESCRIPTION
Apparently if you don't specify a version cmake doesn't necessarily prefer newer versions to older versions, so we need to do this explicitly after all.