### PR TITLE
fix more llvm 10 bugs

### DIFF
--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -1,5 +1,6 @@
 #include "kllvm/codegen/Util.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace kllvm {
 

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(getc) {
   b = hook_IO_getc(f);
   BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
   const char * temp = GETTAG(EOF);
-  BOOST_CHECK(temp != "");
+  BOOST_CHECK(std::string(temp) != "");
   BOOST_CHECK_EQUAL((uint64_t)*(b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EOF))));
 
   ::close(fd);


### PR DESCRIPTION
Clang 10 reports a warning here because we were accidentally comparing a `char *` with != instead of first converting it to a std::string.