### PR TITLE
Fix llvm backend on mac os

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -2,7 +2,7 @@
 set -e
 
 ARGV=()
-declare -A params
+params=()
 output_file="$(mktemp tmp.out.XXXXXXXXXX)"
 input_file="$(mktemp tmp.in.XXXXXXXXXX)"
 trap "rm -rf $input_file $output_file" INT TERM EXIT
@@ -18,21 +18,23 @@ do
     -c)
     name="$2"
     value="$3"
+    var_name="params_$name"
+    params+=("$name")
     sort="$4"
     type="$5"
     case $type in
       kore)
-      params[$name]="$value"
+      printf -v "$var_name" %s "$value"
       ;;
       korefile)
-      params[$name]=`cat "$value"`
+      printf -v "$var_name" %s `cat "$value"`
       ;;
     esac
     case $sort in
       KItem)
       ;;
       *)
-      params[$name]="inj{Sort$sort{}, SortKItem{}}(${params[$name]})"
+      printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
       ;;
     esac
     shift; shift; shift; shift; shift
@@ -81,7 +83,7 @@ cat <<HERE >> $input_file
 (
 HERE
 
-for param in "${!params[@]}"; do
+for param in "${params[@]}"; do
   cat <<HERE >> $input_file
 Lbl'Unds'Map'Unds'{}(
 HERE
@@ -91,7 +93,7 @@ cat <<HERE >> $input_file
 Lbl'Stop'Map{}()
 HERE
 
-for param in "${!params[@]}"; do
+for param in "${params[@]}"; do
   cat <<HERE >> $input_file
 , Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}(
 HERE
@@ -102,8 +104,8 @@ HERE
   cat <<HERE >> $input_file
 )),
 HERE
-
-  echo "${params[$param]}" >> $input_file
+  var_name="params_$param"
+  echo "${!var_name}" >> $input_file
 
   cat <<HERE >> $input_file
 ))

--- a/runtime/configurationparser/ConfigurationPrinter.cpp
+++ b/runtime/configurationparser/ConfigurationPrinter.cpp
@@ -205,6 +205,10 @@ void printConfigurationToFile(FILE *file, block *subject) {
   usedVarNames.clear();
 }
 
+extern "C" void* getStderr(void) {
+  return stderr;
+}
+
 
 #define DEFINE_GDB_PY_SCRIPT(script_name) \
   asm("\

--- a/runtime/finish_rewriting.ll
+++ b/runtime/finish_rewriting.ll
@@ -11,6 +11,8 @@ declare void @exit(i32) #0
 declare void @abort() #0
 declare i64 @__gmpz_get_ui(%mpz*)
 
+declare i8* @getStderr()
+
 @stderr = external global i8*
 
 @exit_int_0 = global %mpz { i32 0, i32 0, i64* getelementptr inbounds ([0 x i64], [0 x i64]* @exit_int_0_limbs, i32 0, i32 0) }
@@ -28,7 +30,7 @@ define void @finish_rewriting(%block* %subject, i1 %error) #0 {
   %isnull = icmp eq i64 %outputintptr, 0
   br i1 %isnull, label %abort, label %print
 abort:
-  %stderr = load i8*, i8** @stderr
+  %stderr = call i8* @getStderr()
   call void @printConfigurationToFile(i8* %stderr, %block* %subject)
   call void @abort()
   unreachable


### PR DESCRIPTION
I discovered some more portability issues. One involves stderr, which is not a symbol on mac OS but a macro, and another involves reliance on bash 4 associative arrays in the llvm-krun script, when bash is still version 3 on mac os.

With these changes, the IMP example in the k frontend now passes on mac os.