### PR TITLE
llvm backend pretty printing tool

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -3,13 +3,16 @@ set -e
 
 ARGV=()
 params=()
+pretty=()
 output_file="$(mktemp tmp.out.XXXXXXXXXX)"
 input_file="$(mktemp tmp.in.XXXXXXXXXX)"
-trap "rm -rf $input_file $output_file" INT TERM EXIT
+parser_file="$(mktemp tmp.parse.XXXXXXXXXX)"
+trap 'rm -rf "$input_file" "$output_file" "$parser_file"' INT TERM EXIT
 initializer="LblinitGeneratedTopCell{}"
 dir=.
 debug=
 depth=-1
+pretty_print=false
 
 while [[ $# -gt 0 ]]
 do
@@ -19,9 +22,12 @@ do
     name="$2"
     value="$3"
     var_name="params_$name"
+    pretty_name="pretty_$name"
+    sort_name="sort_$name"
     params+=("$name")
     sort="$4"
     type="$5"
+    printf -v "$sort_name" %s "$sort"
     case $type in
       kore)
       printf -v "$var_name" %s "$value"
@@ -29,12 +35,13 @@ do
       korefile)
       printf -v "$var_name" %s "`cat "$value"`"
       ;;
-    esac
-    case $sort in
-      KItem)
+      pretty)
+      printf -v "$pretty_name" %s "$value"
+      pretty+=("$name")
       ;;
-      *)
-      printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
+      prettyfile)
+      printf -v "$pretty_name" %s "`cat "$value"`"
+      pretty+=("$name")
       ;;
     esac
     shift; shift; shift; shift; shift
@@ -43,6 +50,11 @@ do
     -o|--output-file)
     real_output_file="$2"
     shift; shift
+    ;;
+
+    -p)
+    pretty_print=true
+    shift
     ;;
 
     -i|--initializer)
@@ -73,6 +85,26 @@ do
     -save-temps)
     trap - INT TERM EXIT
     shift;
+    ;;
+  esac
+done
+
+for name in "${pretty[@]}"; do
+  var_name="params_$name"
+  pretty_name="pretty_$name"
+  printf %s "${!pretty_name}" | "$dir/parser_$name" /dev/stdin > "$parser_file"
+  printf -v "$var_name" %s "`cat $parser_file`"
+done
+
+for name in "${params[@]}"; do
+  sort_name="sort_$name"
+  var_name="params_$name"
+  sort="${!sort_name}"
+  case $sort in
+    KItem)
+    ;;
+    *)
+    printf -v "$var_name" %s "inj{Sort$sort{}, SortKItem{}}(${!var_name})"
     ;;
   esac
 done
@@ -122,13 +154,21 @@ set +e
 if [ -n "$verbose" ]; then
   set -x
 fi
-$debug "$dir"/interpreter $input_file $depth $output_file
+$debug "$dir"/interpreter "$input_file" $depth "$output_file"
 )
 EXIT=$?
 set -e
 
 if [ -n "${real_output_file}" ]; then
-  mv -f $output_file "$real_output_file"
+  if $pretty_print; then
+  "$(dirname "$0")/kprint" "$dir" "$output_file" > "$real_output_file"
+  else
+    mv -f "$output_file" "$real_output_file"
+  fi
+elif $pretty_print; then
+  "$(dirname "$0")/kprint" "$dir" "$output_file"
+else
+  cat "$output_file"
 fi
 
 exit $EXIT

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -14,6 +14,43 @@ debug=
 depth=-1
 pretty_print=false
 
+print_usage () {
+cat <<HERE
+Usage: $0 -d DIR [-c NAME VALUE SORT TYPE]... [-o OUTPUT] [-p]
+Invoke llvm backend without calling java krun frontend. Functionality for
+parsing and unparsing is limited, and the user interface is lower level, but
+overhead is dramatically reduced.
+
+Mandatory arguments to long options are mandatory for short options too.
+
+  -d, --directory DIR      DIR is the kompiled directory of the definition to
+                           run
+  -c NAME VALUE SORT TYPE  Specify configuration variable. NAME is the name
+                           of the configuration variable without the '$'.
+                           VALUE is the value of the configuration variable
+                           (see below). SORT is the sort of the term passed
+                           as the value. TYPE is one of:
+                             * kore: VALUE is a literal kore string
+                             * korefile: VALUE is a filename containing kore
+                             * pretty: VALUE is parsed using a bison parser
+                                       and is a literal string in concrete
+                                       syntax
+                             * prettyfile: VALUE is a filename containing
+                                           concrete syntax, pasred like
+                                           'pretty'
+  -o, --output-file FILE   Write resulting configuration to FILE. Defaults to
+                           standard output
+  -p, --pretty-print       Pretty print output configuration. By default,
+                           output is in kore syntax
+      --debug              Use GDB to debug program
+      --depth INT          Execute up to INT steps
+  -i, --initializer INIT   Use INIT as the top cell initializer 
+  -v, --verbose            Print commands executed to standazd error
+      -save-temps          Do not delete temporary files on exit
+  -h, --help               Display this help and exit
+HERE
+}
+
 while [[ $# -gt 0 ]]
 do
   arg="$1"
@@ -52,7 +89,7 @@ do
     shift; shift
     ;;
 
-    -p)
+    -p|--pretty-print)
     pretty_print=true
     shift
     ;;
@@ -62,7 +99,7 @@ do
     shift; shift
     ;;
 
-    -d)
+    -d|--directory)
     dir="$2"
     shift; shift
     ;;
@@ -86,13 +123,29 @@ do
     trap - INT TERM EXIT
     shift;
     ;;
+
+    -h|--help)
+    print_usage
+    exit 0
+    ;;
+
+    *)
+    print_usage
+    exit 1
+    ;;
   esac
 done
 
 for name in "${pretty[@]}"; do
   var_name="params_$name"
   pretty_name="pretty_$name"
+  set +e
+  (
+  if [ -n "$verbose" ]; then
+    set -x
+  fi
   printf %s "${!pretty_name}" | "$dir/parser_$name" /dev/stdin > "$parser_file"
+  )
   printf -v "$var_name" %s "`cat $parser_file`"
 done
 
@@ -161,12 +214,24 @@ set -e
 
 if [ -n "${real_output_file}" ]; then
   if $pretty_print; then
+  set +e
+  (
+  if [ -n "$verbose" ]; then
+    set -x
+  fi
   "$(dirname "$0")/kprint" "$dir" "$output_file" > "$real_output_file"
+  )
   else
     mv -f "$output_file" "$real_output_file"
   fi
 elif $pretty_print; then
+  set +e
+  (
+  if [ -n "$verbose" ]; then
+    set -x
+  fi
   "$(dirname "$0")/kprint" "$dir" "$output_file"
+  )
 else
   cat "$output_file"
 fi

--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -36,7 +36,7 @@ Mandatory arguments to long options are mandatory for short options too.
                                        and is a literal string in concrete
                                        syntax
                              * prettyfile: VALUE is a filename containing
-                                           concrete syntax, pasred like
+                                           concrete syntax, parsed like
                                            'pretty'
   -o, --output-file FILE   Write resulting configuration to FILE. Defaults to
                            standard output

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -250,10 +250,15 @@ private:
 class KOREVariablePattern;
 
 struct PrettyPrintData {
+  // map from symbol name to format attribute specifying how to print that symbol
   std::map<std::string, std::string> format;
+  // map from symbol name to vector of colors for that symbol
   std::map<std::string, std::vector<std::string>> colors;
+  // map from sort name to hook attribute for that symbol
   std::map<std::string, std::string> hook;
+  // set of associative symbols
   std::set<std::string> assoc;
+  // set of commutative symbols
   std::set<std::string> comm;
 };
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -279,6 +279,7 @@ public:
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
 
   virtual void prettyPrint(std::ostream &, PrettyPrintData const& data) const = 0;
+  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) = 0;
 };
 
 class KOREVariablePattern : public KOREPattern {
@@ -307,6 +308,7 @@ public:
     return val->second;
   }
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
+  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
   virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override {
     out << getName() << ":";
     sort->prettyPrint(out);
@@ -348,6 +350,7 @@ public:
   virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) override;
   virtual sptr<KOREPattern> substitute(const substitution &) override;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override;
+  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override;
 
 private:
   KORECompositePattern(ptr<KORESymbol> Constructor)
@@ -372,6 +375,7 @@ public:
   virtual sptr<KORESort> getSort(void) const override { abort(); }
   virtual sptr<KOREPattern> substitute(const substitution &) override { return shared_from_this(); }
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
+  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
 
 private:
   KOREStringPattern(const std::string &Contents) : contents(Contents) { }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <unordered_map>
 #include <utility>
+#include <iostream>
 
 namespace kllvm {
 
@@ -35,6 +36,8 @@ public:
   bool operator!=(const KORESort &other) const { return !(*this == other); }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const =0;
+  virtual void prettyPrint(std::ostream &Out) const = 0;
+
   virtual ~KORESort() = default;
 };
 
@@ -63,6 +66,7 @@ public:
   virtual sptr<KORESort> substitute(const substitution &subst) override { return subst.at(*this); }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  virtual void prettyPrint(std::ostream &Out) const override { std::cout << name; }
   virtual bool operator==(const KORESort &other) const override;
 
 private:
@@ -108,6 +112,19 @@ public:
 
   void addArgument(sptr<KORESort> Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  virtual void prettyPrint(std::ostream &out) const override {
+    out << name.substr(4);
+    if (!arguments.empty()) {
+      out << "{";
+      std::string conn = "";
+      for (auto &sort : arguments) {
+        out << conn;
+        sort->prettyPrint(out);
+        conn = ",";
+      }
+      out << "}";
+    }
+  }
   virtual bool operator==(const KORESort &other) const override;
 
 private:
@@ -232,6 +249,14 @@ private:
 
 class KOREVariablePattern;
 
+struct PrettyPrintData {
+  std::map<std::string, std::string> format;
+  std::map<std::string, std::vector<std::string>> colors;
+  std::map<std::string, std::string> hook;
+  std::set<std::string> assoc;
+  std::set<std::string> comm;
+};
+
 // KOREPattern
 class KOREPattern : public std::enable_shared_from_this<KOREPattern> {
 public:
@@ -252,6 +277,8 @@ public:
 
   virtual sptr<KOREPattern> substitute(const substitution &) = 0;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
+
+  virtual void prettyPrint(std::ostream &, PrettyPrintData const& data) const = 0;
 };
 
 class KOREVariablePattern : public KOREPattern {
@@ -280,6 +307,10 @@ public:
     return val->second;
   }
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
+  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override {
+    out << getName() << ":";
+    sort->prettyPrint(out);
+  }
 
 private:
   KOREVariablePattern(ptr<KOREVariable> Name, sptr<KORESort> Sort)
@@ -312,6 +343,7 @@ public:
 
   void addArgument(sptr<KOREPattern> Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override;
   virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
   virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) override;
   virtual sptr<KOREPattern> substitute(const substitution &) override;
@@ -334,6 +366,7 @@ public:
   std::string getContents() { return contents; }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
+  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override { abort(); }
   virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override {}
   virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) override {}
   virtual sptr<KORESort> getSort(void) const override { abort(); }

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -35,7 +35,7 @@ public:
   virtual bool operator==(const KORESort &other) const = 0;
   bool operator!=(const KORESort &other) const { return !(*this == other); }
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const =0;
+  virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
   virtual void prettyPrint(std::ostream &Out) const = 0;
 
   virtual ~KORESort() = default;

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -613,7 +613,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
             break;
           case 'c':
             if (data.colors.count(name)) {
-              if (localColor >= data.colors.at(name).length() ) {
+              if (localColor >= data.colors.at(name).size() ) {
                 abort();
               }
               color(out, data.colors.at(name)[localColor++]);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -594,6 +594,9 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
     for (int i = 0; i < format.length(); ++i) {
       char c = format[i];
       if (c == '%') {
+        if (i == format.length() - 1) {
+          abort();
+        }
         char c2 = format[i+1];
         ++i;
         switch(c2) {
@@ -610,6 +613,9 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
             break;
           case 'c':
             if (data.colors.count(name)) {
+              if (localColor >= data.colors.at(name).length() ) {
+                abort();
+              }
               color(out, data.colors.at(name)[localColor++]);
             }
             break;

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -525,6 +525,8 @@ static void color(std::ostream &out, std::string color) {
   }
 }
 
+#define RESET_COLOR "\x1b[0m"
+
 std::string enquote(std::string str) {
   std::string result;
   for (size_t i = 0; i < str.length(); ++i) {
@@ -613,7 +615,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
             break;
           case 'r':
             if (hasColor) {
-              append(out, "\x1b[0m");
+              append(out, RESET_COLOR);
             }
             break;
           case '0':

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -3,6 +3,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <iostream>
+#include <algorithm>
 
 using namespace kllvm;
 
@@ -283,6 +284,468 @@ sptr<KOREPattern> KORECompositePattern::expandAliases(KOREDefinition *def) {
     ptr->addArgument(arg->expandAliases(def));
   }
   return ptr;
+}
+
+static int indent = 0;
+static bool atNewLine = true;
+static bool hasColor = isatty(1);
+
+#define INDENT_SIZE 2
+
+static void newline() {
+  std::cout << std::endl;
+  atNewLine = true;
+}
+
+static void printIndent() {
+  if (atNewLine) {
+    for (int i = 0; i < INDENT_SIZE * indent; i++) {
+      std::cout << ' ';
+    }
+    atNewLine = false;
+  }
+}
+
+static void append(std::ostream &out, char c) {
+  printIndent();
+  out << c;
+}
+
+static void append(std::ostream &out, std::string str) {
+  printIndent();
+  out << str;
+}
+
+static void color(std::ostream &out, std::string color) {
+  if (hasColor) {
+    static bool once = true;
+    static std::map<std::string, std::string> colors;
+    if (once) {
+      colors["MediumOrchid"] = "\x1b[38;5;134m";
+      colors["Black"] = "\x1b[38;5;16m";
+      colors["DarkSeaGreen"] = "\x1b[38;5;108m";
+      colors["Sienna"] = "\x1b[38;5;130m";
+      colors["Gainsboro"] = "\x1b[38;5;188m";
+      colors["LightCoral"] = "\x1b[38;5;210m";
+      colors["DarkGrey"] = "\x1b[38;5;145m";
+      colors["DodgerBlue"] = "\x1b[38;5;33m";
+      colors["CarnationPink"] = "\x1b[38;5;211m";
+      colors["Aquamarine"] = "\x1b[38;5;122m";
+      colors["Beige"] = "\x1b[38;5;230m";
+      colors["OliveDrab"] = "\x1b[38;5;64m";
+      colors["YellowOrange"] = "\x1b[38;5;214m";
+      colors["Mulberry"] = "\x1b[38;5;126m";
+      colors["Violet"] = "\x1b[38;5;213m";
+      colors["LimeGreen"] = "\x1b[38;5;40m";
+      colors["PaleGoldenrod"] = "\x1b[38;5;187m";
+      colors["Magenta"] = "\x1b[38;5;201m";
+      colors["PowderBlue"] = "\x1b[38;5;152m";
+      colors["DarkTurquoise"] = "\x1b[38;5;44m";
+      colors["IndianRed"] = "\x1b[38;5;167m";
+      colors["LightGray"] = "\x1b[38;5;188m";
+      colors["PeachPuff"] = "\x1b[38;5;223m";
+      colors["LightBlue"] = "\x1b[38;5;152m";
+      colors["ProcessBlue"] = "\x1b[38;5;39m";
+      colors["SpringGreen"] = "\x1b[38;5;48m";
+      colors["Indigo"] = "\x1b[38;5;54m";
+      colors["RedViolet"] = "\x1b[38;5;125m";
+      colors["DarkRed"] = "\x1b[38;5;88m";
+      colors["Wheat"] = "\x1b[38;5;223m";
+      colors["DarkCyan"] = "\x1b[38;5;30m";
+      colors["yellow"] = "\x1b[38;5;226m";
+      colors["LawnGreen"] = "\x1b[38;5;118m";
+      colors["gray"] = "\x1b[38;5;102m";
+      colors["DarkOrange"] = "\x1b[38;5;208m";
+      colors["Teal"] = "\x1b[38;5;30m";
+      colors["Maroon"] = "\x1b[38;5;88m";
+      colors["JungleGreen"] = "\x1b[38;5;37m";
+      colors["Blue"] = "\x1b[38;5;21m";
+      colors["Periwinkle"] = "\x1b[38;5;104m";
+      colors["Moccasin"] = "\x1b[38;5;223m";
+      colors["black"] = "\x1b[38;5;16m";
+      colors["Chocolate"] = "\x1b[38;5;166m";
+      colors["teal"] = "\x1b[38;5;30m";
+      colors["SeaGreen"] = "\x1b[38;5;29m";
+      colors["Thistle"] = "\x1b[38;5;182m";
+      colors["Red"] = "\x1b[38;5;196m";
+      colors["blue"] = "\x1b[38;5;21m";
+      colors["MistyRose"] = "\x1b[38;5;224m";
+      colors["purple"] = "\x1b[38;5;161m";
+      colors["Crimson"] = "\x1b[38;5;197m";
+      colors["DarkGray"] = "\x1b[38;5;145m";
+      colors["Fuchsia"] = "\x1b[38;5;201m";
+      colors["DarkBlue"] = "\x1b[38;5;18m";
+      colors["red"] = "\x1b[38;5;196m";
+      colors["Cornsilk"] = "\x1b[38;5;230m";
+      colors["white"] = "\x1b[38;5;231m";
+      colors["DarkSlateGrey"] = "\x1b[38;5;23m";
+      colors["PaleGreen"] = "\x1b[38;5;120m";
+      colors["DimGray"] = "\x1b[38;5;59m";
+      colors["lightgray"] = "\x1b[38;5;145m";
+      colors["Gold"] = "\x1b[38;5;220m";
+      colors["Gray"] = "\x1b[38;5;102m";
+      colors["DarkOliveGreen"] = "\x1b[38;5;58m";
+      colors["LemonChiffon"] = "\x1b[38;5;230m";
+      colors["brown"] = "\x1b[38;5;137m";
+      colors["NavyBlue"] = "\x1b[38;5;18m";
+      colors["FloralWhite"] = "\x1b[38;5;231m";
+      colors["LightGoldenrod"] = "\x1b[38;5;186m";
+      colors["GreenYellow"] = "\x1b[38;5;154m";
+      colors["Silver"] = "\x1b[38;5;145m";
+      colors["Khaki"] = "\x1b[38;5;186m";
+      colors["Ivory"] = "\x1b[38;5;231m";
+      colors["LightSkyBlue"] = "\x1b[38;5;117m";
+      colors["DarkGreen"] = "\x1b[38;5;22m";
+      colors["DarkSalmon"] = "\x1b[38;5;173m";
+      colors["TealBlue"] = "\x1b[38;5;37m";
+      colors["Linen"] = "\x1b[38;5;231m";
+      colors["LightGoldenrodYellow"] = "\x1b[38;5;230m";
+      colors["LightGreen"] = "\x1b[38;5;120m";
+      colors["LightGrey"] = "\x1b[38;5;188m";
+      colors["Brown"] = "\x1b[38;5;124m";
+      colors["Aqua"] = "\x1b[38;5;51m";
+      colors["Cerulean"] = "\x1b[38;5;39m";
+      colors["Peach"] = "\x1b[38;5;209m";
+      colors["Bisque"] = "\x1b[38;5;223m";
+      colors["MediumBlue"] = "\x1b[38;5;20m";
+      colors["BlueViolet"] = "\x1b[38;5;93m";
+      colors["RubineRed"] = "\x1b[38;5;198m";
+      colors["Lavender"] = "\x1b[38;5;189m";
+      colors["CornflowerBlue"] = "\x1b[38;5;68m";
+      colors["Goldenrod"] = "\x1b[38;5;178m";
+      colors["Grey"] = "\x1b[38;5;102m";
+      colors["MediumSpringGreen"] = "\x1b[38;5;49m";
+      colors["DarkKhaki"] = "\x1b[38;5;143m";
+      colors["green"] = "\x1b[38;5;46m";
+      colors["ForestGreen"] = "\x1b[38;5;28m";
+      colors["DarkOrchid"] = "\x1b[38;5;128m";
+      colors["White"] = "\x1b[38;5;231m";
+      colors["Purple"] = "\x1b[38;5;90m";
+      colors["DarkMagenta"] = "\x1b[38;5;90m";
+      colors["BlueGreen"] = "\x1b[38;5;37m";
+      colors["Green"] = "\x1b[38;5;28m";
+      colors["Melon"] = "\x1b[38;5;216m";
+      colors["SkyBlue"] = "\x1b[38;5;117m";
+      colors["Rhodamine"] = "\x1b[38;5;205m";
+      colors["Apricot"] = "\x1b[38;5;216m";
+      colors["RedOrange"] = "\x1b[38;5;202m";
+      colors["LightSlateGray"] = "\x1b[38;5;102m";
+      colors["cyan"] = "\x1b[38;5;51m";
+      colors["Orange"] = "\x1b[38;5;214m";
+      colors["DarkSlateGray"] = "\x1b[38;5;23m";
+      colors["DimGrey"] = "\x1b[38;5;59m";
+      colors["LightSeaGreen"] = "\x1b[38;5;37m";
+      colors["RoyalBlue"] = "\x1b[38;5;62m";
+      colors["darkgray"] = "\x1b[38;5;59m";
+      colors["Sepia"] = "\x1b[38;5;52m";
+      colors["DarkViolet"] = "\x1b[38;5;92m";
+      colors["MediumAquamarine"] = "\x1b[38;5;79m";
+      colors["MediumSlateBlue"] = "\x1b[38;5;99m";
+      colors["Dandelion"] = "\x1b[38;5;214m";
+      colors["MidnightBlue"] = "\x1b[38;5;18m";
+      colors["SandyBrown"] = "\x1b[38;5;215m";
+      colors["violet"] = "\x1b[38;5;90m";
+      colors["DarkSlateBlue"] = "\x1b[38;5;61m";
+      colors["DeepSkyBlue"] = "\x1b[38;5;74m";
+      colors["Chartreuse"] = "\x1b[38;5;118m";
+      colors["Olive"] = "\x1b[38;5;100m";
+      colors["MediumPurple"] = "\x1b[38;5;98m";
+      colors["Yellow"] = "\x1b[38;5;226m";
+      colors["Peru"] = "\x1b[38;5;173m";
+      colors["RosyBrown"] = "\x1b[38;5;138m";
+      colors["pink"] = "\x1b[38;5;217m";
+      colors["FireBrick"] = "\x1b[38;5;124m";
+      colors["RawSienna"] = "\x1b[38;5;124m";
+      colors["VioletRed"] = "\x1b[38;5;162m";
+      colors["OrangeRed"] = "\x1b[38;5;202m";
+      colors["Bittersweet"] = "\x1b[38;5;130m";
+      colors["Turquoise"] = "\x1b[38;5;80m";
+      colors["Cyan"] = "\x1b[38;5;51m";
+      colors["WhiteSmoke"] = "\x1b[38;5;231m";
+      colors["MediumSeaGreen"] = "\x1b[38;5;35m";
+      colors["LavenderBlush"] = "\x1b[38;5;231m";
+      colors["LightCyan"] = "\x1b[38;5;195m";
+      colors["PineGreen"] = "\x1b[38;5;29m";
+      colors["OliveGreen"] = "\x1b[38;5;28m";
+      colors["SlateGray"] = "\x1b[38;5;102m";
+      colors["LightSlateBlue"] = "\x1b[38;5;99m";
+      colors["NavajoWhite"] = "\x1b[38;5;223m";
+      colors["SlateBlue"] = "\x1b[38;5;62m";
+      colors["Orchid"] = "\x1b[38;5;170m";
+      colors["Tan"] = "\x1b[38;5;180m";
+      colors["LightSalmon"] = "\x1b[38;5;216m";
+      colors["Seashell"] = "\x1b[38;5;231m";
+      colors["Snow"] = "\x1b[38;5;231m";
+      colors["WildStrawberry"] = "\x1b[38;5;197m";
+      colors["Tomato"] = "\x1b[38;5;203m";
+      colors["RoyalPurple"] = "\x1b[38;5;61m";
+      colors["LightSlateGrey"] = "\x1b[38;5;102m";
+      colors["Plum"] = "\x1b[38;5;182m";
+      colors["YellowGreen"] = "\x1b[38;5;112m";
+      colors["olive"] = "\x1b[38;5;100m";
+      colors["MintCream"] = "\x1b[38;5;231m";
+      colors["PaleVioletRed"] = "\x1b[38;5;168m";
+      colors["Azure"] = "\x1b[38;5;231m";
+      colors["BurntOrange"] = "\x1b[38;5;208m";
+      colors["Salmon"] = "\x1b[38;5;210m";
+      colors["BlanchedAlmond"] = "\x1b[38;5;223m";
+      colors["Pink"] = "\x1b[38;5;217m";
+      colors["AliceBlue"] = "\x1b[38;5;231m";
+      colors["PapayaWhip"] = "\x1b[38;5;230m";
+      colors["Honeydew"] = "\x1b[38;5;231m";
+      colors["MediumTurquoise"] = "\x1b[38;5;44m";
+      colors["AntiqueWhite"] = "\x1b[38;5;231m";
+      colors["magenta"] = "\x1b[38;5;201m";
+      colors["LightPink"] = "\x1b[38;5;217m";
+      colors["OldLace"] = "\x1b[38;5;231m";
+      colors["CadetBlue"] = "\x1b[38;5;73m";
+      colors["BurlyWood"] = "\x1b[38;5;180m";
+      colors["Lime"] = "\x1b[38;5;46m";
+      colors["BrickRed"] = "\x1b[38;5;124m";
+      colors["Emerald"] = "\x1b[38;5;37m";
+      colors["LightSteelBlue"] = "\x1b[38;5;153m";
+      colors["Mahogany"] = "\x1b[38;5;124m";
+      colors["GhostWhite"] = "\x1b[38;5;231m";
+      colors["SteelBlue"] = "\x1b[38;5;67m";
+      colors["PaleTurquoise"] = "\x1b[38;5;159m";
+      colors["DarkGoldenrod"] = "\x1b[38;5;136m";
+      colors["lime"] = "\x1b[38;5;154m";
+      colors["DeepPink"] = "\x1b[38;5;198m";
+      colors["MediumVioletRed"] = "\x1b[38;5;162m";
+      colors["orange"] = "\x1b[38;5;220m";
+      colors["HotPink"] = "\x1b[38;5;205m";
+      colors["LightYellow"] = "\x1b[38;5;230m";
+      colors["Navy"] = "\x1b[38;5;18m";
+      colors["SaddleBrown"] = "\x1b[38;5;94m";
+      colors["Coral"] = "\x1b[38;5;209m";
+      colors["SlateGrey"] = "\x1b[38;5;102m";
+      once = false;
+    }
+    append(out, colors[color]);
+  }
+}
+
+std::string enquote(std::string str) {
+  std::string result;
+  for (size_t i = 0; i < str.length(); ++i) {
+    char c = str[i];
+    switch(c) {
+    case '\\':
+      result.append("\\\\");
+      break;
+    case '"':
+      result.append("\\\"");
+      break;
+    case '\n':
+      result.append("\\n");
+      break;
+    case '\t':
+      result.append("\\t");
+      break;
+    case '\r':
+      result.append("\\r");
+      break;
+    case '\f':
+      result.append("\\f");
+      break;
+    default:
+      if ((unsigned char)c >= 32 && (unsigned char)c < 127) {
+        result.push_back(c);
+      } else {
+        char buf[3];
+        buf[2] = 0;
+        snprintf(buf, 3, "%02x", (unsigned char)c);
+        result.append("\\x");
+        result.append(buf);
+      }
+      break;
+    }
+  }
+  return result;
+}
+
+void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const& data) const {
+  std::string name = getConstructor()->getName();
+  if (name == "\\dv") {
+    KORECompositeSort *s = dynamic_cast<KORECompositeSort *>(getConstructor()->getFormalArguments()[0].get()); 
+    bool hasHook = data.hook.count(s->getName());
+    auto str = dynamic_cast<KOREStringPattern *>(arguments[0].get());
+    if (hasHook) {
+      auto hook = data.hook.at(s->getName());
+      if (hook == "STRING.String") {
+        append(out, enquote(str->getContents()));
+      } else if (hook == "BYTES.Bytes") {
+        append(out, 'b');
+        append(out, enquote(str->getContents()));
+      } else {
+        append(out, str->getContents());
+      }
+    } else {
+      append(out, str->getContents());
+    }
+    return;
+  }
+  if (data.format.count(name)) {
+    auto format = data.format.at(name);
+    int localIndent = 0;
+    int localColor = 0;
+    for (int i = 0; i < format.length(); ++i) {
+      char c = format[i];
+      if (c == '%') {
+        char c2 = format[i+1];
+        ++i;
+        switch(c2) {
+          case 'n':
+            newline();
+            break;
+          case 'i':
+            indent++;
+            localIndent++;
+            break;
+          case 'd':
+            indent--;
+            localIndent--;
+            break;
+          case 'c':
+            if (data.colors.count(name)) {
+              color(out, data.colors.at(name)[localColor++]);
+            }
+            break;
+          case 'r':
+            if (hasColor) {
+              append(out, "\x1b[0m");
+            }
+            break;
+          case '0':
+          case '1':
+          case '2':
+          case '3':
+          case '4':
+          case '5':
+          case '6':
+          case '7':
+          case '8':
+          case '9': {
+            std::string buf;
+            for(; i < format.length() && format[i] >= '0' && format[i] < '9'; i++) {
+              buf.push_back(format[i]);
+            }
+            i--;
+            int idx = std::stoi(buf);
+            if (idx == 0 || idx > arguments.size()) {
+              abort();
+            }
+            KOREPattern *inner = arguments[idx-1].get();
+            bool assoc = false;
+            if (auto app = dynamic_cast<KORECompositePattern *>(inner)) {
+              if (app->getConstructor()->getName() == constructor->getName() && data.assoc.count(name)) {
+                assoc = true;
+              }
+              if (assoc) {
+                for (int j = 0; j < localIndent; j++) {
+                  indent--;
+                }
+              }
+              inner->prettyPrint(out, data);
+              if (assoc) {
+                for (int j = 0; j < localIndent; j++) {
+                  indent++;
+                }
+              }
+            }
+            break;
+          } default:
+            append(out, c2);
+        }
+      } else {
+        append(out, c);
+      }
+    }
+  } else {
+    abort();
+  }
+}
+
+struct CompareFirst {
+  bool isDigit(char c) {
+    return c >= '0' && c <= '9';
+  }
+
+  std::string getChunk(std::string s, size_t slength, size_t marker) {
+    std::string chunk;
+    char c = s[marker];
+    chunk.push_back(c);
+    marker++;
+    if (isDigit(c)) {
+      while (marker < slength) {
+        c = s[marker];
+        if (!isDigit(c)) {
+          break;
+        }
+        chunk.push_back(c);
+        marker++;
+      }
+    } else {
+      while (marker < slength) {
+        c = s[marker];
+        if (isDigit(c)) {
+          break;
+        }
+        chunk.push_back(c);
+        marker++;
+      }
+    }
+    return chunk;
+  }
+
+  template <typename T>
+  bool operator()(std::pair<std::string, T> a, std::pair<std::string, T> b) {
+    std::string s1 = a.first;
+    std::string s2 = b.first;
+    size_t thisMarker = 0;
+    size_t thatMarker = 0;
+    size_t s1length = s1.length();
+    size_t s2length = s2.length();
+    while (thisMarker < s1length && thatMarker < s2length) {
+      std::string thisChunk = getChunk(s1, s1length, thisMarker);
+      thisMarker += thisChunk.length();
+      std::string thatChunk = getChunk(s2, s2length, thatMarker);
+      thatMarker += thatChunk.length();
+      int result = 0;
+      if (isDigit(thisChunk[0]) && isDigit(thatChunk[0])) {
+        size_t thisChunkLength = thisChunk.length();
+        result = thisChunkLength - thatChunk.length();
+        if (result == 0) {
+          for (int i = 0; i < thisChunkLength; i++) {
+            result = thisChunk[i] - thatChunk[i];
+            if (result != 0) {
+              return result < 0;
+            }
+          }
+        }
+      } else {
+        result = thisChunk.compare(thatChunk);
+      }
+      if (result != 0) {
+        return result < 0;
+      }
+    }
+    return s1length < s2length;
+  }
+};
+
+static void flatten(KORECompositePattern *pat, std::string name, std::vector<sptr<KOREPattern>> &result) {
+  for (auto &arg : pat->getArguments()) {
+    if (auto pat2 = dynamic_cast<KORECompositePattern *>(arg.get())) {
+      if (pat2->getConstructor()->getName() == name) {
+        flatten(pat2, name, result);
+      } else {
+        result.push_back(arg);
+      }
+    } else {
+      result.push_back(arg);
+    }
+  }
 }
 
 void KOREDeclaration::addAttribute(ptr<KORECompositePattern> Attribute) {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(llvm-kompile-codegen)
 add_subdirectory(llvm-kompile-gc-stats)
+add_subdirectory(kprint)

--- a/tools/kprint/CMakeLists.txt
+++ b/tools/kprint/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(LLVM_REQUIRES_RTTI ON)
+set(LLVM_REQUIRES_EH ON)
+kllvm_add_tool(kprint
+  main.cpp
+)
+
+target_link_libraries(kprint PUBLIC Parser AST)
+target_compile_options(kprint PUBLIC -O3)
+
+install(
+  TARGETS kprint
+  RUNTIME DESTINATION bin
+)

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -1,0 +1,71 @@
+#include "kllvm/parser/KOREScanner.h"
+#include "kllvm/parser/KOREParser.h"
+
+#include <iostream>
+#include <fstream>
+
+using namespace kllvm;
+using namespace kllvm::parser;
+
+void readMap(std::map<std::string, std::string> &result, std::ifstream &is) {
+  std::string line;
+  while(std::getline(is, line)) {
+    std::string att;
+    if (!std::getline(is, att)) {
+      break;
+    }
+    result[line] = att;
+  }
+}
+
+
+int main (int argc, char **argv) {
+  if (argc != 3) {
+    std::cerr << "usage: " << argv[0] << " <kompiled-dir> <pattern.kore>" << std::endl;
+  }
+
+  std::map<std::string, std::string> formats;
+  formats["kseq"] = "%1 ~> %2";
+  formats["dotk"] = ".";
+  formats["inj"] = "%1";
+  std::map<std::string, std::string> hooks;
+  std::set<std::string> assocs;
+  std::set<std::string> comms;
+  std::map<std::string, std::vector<std::string>> colors;
+
+  std::ifstream iformats(argv[1] + std::string("/format-att.txt"));
+  std::ifstream ihooks(argv[1] + std::string("/hook-att.txt"));
+  std::ifstream iassocs(argv[1] + std::string("/assoc-att.txt"));
+  std::ifstream icomms(argv[1] + std::string("/comm-att.txt"));
+  std::ifstream icolors(argv[1] + std::string("/color-att.txt"));
+
+  readMap(formats, iformats);
+  readMap(hooks, ihooks);
+
+  std::string line;
+  while(std::getline(iassocs, line)) {
+    assocs.insert(line);
+  }
+  while(std::getline(icomms, line)) {
+    comms.insert(line);
+  }
+
+  while(std::getline(icolors, line)) {
+    std::string color;
+    while(std::getline(icolors, color)) {
+      if (color.empty()) {
+        break;
+      }
+      colors[line].push_back(color);
+    }
+  }
+
+  KOREParser parser2(argv[2]);
+  ptr<KOREPattern> config = parser2.pattern();
+
+  PrettyPrintData data = {formats, colors, hooks, assocs, comms};
+
+  sptr<KOREPattern> sorted = config->sortCollections(data);
+  sorted->prettyPrint(std::cout, data);
+  std::cout << std::endl;
+}

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -33,6 +33,7 @@ int main (int argc, char **argv) {
   std::set<std::string> comms;
   std::map<std::string, std::vector<std::string>> colors;
 
+  // load information about definition written by k frontend
   std::ifstream iformats(argv[1] + std::string("/format-att.txt"));
   std::ifstream ihooks(argv[1] + std::string("/hook-att.txt"));
   std::ifstream iassocs(argv[1] + std::string("/assoc-att.txt"));


### PR DESCRIPTION
This is the llvm backend part of a pair of PRs used to support pretty-printing kore terms with a vastly reduced overhead. Some logic is not implemented yet, but it is sufficient to unparse some simple IMP programs. I will add more features as I go if this proves useful to people.

Second PR is here: https://github.com/kframework/k/pull/1211