### PR TITLE
include nine in list of escape digits

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -692,7 +692,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
           case '8':
           case '9': {
             std::string buf;
-            for(; i < format.length() && format[i] >= '0' && format[i] < '9'; i++) {
+            for(; i < format.length() && format[i] >= '0' && format[i] <= '9'; i++) {
               buf.push_back(format[i]);
             }
             i--;


### PR DESCRIPTION
This was an off by one error that causes problems when the format attribute of a production references the ninth nonterminal.