### PR TITLE
fix system hook

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -206,6 +206,7 @@ extern "C" {
 
   stringbuffer *hook_BUFFER_empty(void);
   stringbuffer *hook_BUFFER_concat(stringbuffer *buf, string *s);
+  stringbuffer *hook_BUFFER_concat_raw(stringbuffer *buf, char *data, uint64_t n);
   string *hook_BUFFER_toString(stringbuffer *buf);
 
   size_t hook_SET_size_long(set *);

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -330,8 +330,12 @@ extern "C" {
   }
 
   stringbuffer *hook_BUFFER_concat(stringbuffer *buf, string *s) {
+    return hook_BUFFER_concat_raw(buf, s->data, len(s));
+  }
+
+  stringbuffer *hook_BUFFER_concat_raw(stringbuffer *buf, char *data, uint64_t n) {
     uint64_t newCapacity = len(buf->contents);
-    uint64_t minCapacity = buf->strlen + len(s);
+    uint64_t minCapacity = buf->strlen + n;
     uint64_t notYoungObjectBit = buf->h.hdr & NOT_YOUNG_OBJECT_BIT;
     if (newCapacity < minCapacity) {
       newCapacity = len(buf->contents) * 2 + 2;
@@ -348,8 +352,8 @@ extern "C" {
       memcpy(new_contents->data, buf->contents->data, buf->strlen);
       buf->contents = new_contents;
     }
-    memcpy(buf->contents->data + buf->strlen, s->data, len(s));
-    buf->strlen += len(s);
+    memcpy(buf->contents->data + buf->strlen, data, n);
+    buf->strlen += n;
     set_len(buf->contents, newCapacity);
     return buf;
   }

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -408,7 +408,8 @@ BOOST_AUTO_TEST_CASE(system) {
   BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(ret->children), 0));
 
   string * out = (string *) *(ret->children + 1);
-  BOOST_CHECK_EQUAL(0, strncmp(out->data, "hello", 5));
+  BOOST_CHECK_EQUAL(0, strncmp(out->data, "hello\n", 6));
+  BOOST_CHECK_EQUAL(6, len(out));
 
   /* Check if shell is available */
   command = "";
@@ -448,6 +449,7 @@ BOOST_AUTO_TEST_CASE(system) {
 
   string * err = (string *) *(ret->children + 2);
   BOOST_CHECK_EQUAL(0, strncmp(err->data, "Error", 5));
+  BOOST_CHECK_EQUAL(5, len(err));
 }
 
 BOOST_AUTO_TEST_CASE(time) {


### PR DESCRIPTION
Previously we were only calling read once per file descriptor when we called the system hook. This is bad because it means it won't read the entire output if the output is longer than the buffer size. We were also setting the length of the string equal to the length of the buffer instead of to the number of characters read.

This PR should fix the behavior by allocating string buffers on the KORE heap and using `select` to multiplex reading from stderr and stdout until both have been read to completion, at which time it converts the string buffers into strings. We didn't detect this error before because we were not asserting anything in our unit tests about the length of the string returned, only about the first five characters of the string. So I fixed the unit tests as well.