### PR TITLE
don't call instcombine anymore unless we are actually optimizing

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -25,7 +25,7 @@ for arg in "$@"; do
   esac
 done
 "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
-@OPT@ -mem2reg -tailcallelim -tailcallopt -instcombine "$mod" -o "$modopt"
+@OPT@ -mem2reg -tailcallelim -tailcallopt "$mod" -o "$modopt"
 if [[ "$OSTYPE" != "darwin"* ]]; then
   flags=-fuse-ld=lld
 fi


### PR DESCRIPTION
Previously we were relying on instcombine to combine phi nodes together sufficiently to prevent the stack space from exploding. Now that we are using mem2reg to create the phi nodes, the phi nodes created are already minimal and instcombine is (hopefully) not necessary in order to prevent stack overflows. Removing it from the calls will decrease the time that it takes to kompile.