### PR TITLE
columns are also valid if all the columns they need also need them

### DIFF
--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -433,7 +433,7 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
   }
 
   private lazy val validCols: Seq[MatrixColumn] = {
-    matrixColumns.filter(col => col.column.isValid || columns.forall(c => c == col.column || !c.needed(col.column.keyVars)))
+    matrixColumns.filter(col => col.column.isValid || columns.forall(c => c == col.column || !c.needed(col.column.keyVars) || col.column.needed(c.keyVars)))
   }
 
   private var specializing: Option[IndexedSeq[Pattern[String]]] = None


### PR DESCRIPTION
Essentially, we try to evaluate columns that match on variables before we evaluate columns that need to perform a map or set choice because the map or set key contains those variables. This significantly helps reduce the number of unnecessary choices present in the decision tree by converting as many as possible into concrete lookups. However, we were too aggressively applying this requirement in cases where both columns need to perform a map or set choice to match a particular variable. In this case, the dependency was circular, so both columns were being delayed until the very end of the matching process, which ends up significantly reordering the matching order in ways that significantly increase the size of the decision tree. This was leading to a stack overflow on the execution semantics with the rv match extensions.

Instead, we now look for columns that need each other and if all the columns that a column needs also need it, we don't defer matching until later as the circular dependency implies that at least one choice operation is unavoidable.

I tested this on the open source C semantics and it reduced the shared size of the decision tree from 69k nodes to 55k nodes while not having any effect on the number of choices or the average or max path length. 