### PR TITLE
ffi: do not consider at_quick_exit a private symbol on OSX

### DIFF
--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -273,7 +273,9 @@ extern "C" {
     std::string funcStr = func;
     std::map<std::string, void *> privateSymbols;
     privateSymbols["atexit"] = (void *)atexit;
+#ifndef __APPLE__
     privateSymbols["at_quick_exit"] = (void *)at_quick_exit;
+#endif
 
     void *address;
     if (auto ptr = privateSymbols[funcStr]) {


### PR DESCRIPTION
Reason: at_quick_exit is not defined on OSX (see references in kframework/k#1580)

Note: I'm not sure if this PR is enough --- it seems like you want to handle FFI handles to these symbols specially --- but that seems to be irrelevant if the symbol doesn't exist on this platform. Hence this PR.