### PR TITLE
remove a bunch of stuff and just use alloca + mem2reg

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -25,7 +25,7 @@ for arg in "$@"; do
   esac
 done
 "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-@OPT@ -tailcallelim -tailcallopt -instcombine "$mod" -o "$modopt"
+@OPT@ -mem2reg -tailcallelim -tailcallopt -instcombine "$mod" -o "$modopt"
 if [[ "$OSTYPE" != "darwin"* ]]; then
   flags=-fuse-ld=lld
 fi


### PR DESCRIPTION
The liveness analysis we were doing was proving to be very slow, so I went digging into the details of how SSA is usually constructed, and realized that it's usually done based on dominance frontiers rather than data flow equations. I was going to implement all of that, but then I realized we were probably better off just relying on the mem2reg llvm transformation pass. This turns out to delete a bunch of code /and/ be much much faster, while being much less likely to have bugs. So it's win/win/win.