### PR TITLE
Pretty print terms in gdb by default.

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -260,6 +260,8 @@ struct PrettyPrintData {
   std::set<std::string> assoc;
   // set of commutative symbols
   std::set<std::string> comm;
+  // enable coloring
+  bool hasColor;
 };
 
 // KOREPattern

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -400,6 +400,8 @@ public:
   const std::vector<sptr<KORESortVariable>> &getObjectSortVariables() const { return objectSortVariables; }
   virtual ~KOREDeclaration() = default;
 
+  std::string getStringAttribute(std::string name) const;
+
 protected:
   void printSortVariables(std::ostream &Out) const;
 };

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -578,6 +578,8 @@ public:
   using KORESymbolDeclarationMapType = std::map<std::string, KORESymbolDeclaration *>;
   using KOREAliasDeclarationMapType = std::map<std::string, KOREAliasDeclaration *>;
 
+  using KOREAxiomMapType = std::map<size_t, KOREAxiomDeclaration *>;
+
 private:
   // Symbol tables
   KORESortConstructorMapType objectSortConstructors;
@@ -591,6 +593,7 @@ private:
   KOREAliasDeclarationMapType aliasDeclarations;
   KORECompositeSortMapType hookedSorts;
   KORESymbolStringMapType freshFunctions;
+  KOREAxiomMapType ordinals;
 
   std::vector<ptr<KOREModule>> modules;
   std::map<std::string, ptr<KORECompositePattern>> attributes;
@@ -622,6 +625,7 @@ public:
   const KORESymbolStringMapType &getAllSymbols() const { return allObjectSymbols; }
   const KORECompositeSortMapType getHookedSorts() const { return hookedSorts; }
   const std::list<KOREAxiomDeclaration *> &getAxioms() const { return axioms; }
+  KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const { return ordinals.at(ordinal); }
   const std::map<std::string, ptr<KORECompositePattern>> &getAttributes() const {
     return attributes;
   }

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -60,6 +60,7 @@ public:
 /* Creates a new llvm::Module with the predefined declarations common to all llvm modules
    in the llvm backend. */
 std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Context);
+void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod);
 
 llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol);
 llvm::Value *getBlockHeader(llvm::Module *Module, KOREDefinition *definition,

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -20,11 +20,13 @@ void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable 
 
 llvm::DIType *getDebugType(ValueType type, std::string typeName);
 llvm::DIType *getIntDebugType(void);
+llvm::DIType *getVoidDebugType(void);
 llvm::DIType *getBoolDebugType(void);
 llvm::DIType *getShortDebugType(void);
 llvm::DIType *getPointerDebugType(llvm::DIType *, std::string typeName);
 llvm::DIType *getArrayDebugType(llvm::DIType *ty, size_t len, size_t align);
 llvm::DIType *getCharPtrDebugType(void);
+llvm::DIType *getCharDebugType(void);
 llvm::DIType *getForwardDecl(std::string name);
 
 llvm::DISubroutineType *getDebugFunctionType(llvm::Metadata *, std::vector<llvm::Metadata *>);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -288,7 +288,6 @@ sptr<KOREPattern> KORECompositePattern::expandAliases(KOREDefinition *def) {
 
 static int indent = 0;
 static bool atNewLine = true;
-static bool hasColor = isatty(1);
 
 #define INDENT_SIZE 2
 
@@ -316,8 +315,8 @@ static void append(std::ostream &out, std::string str) {
   out << str;
 }
 
-static void color(std::ostream &out, std::string color) {
-  if (hasColor) {
+static void color(std::ostream &out, std::string color, PrettyPrintData const& data) {
+  if (data.hasColor) {
     static bool once = true;
     static std::map<std::string, std::string> colors;
     if (once) {
@@ -616,11 +615,11 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
               if (localColor >= data.colors.at(name).size() ) {
                 abort();
               }
-              color(out, data.colors.at(name)[localColor++]);
+              color(out, data.colors.at(name)[localColor++], data);
             }
             break;
           case 'r':
-            if (hasColor) {
+            if (data.hasColor) {
               append(out, RESET_COLOR);
             }
             break;
@@ -767,18 +766,17 @@ sptr<KOREPattern> KORECompositePattern::sortCollections(PrettyPrintData const& d
     std::vector<std::pair<std::string, sptr<KOREPattern>>> printed;
     int oldIndent = indent;
     bool oldAtNewLine = atNewLine;
-    bool oldHasColor = hasColor;
     atNewLine = true;
     indent = 0;
-    hasColor = false;
+    PrettyPrintData newData = data;
+    newData.hasColor = false;
     for (auto &item : items) {
       std::ostringstream Out;
-      item->prettyPrint(Out, data);
+      item->prettyPrint(Out, newData);
       printed.push_back({Out.str(), item});
     }
     indent = oldIndent;
     atNewLine = oldAtNewLine;
-    hasColor = oldHasColor;
     std::sort(printed.begin(), printed.end(), CompareFirst{});
     items.clear();
     for (auto &item : printed) {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1067,7 +1067,8 @@ void KOREDefinition::preprocess() {
   }
   for (auto iter = axioms.begin(); iter != axioms.end();) {
     auto axiom = *iter;
-    axiom->ordinal = nextOrdinal++;
+    axiom->ordinal = nextOrdinal;
+    ordinals[nextOrdinal++] = axiom;
     axiom->pattern->markSymbols(symbols);
     if (!axiom->isRequired()) {
       iter = axioms.erase(iter);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -810,6 +810,14 @@ KOREDeclaration::addObjectSortVariable(sptr<KORESortVariable> SortVariable) {
   objectSortVariables.push_back(SortVariable);
 }
 
+std::string KOREDeclaration::getStringAttribute(std::string name) const { 
+  KORECompositePattern *attr = attributes.at(name).get();
+  assert(attr->getArguments().size() == 1);
+  auto strPattern = dynamic_cast<KOREStringPattern *>(attr->getArguments()[0].get());
+  return strPattern->getContents();
+}
+ 
+
 void KOREAxiomDeclaration::addPattern(ptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
 }

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -901,11 +901,7 @@ bool makeFunction(std::string name, KOREPattern *pattern, KOREDefinition *defini
     initDebugAxiom(axiom->getAttributes());
     std::string debugName = name;
     if (axiom->getAttributes().count("label")) {
-      KORECompositePattern *labelAtt = axiom->getAttributes().at("label").get();
-      assert(labelAtt->getArguments().size() == 1);
-      auto strPattern = dynamic_cast<KOREStringPattern *>(labelAtt->getArguments()[0].get());
-      std::string label = strPattern->getContents();
-      debugName = label + postfix;
+      debugName = axiom->getStringAttribute("label") + postfix;
     }
     std::ostringstream Out;
     termSort(pattern)->print(Out);

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -108,6 +108,16 @@ std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Con
   return mod;
 }
 
+void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod) {
+  auto Str = llvm::ConstantDataArray::getString(Context, dir, true);
+  auto global = mod->getOrInsertGlobal("kompiled_directory", Str->getType());
+  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  if (!globalVar->hasInitializer()) {
+    globalVar->setInitializer(Str);
+  }
+  initDebugGlobal("kompiled_directory", getCharDebugType(), globalVar);
+}
+
 static std::string MAP_STRUCT = "map";
 static std::string LIST_STRUCT = "list";
 static std::string SET_STRUCT = "set";

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -179,9 +179,18 @@ llvm::DIType *getBoolDebugType(void) {
   return Dbg->createBasicType("bool", 8, llvm::dwarf::DW_ATE_boolean);
 }
 
+llvm::DIType *getVoidDebugType(void) {
+  return nullptr;
+}
+
 llvm::DIType *getCharPtrDebugType(void) {
   if (!Dbg) return nullptr;
   return Dbg->createPointerType(Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char), sizeof(size_t) * 8);
+}
+
+llvm::DIType *getCharDebugType(void) {
+  if (!Dbg) return nullptr;
+  return Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char);
 }
 
 llvm::DIType *getPointerDebugType(llvm::DIType *ty, std::string typeName) {

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -20,8 +20,16 @@ void readMap(std::map<std::string, std::string> &result, std::ifstream &is) {
 
 
 int main (int argc, char **argv) {
-  if (argc != 3) {
-    std::cerr << "usage: " << argv[0] << " <kompiled-dir> <pattern.kore>" << std::endl;
+  if (argc != 3 && argc != 4) {
+    std::cerr << "usage: " << argv[0] << " <kompiled-dir> <pattern.kore> [true|false]" << std::endl;
+  }
+
+  bool hasColor;
+  if (argc == 4) {
+    std::string arg = argv[3];
+    hasColor = arg == "true";
+  } else {
+    hasColor = isatty(1);
   }
 
   std::map<std::string, std::string> formats;
@@ -64,7 +72,7 @@ int main (int argc, char **argv) {
   KOREParser parser2(argv[2]);
   ptr<KOREPattern> config = parser2.pattern();
 
-  PrettyPrintData data = {formats, colors, hooks, assocs, comms};
+  PrettyPrintData data = {formats, colors, hooks, assocs, comms, hasColor};
 
   sptr<KOREPattern> sorted = config->sortCollections(data);
   sorted->prettyPrint(std::cout, data);

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -70,7 +70,7 @@ int main (int argc, char **argv) {
   }
 
   KOREParser parser2(argv[2]);
-  ptr<KOREPattern> config = parser2.pattern();
+  sptr<KOREPattern> config = parser2.pattern();
 
   PrettyPrintData data = {formats, colors, hooks, assocs, comms, hasColor};
 

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -38,10 +38,13 @@ int main (int argc, char **argv) {
 
   llvm::LLVMContext Context;
 
+  char *realPath = realpath(argv[1], NULL);
+
   std::unique_ptr<llvm::Module> mod = newModule("definition", Context);
 
   if (CODEGEN_DEBUG) {
     initDebugInfo(mod.get(), argv[1]);
+    addKompiledDirSymbol(Context, dirname(realPath), mod.get());
   }
 
   for (auto axiom : definition->getAxioms()) {


### PR DESCRIPTION
This uses the kprint command and thus only works if the kompiled directory still exists in the same location on disk. However, with this, we can step through programs in gdb and get colorized and pretty-printed output. Because it uses the kprint command, details of pretty-printing are divorced from gdb.