### PR TITLE
fix test harness when one definition has multiple tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -46,8 +46,8 @@ $(DEFNDIR)/%.testd: $(INTDIR)/%.interpreter $(INPUTDIR)/%/ $(OUTPUTDIR)/%/
 	$(eval TMP_DIFF_NAME := $(subst $(SUFOUTDIFF),,$(notdir $(TMP_DIFF_OUT))))
 	$(eval TMP_GREP_NAME := $(subst $(SUFOUTGREP),, $(notdir $(TMP_GREP_OUT))))
 	$(eval TMP_DIR_NAME := $(basename $(notdir $@)))
-	$(foreach file, $(TMP_DIFF_NAME), $< $(INPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFINKORE) -1 /dev/stdout | diff - $(OUTPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFOUTDIFF) ;)
-	$(foreach file, $(TMP_GREP_NAME), $< $(INPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFINKORE) -1 /dev/stdout | grep -f $(OUTPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFOUTGREP) -q ;)
+	$(foreach file, $(TMP_DIFF_NAME), $< $(INPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFINKORE) -1 /dev/stdout | diff - $(OUTPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFOUTDIFF) &&) true
+	$(foreach file, $(TMP_GREP_NAME), $< $(INPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFINKORE) -1 /dev/stdout | grep -f $(OUTPUTDIR)/$(TMP_DIR_NAME)/$(file)$(SUFOUTGREP) -q &&) true
 
 $(DEFNDIR)/%.testn: $(INTDIR)/%.interpreter $(INPUTDIR)/%$(SUFINKORE)
 	$< $(word 2, $^) -1 /dev/null


### PR DESCRIPTION
I realized today that we were not actually checking correctly that the diff and grep commands in our test harness reported no errors, inside the tests that test multiple programs with a single definition. This PR fixes that oversight, but fortunately there are no regressions that resulted from it.