### PR TITLE
add more informative error when user uses bags in cells

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/pattern/SortCategory.scala
@@ -5,6 +5,7 @@ import org.kframework.backend.llvm.matching.dt._
 import org.kframework.parser.kore.SymbolOrAlias
 import org.kframework.parser.kore.Sort
 import org.kframework.parser.kore.CompoundSort
+import org.kframework.utils.errorsystem.KEMException
 import org.kframework.mpfr._
 import java.util.regex.{Pattern => Regex}
 
@@ -35,6 +36,7 @@ object SortCategory {
       case Some("KVAR.KVar") => VarS()
       case Some("BUFFER.StringBuffer") => BufferS()
       case Some("MINT.MInt") => MIntS(getBitwidth(s.asInstanceOf[CompoundSort].params(0), symlib))
+      case Some("BAG.Bag") => throw KEMException.compilerError("LLVM Backend does not support multisets. If you are seeing this error due to a configuration cell tagged with multiplicity=\"*\", please add either type=\"Map\" or type=\"Set\". If you still need the collection to not contain duplicates, it is recommended you also add a unique identifier each time a cell is created. You can do this with !X:Int.");
     }
   }
 


### PR DESCRIPTION
We commonly see users confused by the exception that gets thrown by the llvm backend if they do not specify that a cell collection with `multiplicity="*"` is either a set or a map. So I decided to add a more informative error message at the location where this occurs.