### PR TITLE
ignore axioms with simplification attribute

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -306,10 +306,10 @@ static const std::string UNIT = "unit";
 static const std::string FUNCTIONAL = "functional";
 static const std::string SUBSORT = "subsort";
 static const std::string CONSTRUCTOR = "constructor";
-static const std::string CEIL = "ceil";
+static const std::string SIMPLIFICATION = "simplification";
 
 bool KOREAxiomDeclaration::isRequired() {
-  return !attributes.count(ASSOC) && !attributes.count(COMM) && !attributes.count(IDEM) && !attributes.count(UNIT) && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR) && !attributes.count(SUBSORT) && !attributes.count(CEIL);
+  return !attributes.count(ASSOC) && !attributes.count(COMM) && !attributes.count(IDEM) && !attributes.count(UNIT) && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR) && !attributes.count(SUBSORT) && !attributes.count(SIMPLIFICATION);
 }
 
 bool KOREAxiomDeclaration::isTopAxiom() {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -133,7 +133,7 @@ object Parser {
     val splitted = split(axiom._1.pattern)
     if (splitted.isDefined) {
       val s = axiom._1
-      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem")) {
+      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem") || hasAtt(s, "simplification")) {
         Seq()
       } else {
         Seq((splitted.get._1, AxiomInfo(rulePriority(s), axiom._2, splitted.get._2, splitted.get._3, source(s), location(s))))


### PR DESCRIPTION
This attribute is applied to, among other things, `\ceil` axioms, and should be treated as if the axiom does not exist in the llvm backend.