### PR TITLE
workflows: Update Nix actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         submodules: recursive
-    - uses: cachix/install-nix-action@v11
-    - uses: cachix/cachix-action@v7
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v8
       with:
         name: runtimeverification
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/default.nix
+++ b/default.nix
@@ -11,7 +11,6 @@ let
   llvmPackages = pkgs.llvmPackages_10;
 
   llvm-backend = callPackage ./nix/llvm-backend.nix {
-    inherit (nix-gitignore) gitignoreSource;
     inherit llvmPackages;
   };
 

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -1,9 +1,11 @@
 {
-  lib, stdenv, gitignoreSource,
+  lib, stdenv, nix-gitignore,
   cmake, flex, pkgconfig,
   llvmPackages,
   boost, gmp, jemalloc, libffi, libyaml, mpfr,
 }:
+
+let inherit (nix-gitignore) gitignoreSourcePure; in
 
 let
   inherit (llvmPackages) llvm clang;
@@ -13,7 +15,22 @@ in
 
 stdenv.mkDerivation {
   inherit pname version;
-  src = gitignoreSource [ "/nix" "*.nix" "*.nix.sh" ] ../.;
+  src =
+    # Avoid spurious rebuilds by filtering some files that don't affect the
+    # build. Note: `gitignoreSourcePure` only takes a list of patterns in the
+    # gitignore format; it does not actually read `.gitignore` (it is
+    # "pure"). Reading `.gitignore` is a little slow, and the build usually
+    # happens in a clean checkout anyway. If the repository is dirty, run:
+    #
+    # > git clean -f -d -x
+    #
+    gitignoreSourcePure
+      [
+        "/nix" "*.nix" "*.nix.sh"
+        "/.github"
+        "/matching"
+      ]
+      ./..;
 
   nativeBuildInputs = [ cmake clang flex llvm pkgconfig ];
   buildInputs = [ boost gmp libffi libyaml jemalloc mpfr ];


### PR DESCRIPTION
Prior versions used deprecated GitHub Actions features which are now removed.