### PR TITLE
Correctly print sorts of terms in gdb

### DIFF
--- a/gdb/kllvm.py
+++ b/gdb/kllvm.py
@@ -619,6 +619,9 @@ class termPrinter:
         if isBinder:
             self.bound_variables.append((subject.cast(self.long_int) + 8).cast(self.block_ptr_ptr).dereference())
         symbol = self.getSymbolNameForTag(tag).string()
+        if symbol[0:4] == "inj{":
+            prefix = symbol[0:symbol.index(",")]
+            symbol = prefix + ", " + sort[4:] + "}"
         self.result += pp_label(symbol) + "("
         layoutData = self.getLayoutData(layout)
         nargs = int(layoutData['nargs'])

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -15,14 +15,14 @@ void finalizeDebugInfo(void);
 void initDebugFunction(std::string name, std::string linkageName, llvm::DISubroutineType *type, KOREDefinition *definition, llvm::Function *func);
 
 void initDebugAxiom(std::map<std::string, ptr<KORECompositePattern>> const& att);
-void initDebugParam(llvm::Function *func, unsigned argNo, std::string name, ValueType type);
+void initDebugParam(llvm::Function *func, unsigned argNo, std::string name, ValueType type, std::string typeName);
 void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable *var);
 
-llvm::DIType *getDebugType(ValueType type);
+llvm::DIType *getDebugType(ValueType type, std::string typeName);
 llvm::DIType *getIntDebugType(void);
 llvm::DIType *getBoolDebugType(void);
 llvm::DIType *getShortDebugType(void);
-llvm::DIType *getPointerDebugType(llvm::DIType *);
+llvm::DIType *getPointerDebugType(llvm::DIType *, std::string typeName);
 llvm::DIType *getArrayDebugType(llvm::DIType *ty, size_t len, size_t align);
 llvm::DIType *getCharPtrDebugType(void);
 llvm::DIType *getForwardDecl(std::string name);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -816,6 +816,45 @@ static void emitInjTags(KOREDefinition *def, llvm::Module *mod) {
   }
 }
 
+static void emitSortTable(KOREDefinition *definition, llvm::Module *module) {
+  llvm::LLVMContext &Ctx = module->getContext();
+  auto &syms = definition->getSymbols();
+  auto ty = llvm::PointerType::getUnqual(llvm::Type::getInt8PtrTy(Ctx));
+  auto dity = getPointerDebugType(getCharPtrDebugType(), "char *");
+  auto tableType = llvm::ArrayType::get(ty, syms.size());
+  auto table = module->getOrInsertGlobal("sort_table", tableType);
+  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(table);
+  initDebugGlobal("sort_table", getArrayDebugType(dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)), globalVar);
+  std::vector<llvm::Constant *> values;
+  for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
+    auto entry = *iter;
+    auto symbol = entry.second;
+
+    auto subtableType = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), symbol->getArguments().size());
+    std::ostringstream Out;
+    symbol->print(Out);
+    auto subtable = module->getOrInsertGlobal("sorts_" + Out.str(), subtableType);
+    llvm::GlobalVariable *subtableVar = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    initDebugGlobal("sorts_" + symbol->getName(), getArrayDebugType(getCharPtrDebugType(), symbol->getArguments().size(), llvm::DataLayout(module).getABITypeAlignment(llvm::Type::getInt8PtrTy(Ctx))), subtableVar);
+    llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
+    auto indices = std::vector<llvm::Constant *>{zero, zero};
+    values.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(subtableType, subtableVar, indices));
+
+    std::vector<llvm::Constant *> subvalues;
+    for (size_t i = 0; i < symbol->getArguments().size(); ++i) {
+      std::ostringstream Out;
+      symbol->getArguments()[i]->print(Out);
+      auto strType = llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), Out.str().size() + 1);
+      auto sortName = module->getOrInsertGlobal("sort_name_" + Out.str(), strType);
+      subvalues.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(strType, sortName, indices));
+    }
+    subtableVar->setInitializer(llvm::ConstantArray::get(subtableType, subvalues));
+  }
+  if (!globalVar->hasInitializer()) {
+    globalVar->setInitializer(llvm::ConstantArray::get(tableType, values));
+  }
+}
+
 void emitConfigParserFunctions(KOREDefinition *definition, llvm::Module *module) {
   emitGetTagForSymbolName(definition, module); 
   emitGetBlockHeaderForSymbol(definition, module); 
@@ -833,6 +872,8 @@ void emitConfigParserFunctions(KOREDefinition *definition, llvm::Module *module)
   emitLayouts(definition, module);
 
   emitInjTags(definition, module);
+
+  emitSortTable(definition, module);
 }
 
 }

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -774,7 +774,7 @@ static void emitLayouts(KOREDefinition *definition, llvm::Module *module) {
   argTypes.push_back(llvm::Type::getInt16Ty(Ctx));
   auto func = llvm::dyn_cast<llvm::Function>(getOrInsertFunction(module,
       "getLayoutData", llvm::FunctionType::get(llvm::PointerType::getUnqual(module->getTypeByName(LAYOUT_STRUCT)), argTypes, false)));
-  initDebugFunction("getLayoutData", "getLayoutData", getDebugFunctionType(getPointerDebugType(getForwardDecl(LAYOUT_STRUCT)), {getShortDebugType()}), definition, func);
+  initDebugFunction("getLayoutData", "getLayoutData", getDebugFunctionType(getPointerDebugType(getForwardDecl(LAYOUT_STRUCT), "layout *"), {getShortDebugType()}), definition, func);
   auto EntryBlock = llvm::BasicBlock::Create(Ctx, "entry", func);
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
   auto stuck = llvm::BasicBlock::Create(Ctx, "stuck");


### PR DESCRIPTION
Fixes #272 

This should fix both injections and tokens being pretty printed with the wrong sorts.