### PR TITLE
fix arch debug builds

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -30,6 +30,10 @@ else
   flags=-ltinfo
 fi
 
+if [ -f "/etc/arch-release" ]; then
+  llc_flags="$llc_flags --relocation-model=pic"
+fi
+
 lang="-x ir"
 if [ "$lto" = "lto" ]; then
   flags="$flags -flto -Wl,-mllvm,-tailcallopt"


### PR DESCRIPTION
Arch linux patched llvm so that position independent executables were enabled by default by clang and lld, but not llc :/

So we need to pass --relocation-model=pic manually to llc when we invoke llc otherwise we will get a bunch of arcane linker errors.

Fixes #243 