### PR TITLE
set NOT_YOUNG_OBJECT_BIT on ffi alloc'd Bytes

### DIFF
--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -369,6 +369,7 @@ extern "C" {
     }
     memset(ret, 0, sizeof(string *) + s);
     set_len(ret, s);
+    ret->h.hdr |= NOT_YOUNG_OBJECT_BIT;
 
     allocatedKItemPtrs[kitem] = ret;
     allocatedBytesRefs[ret] = kitem;


### PR DESCRIPTION
This fixes a regression found in the C semantics when building a version of K that includes the llvm backend commit e696645d5a50a7ad06d4fed392504bd50fe34ff4. What happens is that the Bytes object allocated by the FFI module isn't getting the bit set telling GC not to migrate the object, so it migrates the object, leading to corrupt memory when you try to read the bits via its original native address.