### PR TITLE
print statistics from llvm backend when requested

### DIFF
--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -167,6 +167,7 @@ extern "C" {
 
   block *parseConfiguration(const char *filename);
   void printConfiguration(const char *filename, block *subject);
+  void printStatistics(const char *filename, uint64_t steps);
   string *printConfigurationToString(block *subject);
   void printConfigurationToFile(FILE *, block *subject);
   void printConfigurationInternal(writer *file, block *subject, const char *sort, bool);

--- a/runtime/configurationparser/ConfigurationPrinter.cpp
+++ b/runtime/configurationparser/ConfigurationPrinter.cpp
@@ -1,3 +1,4 @@
+#include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -174,8 +175,14 @@ void printConfigurationInternal(writer *file, block *subject, const char *sort, 
   sfprintf(file, ")");
 }
 
-void printConfiguration(const char *filename, block *subject) {
+void printStatistics(const char *filename, uint64_t steps) {
   FILE *file = fopen(filename, "w");
+  fprintf(file, "%" PRIu64 "\n", steps-1); //off by one adjustment
+  fclose(file);
+}
+
+void printConfiguration(const char *filename, block *subject) {
+  FILE *file = fopen(filename, "a");
   boundVariables.clear();
   varCounter = 0;
   writer w = {file,nullptr};

--- a/runtime/finish_rewriting.ll
+++ b/runtime/finish_rewriting.ll
@@ -5,6 +5,7 @@ target triple = "x86_64-unknown-linux-gnu"
 %block = type { %blockheader, [0 x i64 *] } ; 16-bit layout, 8-bit length, 32-bit tag, children
 %mpz = type { i32, i32, i64* }
 
+declare void @printStatistics(i8*, i64)
 declare void @printConfiguration(i8*, %block*)
 declare void @printConfigurationToFile(i8*, %block*)
 declare void @exit(i32) #0
@@ -23,6 +24,8 @@ define weak fastcc %mpz* @"eval_LblgetExitCode{SortGeneratedTopCell{}}"(%block*)
 }
 
 @output_file = global i8* zeroinitializer
+@statistics = global i1 zeroinitializer
+@steps = external thread_local global i64
 
 define void @finish_rewriting(%block* %subject, i1 %error) #0 {
   %output = load i8*, i8** @output_file
@@ -35,6 +38,13 @@ abort:
   call void @abort()
   unreachable
 print:
+  %hasStatistics = load i1, i1* @statistics
+  br i1 %hasStatistics, label %printStatistics, label %printConfig
+printStatistics:
+  %steps = load i64, i64* @steps
+  call void @printStatistics(i8* %output, i64 %steps)
+  br label %printConfig
+printConfig:
   call void @printConfiguration(i8* %output, %block* %subject)
   br i1 %error, label %exit, label %exitCode
 exitCode:
@@ -43,7 +53,7 @@ exitCode:
   %exit_trunc = trunc i64 %exit_ul to i32
   br label %exit
 exit:
-  %exit_ui = phi i32 [ %exit_trunc, %exitCode ], [ 113, %print ]
+  %exit_ui = phi i32 [ %exit_trunc, %exitCode ], [ 113, %printConfig ]
   call void @exit(i32 %exit_ui)
   unreachable
 }

--- a/runtime/main/main.ll
+++ b/runtime/main/main.ll
@@ -13,6 +13,7 @@ declare void @finish_rewriting(%block*, i1) #0
 declare void @initStaticObjects()
 
 @output_file = external global i8*
+@statistics = external global i1
 
 define i32 @main(i32 %argc, i8** %argv) {
 entry:
@@ -24,6 +25,8 @@ entry:
   %output_ptr = getelementptr inbounds i8*, i8** %argv, i64 3
   %output_str = load i8*, i8** %output_ptr
   store i8* %output_str, i8** @output_file
+  %hasStatistics = icmp ne i32 %argc, 4
+  store i1 %hasStatistics, i1* @statistics
 
   call void @initStaticObjects()
 

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -7,6 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 declare fastcc %block* @step(%block*)
 
 @depth = thread_local global i64 zeroinitializer
+@steps = thread_local global i64 zeroinitializer
 @INTERVAL = internal thread_local global i64 @GC_INTERVAL@
 @current_interval = thread_local global i64 0
 
@@ -21,6 +22,9 @@ define i1 @finished_rewriting() {
 entry:
   %depth = load i64, i64* @depth
   %hasDepth = icmp sge i64 %depth, 0
+  %steps = load i64, i64* @steps
+  %stepsPlusOne = add i64 %steps, 1
+  store i64 %stepsPlusOne, i64* @steps
   br i1 %hasDepth, label %if, label %else
 if:
   %depthMinusOne = sub i64 %depth, 1


### PR DESCRIPTION
This is the first of two PRs needed in order to allow users to get the number of rewrite steps the llvm backend took before terminating.