### PR TITLE
don't use the same filename for multiple symbols with identical initial

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
@@ -89,6 +89,6 @@ object Matching {
     val file = new File(args(0))
     val outputFolder = new File(args(2))
     logging = args.size > 4
-    writeDecisionTreeToFile(file, args(1), outputFolder, getThreshold(args(3)), false, (e) => ())
+    writeDecisionTreeToFile(file, args(1), outputFolder, getThreshold(args(3)), true, (e) => ())
   }
 }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matching.scala
@@ -57,11 +57,13 @@ object Matching {
     val files = (symlib.functions, dts).zipped.toIterable
     val index = new File(outputFolder, "index.txt")
     val writer = new FileWriter(index)
+    var idx = 0
     for (pair <- files) {
       val sym = pair._1.ctr
-      val filename = (if (sym.length > 250) sym.substring(0, 250) else sym) + ".yaml"
+      val filename = (if (sym.length > 240) sym.substring(0, 240) + idx else sym) + ".yaml"
       pair._2.serializeToYaml(new File(outputFolder, filename))
       writer.write(pair._1.ctr + "\t" + filename + "\n")
+      idx+=1
     }
     writer.close
   }
@@ -87,6 +89,6 @@ object Matching {
     val file = new File(args(0))
     val outputFolder = new File(args(2))
     logging = args.size > 4
-    writeDecisionTreeToFile(file, args(1), outputFolder, getThreshold(args(3)), true, (e) => ())
+    writeDecisionTreeToFile(file, args(1), outputFolder, getThreshold(args(3)), false, (e) => ())
   }
 }


### PR DESCRIPTION
250 characters

We previously ran into an issue where because we were using symbol names as file names for the decision trees of functions, we would get a unix error if the symbol name had >250 characters, because the filename would exceed the 255 character limit of path components on unix. We fixed this by creating an index from symbol names to filenames and trimmed the filenames to their initial 250 characters. However, this has the effect that if there are multiple symbols with the same initial 250 characters, their decision trees overwrite one another, which leads to some of those functions seeing a decision tree intended for another function, which causes the code generation phase to crash with an error.

In order to fix this, we simply create a unique integer variable and append it to the filename, taking a slightly shorter 240 character prefix. Since the maximum integer is 10 digits long, we should always end up with a unique filename less than 255 characters. The index file will still map these filenames back to the original symbol names just fine. Obviously this assumes that there are less than 2^32 functions in the definition, but that's a reasonable limit at which other things would certainly break, not to mention it is unlikely to ever be reached.

I tested this on the C semantics and it fixes the crash that was reported to me.