### PR TITLE
always enable dwarf info in runtime

### DIFF
--- a/lib/ast/CMakeLists.txt
+++ b/lib/ast/CMakeLists.txt
@@ -5,6 +5,9 @@ set(LLVM_LINK_COMPONENTS
 
 set(LLVM_REQUIRES_RTTI ON)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 add_library(AST
   AST.cpp
 )

--- a/lib/parser/CMakeLists.txt
+++ b/lib/parser/CMakeLists.txt
@@ -3,6 +3,9 @@ FLEX_TARGET(KOREScanner KOREScanner.l ${CMAKE_CURRENT_BINARY_DIR}/KOREScanner.cp
 set(LLVM_REQUIRES_RTTI ON)
 set(LLVM_REQUIRES_EH ON)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 add_library(Parser
   KOREScanner.cpp
   KOREParser.cpp

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
 add_subdirectory(arithmetic)
 add_subdirectory(configurationparser)
 add_subdirectory(strings)


### PR DESCRIPTION
Even when building a release build of the llvm backend, we generally want the ability to do debug builds of K definitions. This requires building the llvm backend runtime with debug symbols. So we modify the CMake scripts so that debug symbols are always enabled on runtime components, regardless of the configuration mode selected.