### PR TITLE
Exclude unit tests from default CMake target

### DIFF
--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -39,6 +39,7 @@ stdenv.mkDerivation {
     ''-DCMAKE_C_COMPILER=${lib.getBin stdenv.cc}/bin/cc''
     ''-DCMAKE_CXX_COMPILER=${lib.getBin stdenv.cc}/bin/c++''
     ''-DUSE_NIX=TRUE''
+    ''-DCMAKE_SKIP_BUILD_RPATH=FALSE''
   ];
 
   cmakeBuildType = "FastBuild";
@@ -49,11 +50,12 @@ stdenv.mkDerivation {
   checkPhase = ''
     runHook preCheck
 
-    # Find local test libraries. Nixpkgs' linker script filters paths outside
-    # the Nix store, so the build-local libraries are not linked.
     (
-        export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH:+:}"'$ORIGIN/lib'
-        make run-unittests
+      # Allow linking to paths outside the Nix store.
+      # Primarily, this allows linking to paths in the build tree.
+      # The setting is only applied to the unit tests, which are not installed.
+      export NIX_ENFORCE_PURITY=0
+      make run-unittests
     )
 
     runHook postCheck

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -5,6 +5,9 @@ macro(add_kllvm_unittest test_name)
   # add target for building the test
   kllvm_add_tool(${test_name} ${ARGN})
 
+  # exclude unit tests from the default target
+  set_target_properties(${test_name} PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
   # add a dependency to the global unit test build target
   add_dependencies(unittests ${test_name})
 

--- a/unittests/runtime-ffi/CMakeLists.txt
+++ b/unittests/runtime-ffi/CMakeLists.txt
@@ -4,6 +4,7 @@ add_kllvm_unittest(runtime-ffi-tests
   ffi.cpp
   main.cpp
 )
+add_dependencies(runtime-ffi-tests ffitest)
 
 link_directories(../unittests/runtime-ffi/lib)
 

--- a/unittests/runtime-ffi/lib/CMakeLists.txt
+++ b/unittests/runtime-ffi/lib/CMakeLists.txt
@@ -2,8 +2,3 @@ add_library(ffitest SHARED
   foreign.cpp
 )
 set_target_properties(ffitest PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-set(LIB_FFITEST_DEST "../unittests/runtime-ffi/lib")
-
-install(TARGETS ffitest
-  LIBRARY DESTINATION ${LIB_FFITEST_DEST})

--- a/unittests/runtime-ffi/lib/CMakeLists.txt
+++ b/unittests/runtime-ffi/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ffitest SHARED
   foreign.cpp
 )
+set_target_properties(ffitest PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 set(LIB_FFITEST_DEST "../unittests/runtime-ffi/lib")
 

--- a/unittests/runtime-io/CMakeLists.txt
+++ b/unittests/runtime-io/CMakeLists.txt
@@ -22,3 +22,5 @@ target_link_libraries(runtime-io-tests
 endif()
 
 add_executable(IOTest iotest.cpp)
+set_target_properties(IOTest PROPERTIES EXCLUDE_FROM_ALL TRUE)
+add_dependencies(runtime-io-tests IOTest)


### PR DESCRIPTION
This pull request would exclude the unit tests from the default CMake target. The targets will now be:

- `make`: (default) build the LLVM backend
- `make unittests`: build the unit tests
- `make run-unittests`: (depends on `unittests`) build and run the unit tests