### PR TITLE
Building with Gcc on Fedora

### DIFF
--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -18,7 +18,7 @@ template<class...Ts>
 static llvm::Function* getOrInsertFunction(llvm::Module *module, Ts... Args) {
   llvm::Value *callee;
   auto ret = module->getOrInsertFunction(Args...);
-#if __clang_major__ >= 9
+#if LLVM_LIB_VERSION_MAJOR >= 9
   callee = ret.getCallee();
 #else
   callee = ret;

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -19,7 +19,7 @@
 
 #define len(s) len_hdr((s)->h.hdr)
 #define len_hdr(s) ((s) & LENGTH_MASK)
-#define set_len(s, l) ((s)->h.hdr = (l) | (l > BLOCK_SIZE - sizeof(char *) ? NOT_YOUNG_OBJECT_BIT : 0))
+#define set_len(s, l) ((s)->h.hdr = (l) | ((l) > BLOCK_SIZE - sizeof(char *) ? NOT_YOUNG_OBJECT_BIT : 0))
 #define size_hdr(s) ((((s) >> 32) & 0xff) * 8)
 #define layout(s) layout_hdr((s)->h.hdr)
 #define layout_hdr(s) ((s) >> LAYOUT_OFFSET)
@@ -158,12 +158,12 @@ using set = immer::set<KElem, HashBlock, std::equal_to<KElem>, list::memory_poli
 
 typedef struct mapiter {
   map::iterator curr;
-  map *map;
+  map *m;
 } mapiter;
 
 typedef struct setiter {
   set::iterator curr;
-  set *set;
+  set *s;
 } setiter;
 
 typedef floating *SortFloat;

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -85,7 +85,7 @@ bool KORECompositeSort::operator==(const KORESort &other) const {
     if (sort->name != name || sort->arguments.size() != arguments.size()) {
       return false;
     }
-    for (int i = 0; i < arguments.size(); ++i) {
+    for (size_t i = 0; i < arguments.size(); ++i) {
       if (*sort->arguments[i] != *arguments[i]) return false;
     }
     return true;
@@ -179,7 +179,7 @@ bool KORESymbol::operator==(const KORESymbol &other) const {
   if (name != other.name || arguments.size() != other.arguments.size()) {
     return false;
   }
-  for (int i = 0; i < arguments.size(); ++i) {
+  for (size_t i = 0; i < arguments.size(); ++i) {
     if (*arguments[i] != *other.arguments[i]) return false;
   }
   return true;
@@ -674,7 +674,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
     auto format = data.format.at(name);
     int localIndent = 0;
     int localColor = 0;
-    for (int i = 0; i < format.length(); ++i) {
+    for (size_t i = 0; i < format.length(); ++i) {
       char c = format[i];
       if (c == '%') {
         if (i == format.length() - 1) {
@@ -696,7 +696,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
             break;
           case 'c':
             if (data.colors.count(name)) {
-              if (localColor >= data.colors.at(name).size() ) {
+              if ((size_t)localColor >= data.colors.at(name).size() ) {
                 abort();
               }
               color(out, data.colors.at(name)[localColor++], data);
@@ -723,7 +723,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
             }
             i--;
             int idx = std::stoi(buf);
-            if (idx == 0 || idx > arguments.size()) {
+            if (idx == 0 || (size_t)idx > arguments.size()) {
               abort();
             }
             KOREPattern *inner = arguments[idx-1].get();
@@ -809,7 +809,7 @@ struct CompareFirst {
         size_t thisChunkLength = thisChunk.length();
         result = thisChunkLength - thatChunk.length();
         if (result == 0) {
-          for (int i = 0; i < thisChunkLength; i++) {
+          for (size_t i = 0; i < thisChunkLength; i++) {
             result = thisChunk[i] - thatChunk[i];
             if (result != 0) {
               return result < 0;
@@ -869,7 +869,7 @@ sptr<KOREPattern> KORECompositePattern::sortCollections(PrettyPrintData const& d
       items.push_back(item.second);
     }
     sptr<KOREPattern> result = items[0];
-    for (int i = 1; i < items.size(); ++i) {
+    for (size_t i = 1; i < items.size(); ++i) {
       sptr<KORECompositePattern> tmp = KORECompositePattern::Create(constructor.get());
       tmp->addArgument(result);
       tmp->addArgument(items[i]);

--- a/lib/codegen/CMakeLists.txt
+++ b/lib/codegen/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(Codegen
   Util.cpp
 )
 
+target_compile_definitions(Codegen PRIVATE LLVM_LIB_VERSION_MAJOR=${LLVM_VERSION_MAJOR})
 target_link_libraries(Codegen PUBLIC AST)
 
 add_definitions(${LLVM_DEFINITIONS})

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -167,6 +167,7 @@ llvm::Type *getValueType(ValueType sort, llvm::Module *Module) {
   case SortCategory::Uncomputed:
     abort();
   }
+  abort();
 }
 
 
@@ -273,7 +274,7 @@ llvm::Value *CreateTerm::createToken(ValueType sort, std::string contents) {
         allocdLimbs.push_back(llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), value->_mp_d[i]));
       }
       limbsVar->setInitializer(llvm::ConstantArray::get(limbsType, allocdLimbs));
-      llvm::Constant *hdr = llvm::ConstantStruct::get(Module->getTypeByName(BLOCKHEADER_STRUCT), llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), sizeof(mpz_hdr) - sizeof(blockheader) | NOT_YOUNG_OBJECT_BIT));
+      llvm::Constant *hdr = llvm::ConstantStruct::get(Module->getTypeByName(BLOCKHEADER_STRUCT), llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), (sizeof(mpz_hdr) - sizeof(blockheader)) | NOT_YOUNG_OBJECT_BIT));
       llvm::ConstantInt *numLimbs = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), size);
       llvm::Constant *mp_size = llvm::ConstantExpr::getMul(numLimbs, llvm::ConstantInt::getSigned(llvm::Type::getInt32Ty(Ctx), sign));
       globalVar->setInitializer(llvm::ConstantStruct::get(
@@ -370,6 +371,7 @@ llvm::Value *CreateTerm::createToken(ValueType sort, std::string contents) {
   case SortCategory::Uncomputed:
     abort();
   }
+  abort();
 }
 
 llvm::Value *CreateTerm::createHook(KORECompositePattern *hookAtt, KORECompositePattern *pattern) {
@@ -715,7 +717,7 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
     break;
   }
   llvm::Value *AllocSret;
-  for (int i = 0; i < args.size(); i++) {
+  for (size_t i = 0; i < args.size(); i++) {
     llvm::Value *arg = args[i];
     types.push_back(arg->getType());
   }

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -34,7 +34,7 @@ void initDebugFunction(std::string name, std::string linkageName, llvm::DISubrou
   if(!Dbg) return;
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   llvm::DIScope *FContext = Unit;
-#if __clang_major__ >= 8
+#if LLVM_LIB_VERSION_MAJOR >= 8
   DbgSP = Dbg->createFunction(
     FContext,
     name,

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -167,6 +167,7 @@ llvm::DIType *getDebugType(ValueType type, std::string typeName) {
     abort();
 
   }
+  return nullptr;
 }
 
 llvm::DIType *getIntDebugType(void) {

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -71,7 +71,7 @@ static std::pair<std::string, std::string> getFailPattern(DecisionCase const& _c
     _case.getConstructor()->getSort()->print(returnSort);
     std::string result = symbol.str() + "(";
     std::string conn = "";
-    for (int i = 0; i < _case.getConstructor()->getArguments().size(); i++) {
+    for (size_t i = 0; i < _case.getConstructor()->getArguments().size(); i++) {
       result += conn;
       result += "Var'Unds'";
       std::ostringstream argSort;
@@ -177,7 +177,7 @@ void SwitchNode::codegen(Decision *d) {
     }
     d->CurrentBlock = entry.first;
     if (!isInt) {
-      int offset = 0;
+      size_t offset = 0;
       llvm::StructType *BlockType = getBlockType(d->Module, d->Definition, _case.getConstructor());
       llvm::BitCastInst *Cast = new llvm::BitCastInst(val, llvm::PointerType::getUnqual(BlockType), "", d->CurrentBlock);
       KORESymbolDeclaration *symbolDecl = d->Definition->getSymbolDeclarations().at(_case.getConstructor()->getName());
@@ -512,7 +512,7 @@ void abortWhenStuck(llvm::BasicBlock *CurrentBlock, llvm::Module *Module, KORESy
     llvm::Value *Block = allocateTerm(BlockType, CurrentBlock);
     llvm::Value *BlockHeaderPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Block, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0)}, symbol->getName(), CurrentBlock);
     new llvm::StoreInst(BlockHeader, BlockHeaderPtr, CurrentBlock);
-    for (int idx = 0; idx < symbol->getArguments().size(); idx++) {
+    for (size_t idx = 0; idx < symbol->getArguments().size(); idx++) {
       auto cat = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[idx].get())->getCategory(d);
       auto type = getParamType(cat, Module);
       llvm::Value *ChildValue = codegen.load(std::make_pair("_" + std::to_string(idx+1), type));
@@ -535,7 +535,7 @@ void makeEvalFunction(KORESymbol *function, KOREDefinition *definition, llvm::Mo
 void addOwise(llvm::BasicBlock *stuck, llvm::Module *module, KORESymbol *symbol, Decision &codegen, KOREDefinition *d) {
   llvm::StringMap<llvm::Value *> finalSubst;
   ptr<KORECompositePattern> pat = KORECompositePattern::Create(symbol);
-  for (int i = 0; i < symbol->getArguments().size(); i++) {
+  for (size_t i = 0; i < symbol->getArguments().size(); i++) {
     auto cat = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[i].get())->getCategory(d);
     auto type = getParamType(cat, module);
 

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -39,6 +39,7 @@ static std::string str(token tok) {
   case token::STRING: return "<string>";
   case token::TOKEN_EOF: return "<EOF>";
   }
+  abort();
 }
 
 static struct {
@@ -310,7 +311,7 @@ ptr<KOREPattern> KOREParser::applicationPattern(std::string name) {
     consume(token::RIGHTPAREN);
     if (name == "\\left-assoc") {
       ptr<KOREPattern> accum = std::move(pats[0]);
-      for (int i = 1; i < pats.size(); i++) {
+      for (size_t i = 1; i < pats.size(); i++) {
         auto newAccum = KORECompositePattern::Create(pat->getConstructor());
         newAccum->addArgument(std::move(accum));
         newAccum->addArgument(std::move(pats[i]));
@@ -319,7 +320,7 @@ ptr<KOREPattern> KOREParser::applicationPattern(std::string name) {
       return accum;
     } else {
       ptr<KOREPattern> accum = std::move(pats[pats.size()-1]);
-      for (int i = pats.size() - 2; i >= 0; i--) {
+      for (size_t i = pats.size() - 2; i >= 0; i--) {
         auto newAccum = KORECompositePattern::Create(pat->getConstructor());
         newAccum->addArgument(std::move(pats[i]));
         newAccum->addArgument(std::move(accum));

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -51,25 +51,31 @@ void setKoreMemoryFunctionsForGMP() {
    mp_set_memory_functions(koreAllocMP, koreReallocMP, koreFree);
 }
 
-__attribute__ ((always_inline)) void* koreAlloc(size_t requested) {
+#ifdef __clang__
+#define ALWAYS_INLINE __attribute__ ((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+ALWAYS_INLINE void* koreAlloc(size_t requested) {
   return arenaAlloc(&youngspace, requested);
 }
 
-__attribute__ ((always_inline)) void* koreAllocToken(size_t requested) {
+ALWAYS_INLINE void* koreAllocToken(size_t requested) {
   size_t size = (requested + 7) & ~7;
   return arenaAlloc(&youngspace, size < 16 ? 16 : size);
 }
 
-__attribute__ ((always_inline)) void* koreAllocOld(size_t requested) {
+ALWAYS_INLINE void* koreAllocOld(size_t requested) {
   return arenaAlloc(&oldspace, requested);
 }
 
-__attribute__ ((always_inline)) void* koreAllocTokenOld(size_t requested) {
+ALWAYS_INLINE void* koreAllocTokenOld(size_t requested) {
   size_t size = (requested + 7) & ~7;
   return arenaAlloc(&oldspace, size < 16 ? 16 : size);
 }
 
-__attribute__ ((always_inline)) void* koreAllocAlwaysGC(size_t requested) {
+ALWAYS_INLINE void* koreAllocAlwaysGC(size_t requested) {
   return arenaAlloc(&alwaysgcspace, requested);
 }
 
@@ -106,25 +112,25 @@ void* koreReallocMP(void* ptr, size_t old_size, size_t new_size) {
 
 void koreFree(void* ptr, size_t size) {}
 
-__attribute__ ((always_inline)) void* koreAllocInteger(size_t requested) {
+ALWAYS_INLINE void* koreAllocInteger(size_t requested) {
   mpz_hdr *result = (mpz_hdr *) koreAlloc(sizeof(mpz_hdr));
   set_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
-__attribute__ ((always_inline)) void* koreAllocFloating(size_t requested) {
+ALWAYS_INLINE void* koreAllocFloating(size_t requested) {
   floating_hdr *result = (floating_hdr *) koreAlloc(sizeof(floating_hdr));
   set_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }
 
-__attribute__ ((always_inline)) void* koreAllocIntegerOld(size_t requested) {
+ALWAYS_INLINE void* koreAllocIntegerOld(size_t requested) {
   mpz_hdr *result = (mpz_hdr *) koreAllocOld(sizeof(mpz_hdr));
   set_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
-__attribute__ ((always_inline)) void* koreAllocFloatingOld(size_t requested) {
+ALWAYS_INLINE void* koreAllocFloatingOld(size_t requested) {
   floating_hdr *result = (floating_hdr *) koreAllocOld(sizeof(floating_hdr));
   set_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -22,7 +22,13 @@ const size_t BLOCK_SIZE = 1024 * 1024;
 #define mem_block_start(ptr) \
   ((char *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
 
-__attribute__ ((always_inline))
+#ifdef __clang__
+#define ALWAYS_INLINE __attribute__ ((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+ALWAYS_INLINE
 void arenaReset(struct arena *Arena) {
   char id = Arena->allocation_semispace_id;
   if (id < 0) {
@@ -36,17 +42,17 @@ void arenaReset(struct arena *Arena) {
   Arena->allocation_semispace_id = id;
 }
 
-__attribute__ ((always_inline))
+ALWAYS_INLINE
 char getArenaAllocationSemispaceID(const struct arena *Arena) {
   return Arena->allocation_semispace_id;
 }
 
-__attribute__ ((always_inline))
+ALWAYS_INLINE
 char getArenaCollectionSemispaceID(const struct arena *Arena) {
   return ~Arena->allocation_semispace_id;
 }
 
-__attribute__ ((always_inline)) char getArenaSemispaceIDOfObject(void *ptr) {
+ALWAYS_INLINE char getArenaSemispaceIDOfObject(void *ptr) {
   return mem_block_header(ptr)->semispace;
 }
 
@@ -124,7 +130,7 @@ void *doAllocSlow(size_t requested, struct arena *Arena) {
   }
 }
 
-__attribute__ ((always_inline))
+ALWAYS_INLINE
 void *arenaAlloc(struct arena *Arena, size_t requested) {
   if (Arena->block + requested > Arena->block_end) {
     return doAllocSlow(requested, Arena);
@@ -135,7 +141,7 @@ void *arenaAlloc(struct arena *Arena, size_t requested) {
   return result;
 }
 
-__attribute__ ((always_inline))
+ALWAYS_INLINE
 void *arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
   if (Arena->block + increase <= Arena->block_end) {
     Arena->block += increase;
@@ -144,7 +150,7 @@ void *arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
   return 0;
 }
 
-__attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
+ALWAYS_INLINE void arenaSwapAndClear(struct arena *Arena) {
   char *tmp = Arena->first_block;
   Arena->first_block = Arena->first_collection_block;
   Arena->first_collection_block = tmp;
@@ -152,17 +158,17 @@ __attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
   arenaClear(Arena);
 }
 
-__attribute__ ((always_inline)) void arenaClear(struct arena *Arena) {
+ALWAYS_INLINE void arenaClear(struct arena *Arena) {
   Arena->block = Arena->first_block ? Arena->first_block + sizeof(memory_block_header) : 0;
   Arena->block_start = Arena->first_block;
   Arena->block_end = Arena->first_block ? Arena->first_block + BLOCK_SIZE : 0;
 }
 
-__attribute__ ((always_inline)) char *arenaStartPtr(const struct arena *Arena) {
+ALWAYS_INLINE char *arenaStartPtr(const struct arena *Arena) {
   return Arena->first_block ? Arena->first_block + sizeof(memory_block_header) : 0;
 }
 
-__attribute__ ((always_inline)) char **arenaEndPtr(struct arena *Arena) {
+ALWAYS_INLINE char **arenaEndPtr(struct arena *Arena) {
   return &Arena->block;
 }
 

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -254,7 +254,7 @@ void extract(mpz_t result, mpz_t i, size_t off, size_t len) {
   }
   if (mpz_sgn(i) < 0) {
     mpn_com(result->_mp_d, result->_mp_d, size);
-    for (int j = 0; !carry && j < off_words && j < num_limbs; i++) {
+    for (size_t j = 0; !carry && j < off_words && j < num_limbs; i++) {
       carry = i->_mp_d[j];
     }
     if (!carry) {

--- a/runtime/collections/hash.cpp
+++ b/runtime/collections/hash.cpp
@@ -12,13 +12,20 @@ extern "C" {
   static constexpr uint32_t HASH_THRESHOLD = 5;
   static constexpr uint32_t HASH_LENGTH_THRESHOLD = 1024;
 
-  __attribute__((always_inline)) void add_hash8(void *h, uint8_t data) {
+
+#ifdef __clang__
+#define ALWAYS_INLINE __attribute__ ((always_inline))
+#else
+#define ALWAYS_INLINE
+#endif
+
+  ALWAYS_INLINE void add_hash8(void *h, uint8_t data) {
     size_t *hash = (size_t *)h;
     *hash = ((*hash) ^ ((size_t)data)) * 1099511628211UL;
     hash_length++;
   }
 
-  __attribute__((always_inline)) void add_hash64(void *h, uint64_t data) {
+  ALWAYS_INLINE void add_hash64(void *h, uint64_t data) {
     uint8_t *buf = (uint8_t *)&data;
     add_hash8(h, buf[0]);
     add_hash8(h, buf[1]);
@@ -30,7 +37,7 @@ extern "C" {
     add_hash8(h, buf[7]);
   }
 
-  __attribute__((always_inline)) void add_hash_str(void *h, char *data, size_t len) {
+  ALWAYS_INLINE void add_hash_str(void *h, char *data, size_t len) {
     if (len + hash_length > HASH_LENGTH_THRESHOLD) {
       len = HASH_LENGTH_THRESHOLD - hash_length;
     }

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -133,7 +133,7 @@ extern "C" {
     if (size2 < 32) {
       auto tmp = l1->transient();
 
-      for (int i = idx, j = 0; j < size2; ++i, ++j) {
+      for (size_t i = idx, j = 0; j < size2; ++i, ++j) {
         tmp.set(i, l2->at(j));
       }
 

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -8,7 +8,7 @@ extern "C" {
   }
 
   block *map_iterator_next(mapiter *iter) {
-    if (iter->curr == iter->map->end()) {
+    if (iter->curr == iter->m->end()) {
       return nullptr;
     }
     return (iter->curr++)->first;

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -8,7 +8,7 @@ extern "C" {
   }
 
   block *set_iterator_next(setiter *iter) {
-    if (iter->curr == iter->set->end()) {
+    if (iter->curr == iter->s->end()) {
       return nullptr;
     }
     return *(iter->curr++);

--- a/runtime/configurationparser/ConfigurationPrinter.cpp
+++ b/runtime/configurationparser/ConfigurationPrinter.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cstdarg>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -50,21 +51,21 @@ void sfprintf(writer *file, const char *fmt, ...) {
     char buf[8192];
     char *finalBuf = buf;
     int res = vsnprintf(buf + sizeof(blockheader), sizeof(buf) - sizeof(blockheader), fmt, args);
-    if (res >= sizeof(buf) - sizeof(blockheader)) {
+    if ((size_t)res >= sizeof(buf) - sizeof(blockheader)) {
       size_t size = sizeof(buf)*2;
       finalBuf = (char *)malloc(size);
       memcpy(finalBuf, buf, sizeof(buf));
       res = vsnprintf(finalBuf + sizeof(blockheader), size - sizeof(blockheader), fmt, args);
-      if (res >= size - sizeof(blockheader)) {
+      if ((size_t)res >= size - sizeof(blockheader)) {
         do {
           size *= 2;
-	  finalBuf = (char *)realloc(finalBuf, size);
-	  res = vsnprintf(finalBuf + sizeof(blockheader), size - sizeof(blockheader), fmt, args);
-	} while (res >= size - sizeof(blockheader));
+	      finalBuf = (char *)realloc(finalBuf, size);
+	      res = vsnprintf(finalBuf + sizeof(blockheader), size - sizeof(blockheader), fmt, args);
+	    } while ((size_t)res >= size - sizeof(blockheader));
       }
     }
     string *str = (string *)finalBuf;
-    set_len(str, res);
+    set_len(str, (size_t)res);
     hook_BUFFER_concat(file->buffer, str);
   }
 }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -119,7 +119,7 @@ extern "C" {
   static blockheader header_int() {
     static blockheader header = {(uint64_t)-1};
 
-    if (header.hdr == -1) {
+    if (header.hdr == (uint64_t)-1) {
       header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"));
     }
 
@@ -129,7 +129,7 @@ extern "C" {
   blockheader header_err() {
     static blockheader header = {(uint64_t)-1};
 
-    if (header.hdr == -1) {
+    if (header.hdr == (uint64_t)-1) {
       header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"));
     }
 
@@ -139,7 +139,7 @@ extern "C" {
   static blockheader header_string() {
     static blockheader header = {(uint64_t)-1};
 
-    if (header.hdr == -1) {
+    if (header.hdr == (uint64_t)-1) {
       header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortString{}, SortIOString{}}"));
     }
 
@@ -330,7 +330,7 @@ extern "C" {
     result = static_cast<string *>(koreResizeLastAlloc(result, sizeof(string) + bytes, sizeof(string) + length));
     block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
     retBlock->h = header_string();
-    set_len(result, bytes);
+    set_len(result, (size_t)bytes);
     memcpy(retBlock->children, &result, sizeof(string *));
     return retBlock;
   }

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -148,7 +148,7 @@ struct KoreHandler : BaseReaderHandler<UTF8<>, KoreHandler> {
 
   bool EndObject(SizeType memberCount) {
     result = dotList();
-    for (int i = 0; i < memberCount; i++) {
+    for (SizeType i = 0; i < memberCount; i++) {
       jsonmember *member = (jsonmember *)koreAlloc(sizeof(jsonmember));
       member->h = membHdr();
       member->val = stack.back();
@@ -172,7 +172,7 @@ struct KoreHandler : BaseReaderHandler<UTF8<>, KoreHandler> {
 
   bool EndArray(SizeType elementCount) {
     result = dotList();
-    for (int i = 0; i < elementCount; i++) {
+    for (SizeType i = 0; i < elementCount; i++) {
       jsonlist *list = (jsonlist *)koreAlloc(sizeof(jsonlist));
       list->h = listHdr();
       list->hd = stack.back();

--- a/runtime/json/json.cpp
+++ b/runtime/json/json.cpp
@@ -61,7 +61,7 @@ static blockheader kseqHeader = {getBlockHeaderForSymbol((uint64_t)getTagForSymb
 #define get_header(name, symbol) \
 static struct blockheader name() {\
   static struct blockheader hdr = {(uint64_t)-1}; \
-  if (hdr.hdr == -1) { \
+  if (hdr.hdr == (uint64_t)-1) { \
     hdr = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(symbol)); \
   } \
   return hdr; \
@@ -79,7 +79,7 @@ get_header(listWrapHdr, "LblJSONList{}")
 #define get_block(name, symbol) \
 static block *name() {\
   static uint64_t tag = (uint64_t)-1; \
-  if (tag == -1) { \
+  if (tag == (uint64_t)-1) { \
     tag = (uint64_t)leaf_block(getTagForSymbolName(symbol)); \
   } \
   return (block *)tag; \

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -20,7 +20,7 @@ extern "C" {
 
 #define TAG_TYPE(NAME) static uint64_t tag_type_##NAME() {\
   static uint64_t tag = -1; \
-  if (tag == -1) { \
+  if (tag == (uint64_t)-1) { \
     tag = (uint64_t)leaf_block(getTagForSymbolName(TYPETAG(NAME))); \
   } \
   return tag; \

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -60,10 +60,11 @@ extern "C" {
   TAG_TYPE(slong)
   TAG_TYPE(longdouble)
   TAG_TYPE(pointer)
+#ifdef FFI_TARGET_HAS_COMPLEX_TYPE
   TAG_TYPE(complexfloat)
   TAG_TYPE(complexdouble)
   TAG_TYPE(complexlongdouble)
-
+#endif
   mpz_ptr move_int(mpz_t);
   char * getTerminatedString(string * str);
 
@@ -130,12 +131,14 @@ extern "C" {
         return &ffi_type_longdouble;
       } else if (symbol == tag_type_pointer()) {
         return &ffi_type_pointer;
+#ifdef FFI_TARGET_HAS_COMPLEX_TYPE
       } else if (symbol == tag_type_complexfloat()) {
         return &ffi_type_complex_float;
       } else if (symbol == tag_type_complexdouble()) {
         return &ffi_type_complex_double;
       } else if (symbol == tag_type_complexlongdouble()) {
         return &ffi_type_complex_longdouble;
+#endif
       }
     } else if (tag_hdr(elem->h.hdr) == (uint64_t)getTagForSymbolName(TYPETAG(struct))){
       list * elements = (list *) *elem->children;
@@ -148,7 +151,7 @@ extern "C" {
       structType->type = FFI_TYPE_STRUCT;
       structType->elements = (ffi_type **) malloc(sizeof(ffi_type *) * (numFields + 1));
 
-      for (int j = 0; j < numFields; j++) {
+      for (size_t j = 0; j < numFields; j++) {
         structField = hook_LIST_get_long(elements, j);
 
         if (tag_hdr(structField->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
@@ -194,7 +197,7 @@ extern "C" {
     argtypes = (ffi_type **) malloc(sizeof(ffi_type *) * nargs);
 
     block * elem;
-    for (int i = 0; i < nfixtypes; i++) {
+    for (size_t i = 0; i < nfixtypes; i++) {
         elem = hook_LIST_get_long(fixtypes, i);
         if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
           throw std::invalid_argument("Fix types list contains invalid FFI type");
@@ -203,7 +206,7 @@ extern "C" {
         argtypes[i] = getTypeFromBlock((block *) *elem->children);
     }
 
-    for (int i = 0; i < nvartypes; i++) {
+    for (size_t i = 0; i < nvartypes; i++) {
         elem = hook_LIST_get_long(vartypes, i);
         if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
           throw std::invalid_argument("Var types list contains invalid FFI type");
@@ -213,7 +216,7 @@ extern "C" {
     }
 
     void ** avalues = (void **) malloc(sizeof(void *) * nargs);
-    for (int i = 0; i < nargs; i++) {
+    for (size_t i = 0; i < nargs; i++) {
         elem = hook_LIST_get_long(args, i);
         if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}")) {
           throw std::invalid_argument("Args list contains non-bytes type");

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -26,7 +26,7 @@ extern "C" {
   // constant value in the K term representation
   uint64_t tag_big_endian() {
     static uint64_t tag = (uint64_t)-1;
-    if (tag == -1) {
+    if (tag == (uint64_t)-1) {
       tag = (uint64_t)leaf_block(getTagForSymbolName("LblbigEndianBytes{}"));
     }
     return tag;
@@ -36,7 +36,7 @@ extern "C" {
   // constant value in the K term representation
   uint64_t tag_unsigned() {
     static uint64_t tag = (uint64_t)-1;
-    if (tag == -1) {
+    if (tag == (uint64_t)-1) {
       tag = (uint64_t)leaf_block(getTagForSymbolName("LblunsignedBytes{}"));
     }
     return tag;

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -112,7 +112,8 @@ extern "C" {
     }
     auto out = std::search(haystack->data + upos * sizeof(KCHAR), haystack->data + len(haystack) * sizeof(KCHAR),
         needle->data,   needle->data   + len(needle) * sizeof(KCHAR));
-    int64_t ret = (out - haystack->data) / sizeof(KCHAR);
+    assert(out >= haystack->data);
+    uint64_t ret = (out - haystack->data) / sizeof(KCHAR);
     // search returns the end of the range if it is not found, but we want -1 in such a case.
     auto res = (ret < len(haystack))?ret:-1;
     mpz_init_set_si(result, res);
@@ -129,7 +130,8 @@ extern "C" {
     auto end = (upos < len(haystack))?upos:len(haystack);
     auto out = std::find_end(&haystack->data[0], &haystack->data[end],
         &needle->data[0], &needle->data[len(needle)]);
-    auto ret = &*out - &haystack->data[0];
+    assert(&*out >= &haystack->data[0]);
+    uint64_t ret = &*out - &haystack->data[0];
     auto res = (ret < end)?ret:-1;
     mpz_init_set_si(result, res);
     return move_int(result);

--- a/unittests/runtime-arithmetic/floattest.cpp
+++ b/unittests/runtime-arithmetic/floattest.cpp
@@ -407,8 +407,8 @@ BOOST_AUTO_TEST_CASE(ne) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_ne(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
@@ -419,7 +419,7 @@ BOOST_AUTO_TEST_CASE(ne) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(hook_FLOAT_ne(arr+i, nan));
     BOOST_CHECK(hook_FLOAT_ne(nan, arr+i));
   }
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(abs) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
     floating *result = hook_FLOAT_abs(arr+i);
     float f = fabsf(ref[i]);
     if (f!=f) {
@@ -479,7 +479,7 @@ BOOST_AUTO_TEST_CASE(log) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
     floating *result = hook_FLOAT_log(arr+i);
     float f = logf(ref[i]);
     if (f!=f) {
@@ -511,7 +511,7 @@ BOOST_AUTO_TEST_CASE(exp) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
     floating *result = hook_FLOAT_exp(arr+i);
     float f = expf(ref[i]);
     if (f!=f) {
@@ -543,7 +543,7 @@ BOOST_AUTO_TEST_CASE(neg) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
     floating *result = hook_FLOAT_neg(arr+i);
     float f = -ref[i];
     if (f!=f) {
@@ -575,8 +575,8 @@ BOOST_AUTO_TEST_CASE(min) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_min(arr+i, arr+j);
       float f = fminf(ref[i], ref[j]);
       if (f!=f) {
@@ -609,8 +609,8 @@ BOOST_AUTO_TEST_CASE(max) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_max(arr+i, arr+j);
       float f = fmaxf(ref[i], ref[j]);
       if (f!=f) {
@@ -643,8 +643,8 @@ BOOST_AUTO_TEST_CASE(add) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_add(arr+i, arr+j);
       float f = ref[i] + ref[j];
       if (f!=f) {
@@ -677,8 +677,8 @@ BOOST_AUTO_TEST_CASE(sub) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_sub(arr+i, arr+j);
       float f = ref[i] - ref[j];
       if (f!=f) {
@@ -711,8 +711,8 @@ BOOST_AUTO_TEST_CASE(mul) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_mul(arr+i, arr+j);
       float f = ref[i] * ref[j];
       if (f!=f) {
@@ -745,8 +745,8 @@ BOOST_AUTO_TEST_CASE(div) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_div(arr+i, arr+j);
       float f = ref[i] / ref[j];
       if (f!=f) {
@@ -779,8 +779,8 @@ BOOST_AUTO_TEST_CASE(rem) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_rem(arr+i, arr+j);
       float f = fmodf(ref[i], ref[j]);
       if (f!=f) {
@@ -813,8 +813,8 @@ BOOST_AUTO_TEST_CASE(pow) {
   ref[6] = 3.0f;
   ref[7] = 0.5f;
   ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+    for (size_t j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
       floating *result = hook_FLOAT_pow(arr+i, arr+j);
       float f = powf(ref[i], ref[j]);
       if (f!=f) {
@@ -849,7 +849,7 @@ BOOST_AUTO_TEST_CASE(root) {
   ref[8] = 0.0f/0.0f;
   mpz_t k;
   mpz_init_set_ui(k, 2);
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
+  for (size_t i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
     floating *result = hook_FLOAT_root(arr+i, k);
     float f = sqrt(ref[i]);
     if (f!=f) {

--- a/unittests/runtime-arithmetic/floattest.cpp
+++ b/unittests/runtime-arithmetic/floattest.cpp
@@ -267,8 +267,8 @@ BOOST_AUTO_TEST_CASE(lt) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_lt(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(lt) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(!hook_FLOAT_lt(arr+i, nan));
     BOOST_CHECK(!hook_FLOAT_lt(nan, arr+i));
   }
@@ -295,8 +295,8 @@ BOOST_AUTO_TEST_CASE(le) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_le(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
@@ -307,7 +307,7 @@ BOOST_AUTO_TEST_CASE(le) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(!hook_FLOAT_le(arr+i, nan));
     BOOST_CHECK(!hook_FLOAT_le(nan, arr+i));
   }
@@ -323,8 +323,8 @@ BOOST_AUTO_TEST_CASE(gt) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_gt(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(gt) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(!hook_FLOAT_gt(arr+i, nan));
     BOOST_CHECK(!hook_FLOAT_gt(nan, arr+i));
   }
@@ -351,8 +351,8 @@ BOOST_AUTO_TEST_CASE(ge) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_ge(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(ge) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(!hook_FLOAT_ge(arr+i, nan));
     BOOST_CHECK(!hook_FLOAT_ge(nan, arr+i));
   }
@@ -379,8 +379,8 @@ BOOST_AUTO_TEST_CASE(eq) {
   set_float(arr+4, 24, 8, 1.0);
   set_float(arr+5, 24, 8, 1.0/0.0);
   set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+    for (size_t j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
       bool result = hook_FLOAT_eq(arr+i, arr+j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
@@ -391,7 +391,7 @@ BOOST_AUTO_TEST_CASE(eq) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
+  for (size_t i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
     BOOST_CHECK(!hook_FLOAT_eq(arr+i, nan));
     BOOST_CHECK(!hook_FLOAT_eq(nan, arr+i));
   }

--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -223,7 +223,8 @@ BOOST_AUTO_TEST_CASE(call) {
   list * structFields = static_cast<list *>(koreAlloc(sizeof(list)));
   list tmp = hook_LIST_element(argtype);
   tmp = hook_LIST_concat(&tmp, &tmp);
-  memcpy(structFields, &tmp, sizeof(list));
+  //TODO: explain why this is ok
+  memcpy((void *)structFields, &tmp, sizeof(list));
 
   memcpy(structType->children, &structFields, sizeof(list *));
 
@@ -305,7 +306,8 @@ BOOST_AUTO_TEST_CASE(call) {
 
   list * structFields2 = static_cast<list *>(koreAlloc(sizeof(list)));
   list tmp2 = hook_LIST_element(structArgType);
-  memcpy(structFields2, &tmp2, sizeof(list));
+  //TODO: explain why this is ok
+  memcpy((void *)structFields2, &tmp2, sizeof(list));
 
   memcpy(structType2->children, &structFields2, sizeof(list *));
   

--- a/unittests/runtime-strings/stringtest.cpp
+++ b/unittests/runtime-strings/stringtest.cpp
@@ -4,6 +4,7 @@
 #include<cstdint>
 #include<cstdlib>
 #include<cstring>
+#include<cmath>
 
 #include "runtime/header.h"
 #include "runtime/alloc.h"

--- a/unittests/runtime-strings/stringtest.cpp
+++ b/unittests/runtime-strings/stringtest.cpp
@@ -518,9 +518,9 @@ BOOST_AUTO_TEST_CASE(buffer_empty) {
 
 BOOST_AUTO_TEST_CASE(buffer_concat) {
   auto buf = hook_BUFFER_empty();
-  int totalLen = 0;
+  size_t totalLen = 0;
   for (int i = 0; i < 10000; i++) {
-    int len = rand() % 1000;
+    size_t len = rand() % 1000;
     totalLen += len;
     auto str = static_cast<string *>(malloc(sizeof(string) + len));
     set_len(str, len);


### PR DESCRIPTION
Most of the changes are straightforward. One tricky thing is the change of `hasTerminalAtIdx`, where we might have passed a negative value to it, but changed the parameter to `size_t`, which is unsigned. In that case, the old code:
```
  if (!hasTerminalAtIdx(terminals, terminalPos-1)) {
    result |= BARE_LEFT;
  }
```
would enter the if-block, which is what we must do in the new code:
```
  if (terminalPos == 0 || !hasTerminalAtIdx(terminals, terminalPos-1)) {
    result |= BARE_LEFT;
  }
```