### PR TITLE
Revert "ignore axioms with simplification attribute (#316)"

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -827,10 +827,10 @@ static const std::string UNIT = "unit";
 static const std::string FUNCTIONAL = "functional";
 static const std::string SUBSORT = "subsort";
 static const std::string CONSTRUCTOR = "constructor";
-static const std::string SIMPLIFICATION = "simplification";
+static const std::string CEIL = "ceil";
 
 bool KOREAxiomDeclaration::isRequired() {
-  return !attributes.count(ASSOC) && !attributes.count(COMM) && !attributes.count(IDEM) && !attributes.count(UNIT) && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR) && !attributes.count(SUBSORT) && !attributes.count(SIMPLIFICATION);
+  return !attributes.count(ASSOC) && !attributes.count(COMM) && !attributes.count(IDEM) && !attributes.count(UNIT) && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR) && !attributes.count(SUBSORT) && !attributes.count(CEIL);
 }
 
 bool KOREAxiomDeclaration::isTopAxiom() {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -133,7 +133,7 @@ object Parser {
     val splitted = split(axiom._1.pattern)
     if (splitted.isDefined) {
       val s = axiom._1
-      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem") || hasAtt(s, "simplification")) {
+      if (hasAtt(s, "comm") || hasAtt(s, "assoc") || hasAtt(s, "idem")) {
         Seq()
       } else {
         Seq((splitted.get._1, AxiomInfo(rulePriority(s), axiom._2, splitted.get._2, splitted.get._3, source(s), location(s))))


### PR DESCRIPTION
This reverts commit 616237b488ae238583558b03a66b02d71454914c.

This commit broke the C semantics and it seems that we will need a more complex fix to the problem that this fixed, so I am reverting this for now so that we aren't in a broken state while we figure out the better solution.