### PR TITLE
Allocation-heuristic based collection interval

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ install(
 file(COPY ${PROJECT_SOURCE_DIR}/deps/immer/immer DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include)
 file(COPY ${PROJECT_SOURCE_DIR}/deps/rapidjson/include/rapidjson DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/include)
 
-set(GC_INTERVAL 2000 CACHE STRING "Garbage collect every N steps")
+set(GC_THRESHOLD 2097152 CACHE STRING "Initial Young Generation Size")
 
 set(NOT_YOUNG_OBJECT_BIT 0x10000000000000)
 if(CMAKE_BUILD_TYPE STREQUAL "GcStats")

--- a/ciscript
+++ b/ciscript
@@ -11,7 +11,7 @@ fi
 rm -rf build
 mkdir -p build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=$1 -DCMAKE_INSTALL_PREFIX=install -DGC_INTERVAL=1
+cmake .. -DCMAKE_BUILD_TYPE=$1 -DCMAKE_INSTALL_PREFIX=install -DGC_THRESHOLD=1
 make -j`nproc`
 if [[ "$1" == "GcStats"* ]]; then
   make install

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -13,6 +13,7 @@ extern const size_t BLOCK_SIZE;
 
 char youngspace_collection_id(void);
 char oldspace_collection_id(void);
+size_t youngspace_size(void);
 
 // allocates exactly requested bytes into the young generation
 void* koreAlloc(size_t requested);

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -16,6 +16,12 @@ struct arena {
   char allocation_semispace_id;
 };
 
+typedef struct {
+  char* next_block;
+  char* next_superblock;
+  char semispace;
+} memory_block_header;
+
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
 #define REGISTER_ARENA(name, id) \

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -11,6 +11,8 @@ struct arena {
   char* block_start;
   char* block_end;
   char *first_collection_block;
+  size_t num_blocks;
+  size_t num_collection_blocks;
   char allocation_semispace_id;
 };
 

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -86,6 +86,9 @@ char *movePtr(char *, size_t, const char *);
 // Given two pointers to objects allocated in the same arena, return the number of bytes they are separated by within the virtual block of memory represented by the blocks of that arena. This difference will include blocks containing sentinel bytes. Undefined behavior will result if the pointers belong to different arenas.
 ssize_t ptrDiff(char *, char *);
 
+// return the total number of allocatable bytes currently in the arena in its active semispace.
+size_t arenaSize(const struct arena *);
+
 // Deallocates all the memory allocated for registered arenas.
 void freeAllMemory(void);
 

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -17,7 +17,7 @@ struct arena {
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
 #define REGISTER_ARENA(name, id) \
-  static struct arena name = { 0, 0, 0, 0, 0, id }
+  static struct arena name = { .allocation_semispace_id = id }
 
 #define mem_block_start(ptr) \
   ((char *)(((uintptr_t)(ptr) - 1) & ~(BLOCK_SIZE-1)))

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -577,6 +577,7 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(uns
 
   auto collection = getOrInsertFunction(module, "is_collection", llvm::FunctionType::get(llvm::Type::getInt1Ty(module->getContext()), {}, false));
   auto isCollection = llvm::CallInst::Create(collection, {}, "", checkCollect);
+  setDebugLoc(isCollection);
   auto collect = llvm::BasicBlock::Create(module->getContext(), "isCollect", block->getParent());
   auto merge = llvm::BasicBlock::Create(module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(collect, merge, isCollection, checkCollect);

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -43,6 +43,16 @@ size_t youngspace_size(void) {
   return arenaSize(&youngspace);
 }
 
+bool youngspaceAlmostFull(size_t threshold) {
+  char *nextBlock = *(char **)youngspace.block_start;
+  if (nextBlock) {
+    // not on the last block, so short circuit and assume that we can keep allocating for now.
+    return false;
+  }
+  ptrdiff_t freeBytes = youngspace.block_end - youngspace.block;
+  return freeBytes * 100 < threshold * 5;
+}
+
 void koreAllocSwap(bool swapOld) {
   arenaSwapAndClear(&youngspace);
   arenaClear(&alwaysgcspace);

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -39,6 +39,10 @@ char oldspace_collection_id() {
   return getArenaCollectionSemispaceID(&oldspace);
 }
 
+size_t youngspace_size(void) {
+  return arenaSize(&youngspace);
+}
+
 void koreAllocSwap(bool swapOld) {
   arenaSwapAndClear(&youngspace);
   arenaClear(&alwaysgcspace);

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -50,7 +50,8 @@ bool youngspaceAlmostFull(size_t threshold) {
     return false;
   }
   ptrdiff_t freeBytes = youngspace.block_end - youngspace.block;
-  return freeBytes * 100 < threshold * 5;
+  size_t totalBytes = youngspace.num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
+  return (totalBytes - freeBytes) * 100 > threshold * 95;
 }
 
 void koreAllocSwap(bool swapOld) {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -214,6 +214,10 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
   }
 }
 
+size_t arenaSize(const struct arena *Arena) {
+  return Arena->num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
+}
+
 void freeAllMemory() {
   memory_block_header *superblock = (memory_block_header *)first_superblock_ptr;
   while (superblock) {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -30,6 +30,8 @@ void arenaReset(struct arena *Arena) {
   Arena->block_start = 0;
   Arena->block_end = 0;
   Arena->first_collection_block = 0;
+  Arena->num_blocks = 0;
+  Arena->num_collection_blocks = 0;
   Arena->allocation_semispace_id = id;
 }
 
@@ -104,6 +106,7 @@ static void freshBlock(struct arena *Arena) {
     Arena->block = nextBlock + sizeof(memory_block_header);
     Arena->block_start = nextBlock;
     Arena->block_end = nextBlock + BLOCK_SIZE;
+    Arena->num_blocks++;
     MEM_LOG("New block at %p (remaining %zd)\n", Arena->block, BLOCK_SIZE - sizeof(memory_block_header));
 }
 
@@ -145,6 +148,9 @@ __attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
   char *tmp = Arena->first_block;
   Arena->first_block = Arena->first_collection_block;
   Arena->first_collection_block = tmp;
+  size_t tmp2 = Arena->num_blocks;
+  Arena->num_blocks = Arena->num_collection_blocks;
+  Arena->num_collection_blocks = tmp2;
   Arena->allocation_semispace_id = ~Arena->allocation_semispace_id;
   arenaClear(Arena);
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -215,7 +215,7 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
 }
 
 size_t arenaSize(const struct arena *Arena) {
-  return Arena->num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
+  return (Arena->num_blocks > Arena->num_collection_blocks ? Arena->num_blocks : Arena->num_collection_blocks) * (BLOCK_SIZE - sizeof(memory_block_header));
 }
 
 void freeAllMemory() {

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -85,6 +85,7 @@ static void freshBlock(struct arena *Arena) {
       memory_block_header *nextHeader = (memory_block_header *)nextBlock;
       nextHeader->next_block = 0;
       nextHeader->semispace = Arena->allocation_semispace_id;
+      Arena->num_blocks++;
     } else {
       nextBlock = *(char**)Arena->block_start;
       if (Arena->block != Arena->block_end) {
@@ -101,12 +102,12 @@ static void freshBlock(struct arena *Arena) {
         memory_block_header *nextHeader = (memory_block_header *)nextBlock;
         nextHeader->next_block = 0;
         nextHeader->semispace = Arena->allocation_semispace_id;
+        Arena->num_blocks++;
       }
     }
     Arena->block = nextBlock + sizeof(memory_block_header);
     Arena->block_start = nextBlock;
     Arena->block_end = nextBlock + BLOCK_SIZE;
-    Arena->num_blocks++;
     MEM_LOG("New block at %p (remaining %zd)\n", Arena->block, BLOCK_SIZE - sizeof(memory_block_header));
 }
 

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -8,12 +8,6 @@
 #include "runtime/header.h"
 #include "runtime/alloc.h"
  
-typedef struct {
-  char* next_block;
-  char* next_superblock;
-  char semispace;
-} memory_block_header;
-
 const size_t BLOCK_SIZE = 1024 * 1024;
 
 #define mem_block_header(ptr) \

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -17,7 +17,7 @@ typedef struct {
 const size_t BLOCK_SIZE = 1024 * 1024;
 
 #define mem_block_header(ptr) \
-  ((memory_block_header *)(((uintptr_t)(ptr)) & ~(BLOCK_SIZE-1)))
+  ((memory_block_header *)(((uintptr_t)(ptr) - 1) & ~(BLOCK_SIZE-1)))
 
 __attribute__ ((always_inline))
 void arenaReset(struct arena *Arena) {

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -25,6 +25,7 @@ static char *last_alloc_ptr;
 #endif
 
 size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
+void set_gc_threshold(size_t);
 
 bool during_gc() {
   return is_gc;
@@ -323,6 +324,7 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
 #endif
   MEM_LOG("Finishing garbage collection\n");
   is_gc = false;
+  set_gc_threshold(youngspace_size());
 }
 
 void freeAllKoreMem() {

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -26,6 +26,8 @@ static char *last_alloc_ptr;
 
 size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
 void set_gc_threshold(size_t);
+size_t get_gc_threshold(void);
+bool youngspaceAlmostFull(size_t);
 
 bool during_gc() {
   return is_gc;
@@ -329,6 +331,11 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
 
 void freeAllKoreMem() {
   koreCollect(nullptr, 0, nullptr);
+}
+
+bool is_collection() {
+  size_t threshold = get_gc_threshold();
+  return youngspaceAlmostFull(threshold);
 }
 
 }

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -5,9 +5,6 @@ target triple = "x86_64-unknown-linux-gnu"
 %block = type { %blockheader, [0 x i64 *] } ; 16-bit layout, 8-bit length, 32-bit tag, children
 
 declare fastcc %block* @step(%block*)
-declare i8* @youngspace_ptr()
-declare i8** @young_alloc_ptr()
-declare i1 @youngspaceAlmostFull(i64)
 
 @depth = thread_local global i64 zeroinitializer
 @steps = thread_local global i64 zeroinitializer
@@ -19,6 +16,11 @@ declare i1 @youngspaceAlmostFull(i64)
 define void @set_gc_threshold(i64 %threshold) {
   store i64 %threshold, i64* @GC_THRESHOLD
   ret void
+}
+
+define i64 @get_gc_threshold() {
+  %threshold = load i64, i64* @GC_THRESHOLD
+  ret i64 %threshold
 }
 
 define i1 @finished_rewriting() {
@@ -36,13 +38,6 @@ if:
   ret i1 %finished
 else:
   ret i1 false
-}
-
-define i1 @is_collection() {
-entry:
-  %threshold = load i64, i64* @GC_THRESHOLD
-  %collection = call i1 @youngspaceAlmostFull(i64 %threshold)
-  ret i1 %collection
 }
 
 define %block* @take_steps(i64 %depth, %block* %subject) {

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-unknown-linux-gnu"
 declare fastcc %block* @step(%block*)
 declare i8* @youngspace_ptr()
 declare i8** @young_alloc_ptr()
-declare i64 @ptrDiff(i8*, i8*)
+declare i1 @youngspaceAlmostFull(i64)
 
 @depth = thread_local global i64 zeroinitializer
 @steps = thread_local global i64 zeroinitializer
@@ -41,13 +41,7 @@ else:
 define i1 @is_collection() {
 entry:
   %threshold = load i64, i64* @GC_THRESHOLD
-  %youngspaceStart = call i8* @youngspace_ptr()
-  %youngspaceEndPtr = call i8** @young_alloc_ptr()
-  %youngspaceEnd = load i8*, i8** %youngspaceEndPtr
-  %youngspaceAllocatedBytes = call i64 @ptrDiff(i8* %youngspaceEnd, i8* %youngspaceStart)
-  %allocatedTimes100 = mul i64 %youngspaceAllocatedBytes, 100
-  %thresholdTimes95 = mul i64 %threshold, 95
-  %collection = icmp ugt i64 %allocatedTimes100, %thresholdTimes95
+  %collection = call i1 @youngspaceAlmostFull(i64 %threshold)
   ret i1 %collection
 }
 


### PR DESCRIPTION
What this does:

* removes the configurable "collect every N rewrite steps" parameter from the build system and the runtime API
* Tracks the total number of blocks allocated in the youngspace
* Collects after a rewrite step if the youngspace is almost full (ie, there is less than 1MB remaining and also the youngspace is over 95% the size it was after the last collection)
* adds a parameter that configures the initial size of the youngspace

The next steps are going to be to collect during an allocation if we don't have enough free space to allocate something, but this will require stack maps and so it has been deferred for a future PR.

I measured the code on the OpenZeppelin tests and they pass. They take about the same amount of time and use about the same amount of memory for most of the run, but the peak memory usage caps out at 11.7 GB instead of the >60GB required before this change.

I have also tested the code on the KEVM blockchain tests and they pass as well, so I am reasonably certain this doesn't introduce any regressions into the garbage collection process.