### PR TITLE
cmake fix for llvm 7.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,11 @@ if (NOT LLVM_FOUND)
 endif()
 
 if (NOT LLVM_FOUND)
-  find_package(LLVM 7 REQUIRED CONFIG)
+          find_package(LLVM 7.1 QUIET CONFIG)
+endif()
+
+if (NOT LLVM_FOUND)
+ find_package(LLVM 7 REQUIRED CONFIG)
 endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
Chris is no longer blocked on this, but this is the fix for the issue he reported. LLVM's cmake package does not appear to distinguish between find_package asking for any version of llvm 7, versus asking specifically for version 7.0. Which means we need an extra case in here for minor versions. We support any version of llvm greater than or equal to 7.0.1, and 7.1 is the only minor version that has been released since then.