### PR TITLE
Fix choice stack size explosion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
       }
     }
     stage('Build and Test') {
-      options { timeout(time: 10, unit: 'MINUTES') }
+      options { timeout(time: 15, unit: 'MINUTES') }
       steps {
         sh '''
           ./ciscript Debug

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -27,7 +27,7 @@ struct HashVar {
 
 
 using var_type = std::pair<std::string, llvm::Type *>;
-using var_set_type = std::unordered_set<var_type, HashVar>;
+using var_set_type = std::unordered_map<var_type, std::unordered_set<IterNextNode *>, HashVar>;
 
 class DecisionNode {
 public:
@@ -185,7 +185,9 @@ public:
   virtual void codegen(Decision *d, std::map<var_type, llvm::Value *> substitution);
   virtual void eraseDefsAndAddUses(var_set_type &vars) {
     vars.erase(std::make_pair(name, type));
-    vars.insert(uses.begin(), uses.end());
+    for (auto &use : uses) {
+      vars[use] = {};
+    }
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
@@ -244,7 +246,7 @@ public:
     vars.erase(std::make_pair(name, type));
     for (auto var : bindings) { 
       if (var.first.find_first_not_of("-0123456789") != std::string::npos) {
-        vars.insert(var);
+        vars[var] = {};
       }
     }
   }
@@ -281,7 +283,9 @@ public:
   
   virtual void codegen(Decision *d, std::map<var_type, llvm::Value *> substitution);
   virtual void eraseDefsAndAddUses(var_set_type &vars) {
-    vars.insert(bindings.begin(), bindings.end());
+    for (auto &binding : bindings) {
+      vars[binding] = {};
+    }
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     leaves.insert(this);
@@ -307,7 +311,7 @@ public:
   virtual void codegen(Decision *d, std::map<var_type, llvm::Value *> substitution);
   virtual void eraseDefsAndAddUses(var_set_type &vars) {
     vars.erase(std::make_pair(name, type));
-    vars.insert(std::make_pair(collection, collectionType));
+    vars[std::make_pair(collection, collectionType)] = {};
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
@@ -340,7 +344,7 @@ public:
   virtual void codegen(Decision *d, std::map<var_type, llvm::Value *> substitution);
   virtual void eraseDefsAndAddUses(var_set_type &vars) {
     vars.erase(std::make_pair(binding, bindingType));
-    vars.insert(std::make_pair(iterator, iteratorType));
+    vars[std::make_pair(iterator, iteratorType)] = {};
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -375,7 +375,7 @@ private:
   std::map<var_type, llvm::PHINode *> failPhis;
 
   llvm::Value *getTag(llvm::Value *);
-  void addFailPhiIncoming(std::map<var_type, llvm::Value *> oldSubst, llvm::BasicBlock *switchBlock);
+  void addFailPhiIncoming(std::map<var_type, llvm::Value *> oldSubst, llvm::BasicBlock *switchBlock, var_set_type &vars);
 public:
   Decision(
     KOREDefinition *Definition,

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -54,6 +54,26 @@ void Decision::operator()(DecisionNode *entry, std::map<std::pair<std::string, l
   }
 }
 
+void SwitchNode::eraseDefsAndAddUses(var_set_type &vars) {
+  for (auto _case : cases) {
+    var_set_type caseVars;
+    if (_case.getChild() == FailNode::get()) {
+      for (DecisionNode *trueSucc : _case.getChild()->successors) {
+        if (choiceAncestors.count(dynamic_cast<IterNextNode *>(trueSucc))) {
+          caseVars.insert(trueSucc->vars.begin(), trueSucc->vars.end());
+        }
+      }
+    } else {
+      caseVars = _case.getChild()->vars;
+    }
+    for (auto var : _case.getBindings()) {
+      caseVars.erase(var);
+    }
+    vars.insert(caseVars.begin(), caseVars.end());
+  }
+  if(cases.size() != 1 || cases[0].getConstructor()) vars.insert(std::make_pair(name, type)); 
+}
+
 void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
   std::deque<DecisionNode *> workList;
   std::unordered_set<DecisionNode *> workListSet;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -498,7 +498,7 @@ void abortWhenStuck(llvm::BasicBlock *CurrentBlock, llvm::Module *Module, KORESy
       auto cat = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[idx].get())->getCategory(d);
       auto type = getParamType(cat, Module);
       llvm::Value *ChildValue = subst[std::make_pair("_" + std::to_string(idx+1), type)];
-      llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Block, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)}, "", CurrentBlock);
+      llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Block, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx + 2)}, "", CurrentBlock);
       if (ChildValue->getType() == ChildPtr->getType()) {
         ChildValue = new llvm::LoadInst(ChildValue, "", CurrentBlock);
       }


### PR DESCRIPTION
It was reported to me that the previous choice PR caused regressions in the C execution semantics, primarily because it exploded the size of the stack frame of the step function, leading to a stack overflow. After analyzing the code, I determined this to be due to the fact that liveness analysis was incorrectly marking variables live in basic blocks due to a path to their use that passed through the failure block, even though static analysis of the control flow graph ought to be able to determine those paths to be infeasible. Fixing this required us to keep track of which choice ancestors cause variables to become live in a block, and removing them from the live variables if they are made live by choice nodes that are no longer an ancestor of that block after propagating to one or more predecessors.