### PR TITLE
more performant alias expansion

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -218,13 +218,13 @@ object Parser {
     }
   }
 
-  private def expandAliases(axiom: AxiomDeclaration, defn: Definition) : AxiomDeclaration = { 
-    val aliases = defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AliasDeclaration]).map(_.asInstanceOf[AliasDeclaration]).map(al => (al.alias.ctr, al)).toMap
+  private def expandAliases(axiom: AxiomDeclaration, aliases: Map[String, AliasDeclaration]) : AxiomDeclaration = { 
     B.AxiomDeclaration(axiom.params, expandAliases(axiom.pattern, aliases), axiom.att).asInstanceOf[AxiomDeclaration]
   }
 
   def getAxioms(defn: Definition) : Seq[AxiomDeclaration] = {
-    defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AxiomDeclaration]).map(_.asInstanceOf[AxiomDeclaration]).map(expandAliases(_, defn))
+    val aliases = defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AliasDeclaration]).map(_.asInstanceOf[AliasDeclaration]).map(al => (al.alias.ctr, al)).toMap
+    defn.modules.flatMap(_.decls).filter(_.isInstanceOf[AxiomDeclaration]).map(_.asInstanceOf[AxiomDeclaration]).map(expandAliases(_, aliases))
   }
 
   def getSorts(defn: Definition): Seq[Sort] = {


### PR DESCRIPTION
Previously we were paying a quadratic cost in the number of axioms in the KORE definition in order to expand all the aliases. This is okay for definitions up to a certain point, but explodes the time spent generating decision trees once the size of the definition gets beyond a certain point. This was simply an oversight, though, and we are able to compute the necessary information in linear time. So here we do just that.