### PR TITLE
Clean up choice code to fix bugs

### DIFF
--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -77,6 +77,7 @@ std::string makeSideConditionFunction(KOREAxiomDeclaration *axiom, KOREDefinitio
 
 /* returns the llvm::Type corresponding to the specified KORE sort category */
 llvm::Type *getValueType(ValueType sort, llvm::Module *Module);
+llvm::Type *getParamType(ValueType sort, llvm::Module *Module);
 
 void addAbort(llvm::BasicBlock *block, llvm::Module *Module);
 

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -51,7 +51,7 @@ public:
   uint64_t getChoiceDepth() const { return choiceDepth; }
 
 private:
-  bool preprocessed = false, containsFailNode = false;
+  bool preprocessed = false, containsFailNode = false, livenessVisited = false;
   uint64_t choiceDepth = 0;
   var_set_type vars;
   friend class Decision;

--- a/include/kllvm/codegen/DecisionParser.h
+++ b/include/kllvm/codegen/DecisionParser.h
@@ -5,6 +5,7 @@
 
 #include "kllvm/ast/AST.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/IR/Module.h"
 
 namespace kllvm {
 
@@ -20,9 +21,9 @@ struct PartialStep {
   std::vector<Residual> residuals;
 };
 
-DecisionNode *parseYamlDecisionTreeFromString(std::string yaml, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
-DecisionNode *parseYamlDecisionTree(std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
-PartialStep parseYamlSpecialDecisionTree(std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+DecisionNode *parseYamlDecisionTreeFromString(llvm::Module *, std::string yaml, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+DecisionNode *parseYamlDecisionTree(llvm::Module *, std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+PartialStep parseYamlSpecialDecisionTree(llvm::Module *, std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
 
 }
 

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -119,6 +119,20 @@ static std::string BUFFER_STRUCT = "stringbuffer";
 static std::string BLOCK_STRUCT = "block";
 static std::string BLOCKHEADER_STRUCT = "blockheader";
 
+llvm::Type *getParamType(ValueType sort, llvm::Module *Module) {
+  llvm::Type *type = getValueType(sort, Module);
+  switch(sort.cat) {
+  case SortCategory::Map:
+  case SortCategory::List:
+  case SortCategory::Set:
+    type = llvm::PointerType::getUnqual(type);
+    break;
+  default:
+    break;
+  }
+  return type;
+}
+
 llvm::Type *getValueType(ValueType sort, llvm::Module *Module) {
   switch(sort.cat) {
   case SortCategory::Map:

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -402,8 +402,8 @@ static void initChoiceBuffer(DecisionNode *dt, llvm::Module *module, llvm::Basic
   auto ty = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
   llvm::AllocaInst *choiceBuffer = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
   llvm::AllocaInst *choiceDepth = new llvm::AllocaInst(llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
-  new llvm::StoreInst(llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0), choiceDepth, block);
   auto zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0);
+  new llvm::StoreInst(zero, choiceDepth, block);
   auto firstElt = llvm::GetElementPtrInst::CreateInBounds(ty, choiceBuffer, {zero, zero}, "", block);
   new llvm::StoreInst(llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -76,10 +76,11 @@ void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
       }
     }
     node->eraseDefsAndAddUses(newVars);
-    if (newVars != node->vars || node->vars.empty()) {
+    if (newVars != node->vars || !livenessVisited) {
       node->vars = newVars;
       workList.insert(node->predecessors.begin(), node->predecessors.end());
     }
+    node->livenessVisited = true;
   }
 }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -54,7 +54,7 @@ void Decision::operator()(DecisionNode *entry, std::map<std::pair<std::string, l
   }
 }
 
-void DecisionNode::computeLiveness(std::set<LeafNode *> &leaves) {
+void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
   std::set<DecisionNode *> workList;
   workList.insert(leaves.begin(), leaves.end());
   if (containsFailNode) {
@@ -63,7 +63,7 @@ void DecisionNode::computeLiveness(std::set<LeafNode *> &leaves) {
   while (!workList.empty()) {
     DecisionNode *node = *workList.begin();
     workList.erase(node);
-    std::set<std::pair<std::string, llvm::Type *>> newVars;
+    var_set_type newVars;
     for (DecisionNode *succ : node->successors) {
       if (succ == FailNode::get()) {
         for (DecisionNode *trueSucc : succ->successors) {
@@ -386,7 +386,7 @@ llvm::Value *Decision::getTag(llvm::Value *val) {
 static void initChoiceBuffer(DecisionNode *dt, llvm::Module *module, llvm::BasicBlock *block, llvm::BasicBlock *stuck, llvm::BasicBlock *fail, llvm::AllocaInst **choiceBufferOut, llvm::AllocaInst **choiceDepthOut, llvm::IndirectBrInst **jumpOut) {
   FailNode::get()->predecessors.clear();
   FailNode::get()->successors.clear();
-  std::set<LeafNode *> leaves;
+  std::unordered_set<LeafNode *> leaves;
   dt->preprocess(leaves);
   dt->computeLiveness(leaves);
   auto ty = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -27,7 +27,7 @@ void Decision::operator()(DecisionNode *entry, std::map<std::pair<std::string, l
     if (entry->containsFailNode) {
       for (auto var : FailNode::get()->vars) {
         llvm::PHINode *failPhi = llvm::PHINode::Create(var.second, FailNode::get()->predecessors.size(), "phi" + var.first.substr(0, max_name_length), FailureBlock->getFirstNonPHI());
-	failPhis[var] = failPhi;
+        failPhis[var] = failPhi;
       }
     }
     entry->codegen(this, substitution);
@@ -73,8 +73,8 @@ void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
         for (DecisionNode *trueSucc : succ->successors) {
           if (node->choiceAncestors.count(dynamic_cast<IterNextNode *>(trueSucc))) {
             newVars.insert(trueSucc->vars.begin(), trueSucc->vars.end());
-	  }
-	}
+          }
+        }
       } else if (!dynamic_cast<SwitchNode *>(node)) {
         newVars.insert(succ->vars.begin(), succ->vars.end());
       }
@@ -85,8 +85,8 @@ void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
       for (DecisionNode *pred : node->predecessors) {
         if (!workListSet.count(pred)) {
           workListSet.insert(pred);
-	  workList.push_back(pred);
-	}
+          workList.push_back(pred);
+        }
       }
     }
     node->livenessVisited = true;
@@ -245,10 +245,10 @@ void SwitchNode::codegen(Decision *d, std::map<std::pair<std::string, llvm::Type
     } else {
       if (currChoiceBlock && _case.getLiteral() == 1) {
         auto PrevDepth = new llvm::LoadInst(d->ChoiceDepth, "", d->CurrentBlock);
-	auto CurrDepth = llvm::BinaryOperator::Create(llvm::Instruction::Add, PrevDepth, llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 1), "", d->CurrentBlock);
-	new llvm::StoreInst(CurrDepth, d->ChoiceDepth, d->CurrentBlock);
+        auto CurrDepth = llvm::BinaryOperator::Create(llvm::Instruction::Add, PrevDepth, llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 1), "", d->CurrentBlock);
+        new llvm::StoreInst(CurrDepth, d->ChoiceDepth, d->CurrentBlock);
 
-	auto ty = d->ChoiceBuffer->getType()->getElementType();
+        auto ty = d->ChoiceBuffer->getType()->getElementType();
         auto zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0);
         auto currentElt = llvm::GetElementPtrInst::CreateInBounds(ty, d->ChoiceBuffer, {zero, CurrDepth}, "", d->CurrentBlock);
         new llvm::StoreInst(llvm::BlockAddress::get(d->CurrentBlock->getParent(), currChoiceBlock), currentElt, d->CurrentBlock);

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Heuristics.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Heuristics.scala
@@ -166,7 +166,7 @@ object LHeuristic extends Heuristic {
 
     val sigma = matrix.columns(colIx).signatureForKey(key)
     for (con <- sigma) {
-      val spec = matrix.specialize(con, colIx, None)._2
+      val spec = matrix.specialize(con, colIx, None)._3
       if (spec.bestRowIx != -1) {
         result += 1.0
       }

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/dt/DecisionTree.scala
@@ -41,7 +41,7 @@ case class Failure private() extends DecisionTree {
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class Leaf private(ordinal: Int, occurrences: Seq[Occurrence]) extends DecisionTree {
+case class Leaf private(ordinal: Int, occurrences: Seq[(Occurrence, String)]) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   val action = new util.ArrayList[AnyRef]()
   representation.put("action", action)
@@ -49,21 +49,30 @@ case class Leaf private(ordinal: Int, occurrences: Seq[Occurrence]) extends Deci
   private val os = new util.ArrayList[AnyRef]()
   action.add(os)
   for (occurrence <- occurrences) {
-    os.add(occurrence.representation)
+    val _var = new util.ArrayList[AnyRef]()
+    _var.add(occurrence._1.representation)
+    _var.add(occurrence._2)
+    os.add(_var)
   }
   override lazy val hashCode: Int = super.hashCode
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class Switch private(occurrence: Occurrence, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
+case class Switch private(occurrence: Occurrence, hook: String, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   val specs = new util.ArrayList[AnyRef]()
+  representation.put("sort", hook)
   representation.put("specializations", specs)
-  for ((c, dt) <- cases) {
+  for ((c, bindings, dt) <- cases) {
+    val _bindings = new util.ArrayList[AnyRef]()
     val _case = new util.ArrayList[AnyRef]()
     _case.add(c)
     _case.add(dt.representation)
+    _case.add(_bindings)
     specs.add(_case)
+    for (binding <- bindings) {
+      _bindings.add(binding)
+    }
   }
   representation.put("default", default.map(_.representation).orNull)
   representation.put("occurrence", occurrence.representation)
@@ -71,15 +80,21 @@ case class Switch private(occurrence: Occurrence, cases: Seq[(String, DecisionTr
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class SwitchLit private(occurrence: Occurrence, bitwidth: Int, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
+case class SwitchLit private(occurrence: Occurrence, hook: String, bitwidth: Int, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   val specs = new util.ArrayList[AnyRef]()
+  representation.put("sort", hook)
   representation.put("specializations", specs)
-  for ((c, dt) <- cases) {
+  for ((c, bindings, dt) <- cases) {
+    val _bindings = new util.ArrayList[AnyRef]()
     val _case = new util.ArrayList[AnyRef]()
     _case.add(c)
     _case.add(dt.representation)
+    _case.add(_bindings)
     specs.add(_case)
+    for (binding <- bindings) {
+      _bindings.add(binding)
+    }
   }
   representation.put("bitwidth", bitwidth.asInstanceOf[AnyRef])
   representation.put("default", default.map(_.representation).orNull)
@@ -88,7 +103,7 @@ case class SwitchLit private(occurrence: Occurrence, bitwidth: Int, cases: Seq[(
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class Function private(name: String, occurrence: Occurrence, vars: Seq[Occurrence], hook: String, child: DecisionTree) extends DecisionTree {
+case class Function private(name: String, occurrence: Occurrence, vars: Seq[(Occurrence, String)], hook: String, child: DecisionTree) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   representation.put("function", name)
   representation.put("sort", hook)
@@ -96,22 +111,31 @@ case class Function private(name: String, occurrence: Occurrence, vars: Seq[Occu
   val args = new util.ArrayList[AnyRef]()
   representation.put("args", args)
   for (v <- vars) {
-    args.add(v.representation)
+    val _var = new util.ArrayList[AnyRef]()
+    _var.add(v._1.representation)
+    _var.add(v._2)
+    args.add(_var)
   }
   representation.put("next", child.representation)
   override lazy val hashCode: Int = super.hashCode
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class CheckNull private(occurrence: Occurrence, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
+case class CheckNull private(occurrence: Occurrence, hook: String, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   val specs = new util.ArrayList[AnyRef]()
+  representation.put("sort", hook)
   representation.put("specializations", specs)
-  for ((c, dt) <- cases) {
+  for ((c, bindings, dt) <- cases) {
+    val _bindings = new util.ArrayList[AnyRef]()
     val _case = new util.ArrayList[AnyRef]()
     _case.add(c)
     _case.add(dt.representation)
+    _case.add(_bindings)
     specs.add(_case)
+    for (binding <- bindings) {
+      _bindings.add(binding)
+    }
   }
   representation.put("default", default.map(_.representation).orNull)
   representation.put("isnull", true.asInstanceOf[AnyRef])
@@ -120,10 +144,11 @@ case class CheckNull private(occurrence: Occurrence, cases: Seq[(String, Decisio
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
 }
 
-case class MakePattern private(occurrence: Occurrence, pattern: Pattern[Option[Occurrence]], child: DecisionTree) extends DecisionTree {
+case class MakePattern private(occurrence: Occurrence, hook: String, pattern: Pattern[Option[Occurrence]], child: DecisionTree) extends DecisionTree {
   val representation = new util.HashMap[String, AnyRef]()
   representation.put("pattern", MakePattern.representPattern(pattern))
   representation.put("occurrence", occurrence.representation)
+  representation.put("sort", hook)
   representation.put("next", child.representation)
 
   override lazy val hashCode: Int = super.hashCode
@@ -134,6 +159,7 @@ case class MakeIterator private(hookName: String, occurrence: Occurrence, child:
   val representation = new util.HashMap[String, AnyRef]()
   representation.put("function", hookName)
   representation.put("collection", occurrence.representation)
+  representation.put("sort", if (hookName == "set_iterator") "SET.Set" else "MAP.Map")
   representation.put("next", child.representation)
   override lazy val hashCode: Int = super.hashCode
   override def equals(that: Any): Boolean = that.isInstanceOf[AnyRef] && (this eq that.asInstanceOf[AnyRef])
@@ -143,6 +169,7 @@ case class IterNext private(hookName: String, iterator: Occurrence, binding: Occ
   val representation = new util.HashMap[String, AnyRef]()
   representation.put("function", hookName)
   representation.put("iterator", iterator.representation)
+  representation.put("sort", "STRING.String")
   representation.put("binding", binding.representation)
   representation.put("next", child.representation)
   override lazy val hashCode: Int = super.hashCode
@@ -155,44 +182,44 @@ object Failure {
 }
 
 object Leaf {
-  private val cache = new ConcurrentHashMap[(Int, Seq[Occurrence]), Leaf]()
-  def apply(ordinal: Int, occurrences: Seq[Occurrence]): Leaf = {
+  private val cache = new ConcurrentHashMap[(Int, Seq[(Occurrence, String)]), Leaf]()
+  def apply(ordinal: Int, occurrences: Seq[(Occurrence, String)]): Leaf = {
     cache.computeIfAbsent((ordinal, occurrences), k => new Leaf(k._1, k._2))
   }
 }
 
 object Switch {
-  val cache = new ConcurrentHashMap[(Occurrence, Seq[(String, DecisionTree)], Option[DecisionTree]), Switch]()
-  def apply(occurrence: Occurrence, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]): Switch = {
-    cache.computeIfAbsent((occurrence, cases, default), k => new Switch(k._1, k._2, k._3))
+  val cache = new ConcurrentHashMap[(Occurrence, String, Seq[(String, Seq[String], DecisionTree)], Option[DecisionTree]), Switch]()
+  def apply(occurrence: Occurrence, hook: String, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]): Switch = {
+    cache.computeIfAbsent((occurrence, hook, cases, default), k => new Switch(k._1, k._2, k._3, k._4))
   }
 }
 
 object SwitchLit {
-  val cache = new ConcurrentHashMap[(Occurrence, Int, Seq[(String, DecisionTree)], Option[DecisionTree]), SwitchLit]()
-  def apply(occurrence: Occurrence, bitwidth: Int, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]): SwitchLit = {
-    cache.computeIfAbsent((occurrence, bitwidth, cases, default), k => new SwitchLit(k._1, k._2, k._3, k._4))
+  val cache = new ConcurrentHashMap[(Occurrence, String, Int, Seq[(String, Seq[String], DecisionTree)], Option[DecisionTree]), SwitchLit]()
+  def apply(occurrence: Occurrence, hook: String, bitwidth: Int, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]): SwitchLit = {
+    cache.computeIfAbsent((occurrence, hook, bitwidth, cases, default), k => new SwitchLit(k._1, k._2, k._3, k._4, k._5))
   }
 }
 
 object Function {
-  val cache = new ConcurrentHashMap[(String, Occurrence, Seq[Occurrence], String, DecisionTree), Function]()
-  def apply(name: String, occurrence: Occurrence, vars: Seq[Occurrence], hook: String, child: DecisionTree): Function = {
+  val cache = new ConcurrentHashMap[(String, Occurrence, Seq[(Occurrence, String)], String, DecisionTree), Function]()
+  def apply(name: String, occurrence: Occurrence, vars: Seq[(Occurrence, String)], hook: String, child: DecisionTree): Function = {
     cache.computeIfAbsent((name, occurrence, vars, hook, child), k => new Function(k._1, k._2, k._3, k._4, k._5))
   }
 }
 
 object CheckNull {
-  val cache = new ConcurrentHashMap[(Occurrence, Seq[(String, DecisionTree)], Option[DecisionTree]), CheckNull]()
-  def apply(occurrence: Occurrence, cases: Seq[(String, DecisionTree)], default: Option[DecisionTree]): CheckNull = {
-    cache.computeIfAbsent((occurrence, cases, default), k => new CheckNull(k._1, k._2, k._3))
+  val cache = new ConcurrentHashMap[(Occurrence, String, Seq[(String, Seq[String], DecisionTree)], Option[DecisionTree]), CheckNull]()
+  def apply(occurrence: Occurrence, hook: String, cases: Seq[(String, Seq[String], DecisionTree)], default: Option[DecisionTree]): CheckNull = {
+    cache.computeIfAbsent((occurrence, hook, cases, default), k => new CheckNull(k._1, k._2, k._3, k._4))
   }
 }
 
 object MakePattern {
-  val cache = new ConcurrentHashMap[(Occurrence, Pattern[Option[Occurrence]], DecisionTree), MakePattern]()
-  def apply(occurrence: Occurrence, pattern: Pattern[Option[Occurrence]], child: DecisionTree): MakePattern = {
-    cache.computeIfAbsent((occurrence, pattern, child), k => new MakePattern(k._1, k._2, k._3))
+  val cache = new ConcurrentHashMap[(Occurrence, String, Pattern[Option[Occurrence]], DecisionTree), MakePattern]()
+  def apply(occurrence: Occurrence, hook: String, pattern: Pattern[Option[Occurrence]], child: DecisionTree): MakePattern = {
+    cache.computeIfAbsent((occurrence, hook, pattern, child), k => new MakePattern(k._1, k._2, k._3, k._4))
   }
   def representPattern(pattern: Pattern[Option[Occurrence]]): util.HashMap[String, AnyRef] = {
     val result = new util.HashMap[String, AnyRef]()

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -52,7 +52,7 @@ int main (int argc, char **argv) {
       std::string filename = argv[3] + std::string("/") + "dt_" + std::to_string(axiom->getOrdinal()) + ".yaml";
       struct stat buf;
       if (stat(filename.c_str(), &buf) == 0) {
-        auto residuals = parseYamlSpecialDecisionTree(filename, definition->getAllSymbols(), definition->getHookedSorts());
+        auto residuals = parseYamlSpecialDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
         makeApplyRuleFunction(axiom, definition.get(), mod.get(), residuals.residuals);
         makeStepFunction(axiom, definition.get(), mod.get(), residuals);
       } else {
@@ -63,7 +63,7 @@ int main (int argc, char **argv) {
 
   emitConfigParserFunctions(definition.get(), mod.get());
 
-  auto dt = parseYamlDecisionTree(argv[2], definition->getAllSymbols(), definition->getHookedSorts());
+  auto dt = parseYamlDecisionTree(mod.get(), argv[2], definition->getAllSymbols(), definition->getHookedSorts());
   makeStepFunction(definition.get(), mod.get(), dt);
 
   std::map<std::string, std::string> index;
@@ -83,11 +83,11 @@ int main (int argc, char **argv) {
     auto decl = definition->getSymbolDeclarations().at(symbol->getName());
     if ((decl->getAttributes().count("function") && !decl->isHooked())) {
       std::string filename = getFilename(index, argv, decl);
-      auto funcDt = parseYamlDecisionTree(filename, definition->getAllSymbols(), definition->getHookedSorts());
+      auto funcDt = parseYamlDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
       makeEvalFunction(decl->getSymbol(), definition.get(), mod.get(), funcDt);
     } else if (decl->isAnywhere()) {
       std::string filename = getFilename(index, argv, decl);
-      auto funcDt = parseYamlDecisionTree(filename, definition->getAllSymbols(), definition->getHookedSorts());
+      auto funcDt = parseYamlDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
       std::ostringstream Out;
       decl->getSymbol()->print(Out);
       makeAnywhereFunction(definition->getAllSymbols().at(Out.str()), definition.get(), mod.get(), funcDt);


### PR DESCRIPTION
In the process of testing the llvm backend on the K tutorial, I uncovered a number of bugs associated with nondeterministic set and map choices.

Roughly, there were three bugs:
1. Phi nodes for variables that are needed on only one ancestor path of a shared node with multiple choice nodes as ancestors were not being computed correctly if that shared node only had a single immediate parent.
2. The choice to be jumped back to after an iterator for a choice runs out of elements was incorrect for nested choice nodes that are shared across multiple different parent choices.
3. If both children of a switch that checks whether the iterator of a choice has run out of elements have nested choice nodes, the code was not correctly computing the jump destination after entering the outer switch.

The fix for these problems was complexified by a fourth problem that was not immediately causing trouble, but needed to be addressed in order to cause a robust fix. Essentially, we were using only the occurrence to identify variables in decision tree functions, when in fact a shared node can have two different variables with the same occurrence and different types. We were correctly handling this case in the old implementation (with the exception of the above bugs, obviously), but we had to change the variable key to an occurrence/type tuple in order to make it unique so that we would be able to precompute the liveness of each variable in the function.

As a result, the fix for the above three issues roughly requires the following four changes:
1. The scala and llvm code was modified to treat occurrence/type tuples as the unique identifier of variables in decision tree functions and substitutions. This required annotating the yaml decision tree with additional information, hence the alteration to the scala code. In itself, this fixes none of the bugs, but it makes it possible to perform step 2.
2. We precompute the live-in variables for each of nodes in the decision tree using a minor variant of the standard liveness analysis algorithm. The reason for the variation is that if I have a switch whose children are a fail node and a choice node, and the choice node has another fail node as a decendent, we can statically know that the path from the outer failure node directly to the inner choice without passing through the other path of the switch is not feasible because of our knowledge of how the successors of the failure block are computed. This is still not a perfect representation of liveness in this modified context; I ran into a situation where variables were treated as live at the root of a decision tree that were not actually live there because there was a path to a shared node with a choice as an ancestor that statically depended on a particular variable in order to jump back to that choice, when the path to the root in question can be statically known not to pass through any choices, and thus those variables should not actually be live. However, the algorithm is able to solve this case with only a minor loss of code quality because it simply emits undefined values into the phi nodes for edges of the dataflow graph that the code generator does not have a value in the substitution for. Thus these incorrectly live variables can safely be ignored. There might be a minor loss to performance and code size as a result, but further improvements can be made if this becomes an issue.
3. Instead of assuming that the choice to jump back to when an runs out of elements can be statically known (it cannot because multiple choices may contain the same shared node as descendents), we maintain a stack of jump destinations in local memory for the function. We push onto the stack when an iterator has another element, and pop from the stack when local matching fails and it's time to try the next element. Because we can statically know for each function the maximum nesting depth of choices in that function, we simply use an integer and array alloca to represent the stack. the first element popped onto the stack is always the basic block that tells you that the function got stuck, and this element is popped off when the entire function gets stuck.
4. We fix the third bug above by means of creating a local variable in the SwitchNode::codegen function which stores the basic block of the current choice prior to evaluating any of the branches of the switch, and then refers to it after each branch, rather than relying on a class variable that might get clobbered by one of the children of the switch and thus contain an incorrect value in the next loop iteration.

I would like both @mickyabir and @theo25 to review because Theo has reviewed code for the choices in the past and this change is quite complex.

This code has been tested and it fixes the problems associated with executing IMP++ in the K tutorial.