### PR TITLE
fix bug involving garbage collection

### DIFF
--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -20,7 +20,7 @@ struct arena {
   static struct arena name = { 0, 0, 0, 0, 0, id }
 
 #define mem_block_start(ptr) \
-  ((char *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
+  ((char *)(((uintptr_t)(ptr) - 1) & ~(BLOCK_SIZE-1)))
 
 // Resets the given arena.
 void arenaReset(struct arena *);

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -19,6 +19,9 @@ struct arena {
 #define REGISTER_ARENA(name, id) \
   static struct arena name = { 0, 0, 0, 0, 0, id }
 
+#define mem_block_start(ptr) \
+  ((char *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
+
 // Resets the given arena.
 void arenaReset(struct arena *);
 

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -19,9 +19,6 @@ const size_t BLOCK_SIZE = 1024 * 1024;
 #define mem_block_header(ptr) \
   ((memory_block_header *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
 
-#define mem_block_start(ptr) \
-  ((char *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
-
 __attribute__ ((always_inline))
 void arenaReset(struct arena *Arena) {
   char id = Arena->allocation_semispace_id;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -290,7 +290,7 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
   if (collect_old || !previous_oldspace_alloc_ptr) {
     scan_ptr = oldspace_ptr();
   } else {
-    if (mem_block_start(previous_oldspace_alloc_ptr) == previous_oldspace_alloc_ptr) {
+    if (mem_block_start(previous_oldspace_alloc_ptr+1) == previous_oldspace_alloc_ptr) {
       // this means that the previous oldspace allocation pointer points to an
       // address that is megabyte-aligned. This can only happen if we have just
       // filled up a block but have not yet allocated the next block in the

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -290,7 +290,20 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
   if (collect_old || !previous_oldspace_alloc_ptr) {
     scan_ptr = oldspace_ptr();
   } else {
-    scan_ptr = previous_oldspace_alloc_ptr;
+    if (mem_block_start(previous_oldspace_alloc_ptr) == previous_oldspace_alloc_ptr) {
+      // this means that the previous oldspace allocation pointer points to an
+      // address that is megabyte-aligned. This can only happen if we have just
+      // filled up a block but have not yet allocated the next block in the
+      // sequence at the start of the collection cycle. This means that the
+      // allocation pointer is invalid and does not actually point to the next
+      // address that would have been allocated at, according to the logic of
+      // arenaAlloc, which will have allocated a fresh memory block and put
+      // the allocation at the start of it. Thus, we use movePtr with a size
+      // of zero to adjust and get the true address of the allocation.
+      scan_ptr = movePtr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
+    } else {
+      scan_ptr = previous_oldspace_alloc_ptr;
+    }
   }
   if (scan_ptr != *old_alloc_ptr()) {
     MEM_LOG("Evacuating old generation\n");


### PR DESCRIPTION
This commit fixes a bug that occurs when a young collection cycle starts
in between filling up an old generation memory block, and the allocation
of a fresh block in the oldspace.