### PR TITLE
Make kprint work on symbolic configurations

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -68,7 +68,7 @@ public:
   virtual sptr<KORESort> substitute(const substitution &subst) override { return subst.at(*this); }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &Out) const override { std::cout << name; }
+  virtual void prettyPrint(std::ostream &Out) const override;
   virtual bool operator==(const KORESort &other) const override;
 
 private:
@@ -114,19 +114,7 @@ public:
 
   void addArgument(sptr<KORESort> Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &out) const override {
-    out << name.substr(4);
-    if (!arguments.empty()) {
-      out << "{";
-      std::string conn = "";
-      for (auto &sort : arguments) {
-        out << conn;
-        sort->prettyPrint(out);
-        conn = ",";
-      }
-      out << "}";
-    }
-  }
+  virtual void prettyPrint(std::ostream &out) const override;
   virtual bool operator==(const KORESort &other) const override;
 
 private:
@@ -318,10 +306,7 @@ public:
   }
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
-  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override {
-    out << decodeKore(getName().substr(3)) << ":";
-    sort->prettyPrint(out);
-  }
+  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override;
 
 private:
   KOREVariablePattern(ptr<KOREVariable> Name, sptr<KORESort> Sort)

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -349,27 +349,27 @@ static bool atNewLine = true;
 
 #define INDENT_SIZE 2
 
-static void newline() {
-  std::cout << std::endl;
+static void newline(std::ostream &out) {
+  out << std::endl;
   atNewLine = true;
 }
 
-static void printIndent() {
+static void printIndent(std::ostream &out) {
   if (atNewLine) {
     for (int i = 0; i < INDENT_SIZE * indent; i++) {
-      std::cout << ' ';
+      out << ' ';
     }
     atNewLine = false;
   }
 }
 
 static void append(std::ostream &out, char c) {
-  printIndent();
+  printIndent(out);
   out << c;
 }
 
 static void append(std::ostream &out, std::string str) {
-  printIndent();
+  printIndent(out);
   out << str;
 }
 
@@ -623,6 +623,30 @@ std::string enquote(std::string str) {
   return result;
 }
 
+void KORESortVariable::prettyPrint(std::ostream &out) const {
+  append(out, name);
+}
+
+void KORECompositeSort::prettyPrint(std::ostream &out) const {
+  append(out, name.substr(4));
+  if (!arguments.empty()) {
+    append(out, '{');
+    std::string conn = "";
+    for (auto &sort : arguments) {
+      append(out, conn);
+      sort->prettyPrint(out);
+      conn = ",";
+    }
+    append(out, '}');
+  }
+}
+
+void KOREVariablePattern::prettyPrint(std::ostream &out, PrettyPrintData const& data) const {
+  append(out, decodeKore(getName().substr(3)));
+  append(out, ':');
+  sort->prettyPrint(out);
+}
+
 void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const& data) const {
   std::string name = getConstructor()->getName();
   if (name == "\\dv") {
@@ -658,7 +682,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
         ++i;
         switch(c2) {
           case 'n':
-            newline();
+            newline(out);
             break;
           case 'i':
             indent++;

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -34,13 +34,32 @@ int main (int argc, char **argv) {
 
   std::map<std::string, std::string> formats;
   formats["kseq"] = "%1 ~> %2";
+  formats["append"] = "%1 ~> %2";
   formats["dotk"] = ".";
   formats["inj"] = "%1";
   formats["\\bottom"] = "#False";
   formats["\\top"] = "#True";
+  formats["\\not"] = "#Not ( %1 )";
+  formats["\\ceil"] = "#Ceil ( %1 )";
+  formats["\\floor"] = "#Floor ( %1 )";
+  formats["\\equals"] = "{%i%n%1%d%n#Equals%i%n%2%d%n}";
+  formats["\\and"] = "%i%1%d%n#And%n%i%2%d";
+  formats["\\or"] = "%i%1%d%n#Or%n%i%2%d";
+  formats["\\implies"] = "%i%1%d%n#Implies%n%i%2%d";
+  formats["\\exists"] = "#Exists %1 . %2";
+  formats["\\forall"] = "#Forall %1 . %2";
+  formats["\\rewrites"] = "%1 => %2";
+  formats["\\weakExistsFinally"] = "#wEF ( %1 )";
+  formats["\\allPathGlobally"] = "#AG ( %1 )";
+
   std::map<std::string, std::string> hooks;
   std::set<std::string> assocs;
+  assocs.insert("kseq");
+  assocs.insert("\\and");
+  assocs.insert("\\or");
   std::set<std::string> comms;
+  comms.insert("\\and");
+  comms.insert("\\or");
   std::map<std::string, std::vector<std::string>> colors;
 
   // load information about definition written by k frontend


### PR DESCRIPTION
Adds some new fixes for kprint, adding attribute data for the remaining connectives and prelude symbols, and fixes some bugs relating to formatting.

Sample input:
```
\and{SortGeneratedTopCell{}}(
    Lbl'-LT-'generatedTop'-GT-'{}(
        Lbl'-LT-'T'-GT-'{}(
            Lbl'-LT-'k'-GT-'{}( dotk{}()),
            Lbl'-LT-'state'-GT-'{}(
                Lbl'Unds'Map'Unds'{}(
                     Lbl'UndsPipe'-'-GT-Unds'{}(
                         inj{SortId{}, SortKItem{}}(
                            \dv{SortId{}}( "a")
                        ),
                         inj{SortInt{}, SortKItem{}}(
                             VarA:SortInt{}
                        )
                    ),
                Lbl'Unds'Map'Unds'{}(
                     Lbl'UndsPipe'-'-GT-Unds'{}(
                         inj{SortId{}, SortKItem{}}(
                            \dv{SortId{}}( "b")
                        ),
                         inj{SortInt{}, SortKItem{}}(
                             VarB:SortInt{}
                        )
                    ),
                     Lbl'UndsPipe'-'-GT-Unds'{}(
                         inj{SortId{}, SortKItem{}}(
                            \dv{SortId{}}( "max")
                        ),
                         inj{SortInt{}, SortKItem{}}(
                             VarB:SortInt{}
                        )
                    )
                ))
            )
        ),
        Lbl'-LT-'generatedCounter'-GT-'{}(
             VarDotVar00:SortInt{}
        )
    ),
    \and{SortGeneratedTopCell{}}(
        \equals{SortBool{}, SortGeneratedTopCell{}}(
            Lbl'Unds-LT-Eqls'Int'Unds'{}(
                 VarA:SortInt{},
                 VarB:SortInt{}
            ),
             \dv{SortBool{}}("true")
        ),
        \not{SortGeneratedTopCell{}}(
            \and{SortGeneratedTopCell{}}(
                \equals{SortBool{}, SortGeneratedTopCell{}}(
                     \dv{SortBool{}}("true"),
                    Lbl'Unds-GT-Eqls'Int'Unds'{}(
                         VarA:SortInt{},
                         VarB:SortInt{}
                    )
                ),
                \equals{SortBool{}, SortGeneratedTopCell{}}(
                     \dv{SortBool{}}("true"),
                    Lbl'UndsEqlsEqls'Int'Unds'{}(
                         VarB:SortInt{},
                         VarA:SortInt{}
                    )
                )
            )
        )
    )
)
```

Sample output:
```
  #Not ( {
      true
    #Equals
      A:Int >=Int B:Int
    }
  #And
    {
      true
    #Equals
      B:Int ==Int A:Int
    } )
#And
  <T>
    <k>
      .
    </k>
    <state>
      a |-> A:Int
      b |-> B:Int
      max |-> B:Int
    </state>
  </T>
#And
  {
    A:Int <=Int B:Int
  #Equals
    true
  }
```