### PR TITLE
Fix another bug involving phi nodes and choices in decision trees

### DIFF
--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -50,6 +50,8 @@ public:
   bool beginNode(Decision *d, std::string name, std::map<var_type, llvm::Value *> &substitution);
   std::vector<DecisionNode *> topologicalSort(void);
 
+  static void computeChoiceAncestors(std::vector<DecisionNode *> sorted);
+
   void setCompleted() { completed = true; }
   bool isCompleted() const { return completed; }
   uint64_t getChoiceDepth() const { return choiceDepth; }
@@ -141,7 +143,6 @@ public:
     if(preprocessed) return;
     bool hasDefault = false;
     for (auto _case : cases) {
-      _case.getChild()->choiceAncestors.insert(choiceAncestors.begin(), choiceAncestors.end());
       _case.getChild()->preprocess(leaves);
       _case.getChild()->predecessors.insert(this);
       _case.getChild()->predecessors2.insert(this);
@@ -197,7 +198,6 @@ public:
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
-    child->choiceAncestors.insert(choiceAncestors.begin(), choiceAncestors.end());
     child->preprocess(leaves);
     child->predecessors.insert(this);
     child->predecessors2.insert(this);
@@ -260,7 +260,6 @@ public:
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
-    child->choiceAncestors.insert(choiceAncestors.begin(), choiceAncestors.end());
     child->preprocess(leaves);
     child->predecessors.insert(this);
     child->predecessors2.insert(this);
@@ -325,7 +324,6 @@ public:
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
-    child->choiceAncestors.insert(choiceAncestors.begin(), choiceAncestors.end());
     child->preprocess(leaves);
     child->predecessors.insert(this);
     child->predecessors2.insert(this);
@@ -360,8 +358,6 @@ public:
   }
   virtual void preprocess(std::unordered_set<LeafNode *> &leaves) {
     if (preprocessed) return;
-    child->choiceAncestors.insert(choiceAncestors.begin(), choiceAncestors.end());
-    child->choiceAncestors.insert(this);
     child->preprocess(leaves);
     child->predecessors.insert(this);
     child->predecessors2.insert(this);

--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -50,7 +50,7 @@ public:
   bool beginNode(Decision *d, std::string name, std::map<var_type, llvm::Value *> &substitution);
   std::vector<DecisionNode *> topologicalSort(void);
 
-  static void computeChoiceAncestors(std::vector<DecisionNode *> sorted);
+  static void computeChoiceAncestors(std::vector<DecisionNode *> const& sorted);
 
   void setCompleted() { completed = true; }
   bool isCompleted() const { return completed; }

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -488,7 +488,7 @@ llvm::Value *Decision::getTag(llvm::Value *val) {
   return res;
 }
 
-void DecisionNode::computeChoiceAncestors(std::vector<DecisionNode *> sorted) {
+void DecisionNode::computeChoiceAncestors(std::vector<DecisionNode *> const& sorted) {
   for (DecisionNode *node : sorted) {
     for (DecisionNode *pred : node->predecessors) {
       if (pred == FailNode::get()) {

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -148,6 +148,28 @@ void DecisionNode::computeLiveness(std::unordered_set<LeafNode *> &leaves) {
   }
 }
 
+std::vector<DecisionNode *> DecisionNode::topologicalSort(void) {
+  std::vector<DecisionNode *> result;
+  std::vector<DecisionNode *> workList;
+  workList.push_back(this);
+  while (!workList.empty()) {
+    DecisionNode *node = workList.back();
+    workList.pop_back();
+    result.push_back(node);
+    auto it = node->successors2.begin();
+    while (it != node->successors2.end()) {
+      auto succ = *it;
+      it = node->successors2.erase(it);
+      succ->predecessors2.erase(node);
+      if (succ->predecessors2.empty()) {
+        workList.push_back(succ);
+      }
+    }
+  }
+
+  return result;
+}
+
 void DecisionNode::sharedNode(Decision *d, std::map<std::pair<std::string, llvm::Type *>, llvm::Value *> &oldSubst, std::map<std::pair<std::string, llvm::Type *>, llvm::Value *> &substitution, llvm::BasicBlock *Block) {
   for (auto &entry : vars) {
     auto &var = entry.first;
@@ -469,6 +491,8 @@ llvm::Value *Decision::getTag(llvm::Value *val) {
 static void initChoiceBuffer(DecisionNode *dt, llvm::Module *module, llvm::BasicBlock *block, llvm::BasicBlock *stuck, llvm::BasicBlock *fail, llvm::AllocaInst **choiceBufferOut, llvm::AllocaInst **choiceDepthOut, llvm::IndirectBrInst **jumpOut) {
   FailNode::get()->predecessors.clear();
   FailNode::get()->successors.clear();
+  FailNode::get()->predecessors2.clear();
+  FailNode::get()->successors2.clear();
   FailNode::get()->choiceAncestors.clear();
   std::unordered_set<LeafNode *> leaves;
   dt->preprocess(leaves);


### PR DESCRIPTION
the K build is failing on Mac OS because llvm 9 introduced some new optimizations that take advantage of undefined values in llvm IR, and this uncovered a bug in how we are computing the phi nodes for decision tree functions in the llvm backend. Essentially, we were not correctly computing the set of choice nodes that are ancestors of the current node, and that led to values getting assigned as undefined when really liveness should have treated them as live. This meant that the same stack slot was being reused for multiple different variables and their values were clobbering one another, leading to memory corruption in the substitution that was being generated by the decision tree.

Essentially, to fix this, instead of doing a DFS on the tree to compute the choice ancestors, we first do a topological sort and then iterate through in sorted order. This guarantees that each node's ancestors are computed after its predecessors ancestors are fully computed, which fixes the issue.