### PR TITLE
update format attribute of builtin brackets

### DIFF
--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -67,7 +67,7 @@ int main (int argc, char **argv) {
   formats["\\rewrites"] = "%1 => %2";
   formats["\\weakExistsFinally"] = "#wEF ( %1 )";
   formats["\\allPathGlobally"] = "#AG ( %1 )";
-  formats["bracket"] = "(%1)";
+  formats["bracket"] = "( %1 )";
 
   std::map<std::string, std::string> terminals;
   terminals["kseq"] = "010";


### PR DESCRIPTION
This is to bring the behavior of kprint in alignment with the behavior of `kast -i kore -o pretty`.