### PR TITLE
Fix various flaws in macro expander

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -235,7 +235,10 @@ struct HashSymbol {
 
 struct EqualSymbolPtr {
   bool operator()(KORESymbol * const & first, KORESymbol * const & second) const {
-    return *first == *second;
+    std::ostringstream Out1, Out2;
+    first->print(Out1);
+    second->print(Out2);
+    return Out1.str() == Out2.str();
   }
 };
 

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -360,7 +360,7 @@ public:
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
   virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
   virtual sptr<KOREPattern> filterSubstitution(PrettyPrintData const& data) override { return shared_from_this(); }
-  virtual bool matches(substitution &subst, SubsortMap const&, SymbolMap const&, sptr<KOREPattern> subject) override { subst[name->getName()] = subject; return true; }
+  virtual bool matches(substitution &subst, SubsortMap const&, SymbolMap const&, sptr<KOREPattern> subject) override;
   virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override;
 
 private:

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1003,10 +1003,10 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
         if (overloads.count(composite->getConstructor()) && overloads.at(composite->getConstructor()).count(getConstructor())) {
           sptr<KORECompositePattern> greater = KORECompositePattern::Create(getConstructor());
           for (int i = 0; i < arguments.size(); i++) {
-            if (*getConstructor()->getArguments()[i] != *subj->getConstructor()->getArguments()[i]) {
+            if (*getConstructor()->getArguments()[i] != *composite->getConstructor()->getArguments()[i]) {
               sptr<KORECompositePattern> inj = KORECompositePattern::Create("inj");
-              inj->getConstructor()->addFormalArgument(subj->getConstructor()->getArguments()[i]);
               inj->getConstructor()->addFormalArgument(composite->getConstructor()->getArguments()[i]);
+              inj->getConstructor()->addFormalArgument(getConstructor()->getArguments()[i]);
               inj->addArgument(composite->getArguments()[i]);
               greater->addArgument(inj);
             } else {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -960,6 +960,18 @@ sptr<KOREPattern> KORECompositePattern::expandMacros(SubsortMap const& subsorts,
   return result;
 }
 
+bool KOREVariablePattern::matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) {
+  if (subst[name->getName()]) {
+    std::ostringstream Out1, Out2;
+    subst[name->getName()]->print(Out1);
+    subject->print(Out2);
+    return Out1.str() == Out2.str();
+  } else {
+    subst[name->getName()] = subject;
+    return true;
+  }
+}
+
 bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) {
   auto subj = dynamic_cast<KORECompositePattern *>(subject.get());
   if (!subj) {

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -986,12 +986,14 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
         sptr<KORECompositePattern> ba = KORECompositePattern::Create("inj");
         ba->getConstructor()->addFormalArgument(b);
         ba->getConstructor()->addFormalArgument(a);
+        ba->getConstructor()->addArgument(b);
         ba->addArgument(arguments[0]);
         return ba->matches(subst, subsorts, overloads, subj->getArguments()[0]);
       } else if (subsorts.count(a.get()) && subsorts.at(a.get()).count(b.get())) {
         sptr<KORECompositePattern> ab = KORECompositePattern::Create("inj");
         ab->getConstructor()->addFormalArgument(a);
         ab->getConstructor()->addFormalArgument(b);
+        ab->getConstructor()->addArgument(a);
         ab->addArgument(subj->getArguments()[0]);
         return arguments[0]->matches(subst, subsorts, overloads, ab);
       } else {
@@ -1007,6 +1009,7 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
               sptr<KORECompositePattern> inj = KORECompositePattern::Create("inj");
               inj->getConstructor()->addFormalArgument(composite->getConstructor()->getArguments()[i]);
               inj->getConstructor()->addFormalArgument(getConstructor()->getArguments()[i]);
+              inj->getConstructor()->addArgument(composite->getConstructor()->getArguments()[i]);
               inj->addArgument(composite->getArguments()[i]);
               greater->addArgument(inj);
             } else {

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -27,8 +27,8 @@ int main (int argc, char **argv) {
     }
     if (axiom->getAttributes().count("overload")) {
       KORECompositePattern *att = axiom->getAttributes().at("overload").get();
-      KORESymbol *innerSymbol = att->getConstructor();
-      KORESymbol *outerSymbol = att->getConstructor();
+      KORESymbol *innerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())->getConstructor();
+      KORESymbol *outerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())->getConstructor();
       overloads[innerSymbol].insert(outerSymbol);
     }
   }

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -38,6 +38,13 @@ int main (int argc, char **argv) {
 
   KOREParser parser2(argv[1] + std::string("/macros.kore"));
   std::vector<ptr<KOREDeclaration>> axioms = parser2.declarations();
+  std::sort(axioms.begin(), axioms.end(), [](const ptr<KOREDeclaration> &l, const ptr<KOREDeclaration> &r) {
+      std::string lStr = l->getStringAttribute("priority");
+      std::string rStr = r->getStringAttribute("priority");
+      int lInt = std::stoi(lStr);
+      int rInt = std::stoi(rStr);
+      return lInt < rInt;
+  });
 
   KOREParser parser3(argv[2]);
   sptr<KOREPattern> config = parser3.pattern();

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -196,8 +196,8 @@ int main (int argc, char **argv) {
     }
     if (axiom->getAttributes().count("overload")) {
       KORECompositePattern *att = axiom->getAttributes().at("overload").get();
-      KORESymbol *innerSymbol = att->getConstructor();
-      KORESymbol *outerSymbol = att->getConstructor();
+      KORESymbol *innerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())->getConstructor();
+      KORESymbol *outerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())->getConstructor();
       overloads[innerSymbol].insert(outerSymbol);
     }
   }


### PR DESCRIPTION
* Adds support for priority and owise attributes
* Fixes a bug involving nonlinear patterns
* Fixes a bug in how macros are recursively applied
* Fixes bugs involving macro matching modulo overloads