### PR TITLE
fix p and n heuristic

### DIFF
--- a/bin/llvm-kompile-testing
+++ b/bin/llvm-kompile-testing
@@ -12,5 +12,5 @@ trap "rm -rf $dt_dir" INT TERM EXIT
 definition="$1"
 main="$2"
 shift; shift
-( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 2" -q )
+( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 1" -q )
 llvm-kompile "$definition" "$dt_dir" "$main" "$@" -g

--- a/bin/llvm-kompile-testing
+++ b/bin/llvm-kompile-testing
@@ -12,5 +12,5 @@ trap "rm -rf $dt_dir" INT TERM EXIT
 definition="$1"
 main="$2"
 shift; shift
-( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 1" -q )
+( cd "@PROJECT_SOURCE_DIR@"/matching && mvn exec:java -Dexec.args="$definition qbaL $dt_dir 2" -q )
 llvm-kompile "$definition" "$dt_dir" "$main" "$@" -g

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Matrix.scala
@@ -611,8 +611,9 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
 
   def compileInternal: DecisionTree = {
     if (Matching.logging) {
+      val s = toString
       System.out.println("-- Compile --")
-      System.out.println(toString)
+      System.out.println(s)
       System.out.println("remaining: " + Matrix.remaining)
     }
     if (clauses.isEmpty)
@@ -637,7 +638,7 @@ class Matrix private(val symlib: Parser.SymLib, private val rawColumns: IndexedS
   }
 
   def necessary(rowIx: Int, colIx: Int): Boolean = {
-    !columns(colIx).patterns(rowIx).isWildcard || !notCol(colIx).rowUseless(rowIx)
+    !columns(colIx).patterns(rowIx).isWildcard || notCol(colIx).rowUseless(rowIx)
   }
 
   private def useful(r: Row): Boolean = {


### PR DESCRIPTION
We accidentally misrepresented the `necessary` function by checking that a row was not useless when we should have been checking that it *was* useless. This was seriously nerfing the p and n heuristics and making them compute the wrong thing. I tested the modified p heuristic on the tezos semantics and while it takes longer than the q heuristic, the resulting decision tree is not any larger and has a slightly smaller average path length.