### PR TITLE
Fix stack overflow when destructing the parsed KORE

### DIFF
--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -377,6 +377,9 @@ private:
   : name(std::move(Name)), sort(Sort) { }
 };
 
+class KOREPattern;
+void deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
+
 class KORECompositePattern : public KOREPattern {
 private:
   ptr<KORESymbol> constructor;
@@ -415,6 +418,8 @@ public:
 
 private:
   virtual sptr<KOREPattern> expandMacros(SubsortMap const&, SymbolMap const&, std::vector<ptr<KOREDeclaration>> const& macros, bool reverse, std::set<size_t> &appliedRules) override;
+
+  friend void ::kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
 
 private:
   KORECompositePattern(ptr<KORESymbol> Constructor)

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1658,3 +1658,23 @@ void kllvm::readMultimap(std::string name, KORESymbolDeclaration *decl, std::map
     }
   }
 }
+
+// Normally, destruction of KOREPattern would call destructor
+// of all its subpatterns. This can sometimes exhaust all the stack space.
+// This function deallocates a pattern iteratively, without recursion.
+void kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern) {
+    std::vector<sptr<KOREPattern>> vec;
+    vec.push_back(std::move(pattern));
+    while(!vec.empty()) {
+        sptr<KOREPattern> curr = std::move(vec.back());
+        vec.pop_back();
+        if (auto composite = std::dynamic_pointer_cast<KORECompositePattern>(curr)) {
+            vec.reserve(vec.size() + composite->arguments.size());
+            // move all the arguments to vec
+            while(!composite->arguments.empty()) {
+                vec.push_back(std::move(composite->arguments.back()));
+                composite->arguments.pop_back();
+            }
+        }
+    }
+}

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1669,12 +1669,7 @@ void kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern) {
         sptr<KOREPattern> curr = std::move(vec.back());
         vec.pop_back();
         if (auto composite = std::dynamic_pointer_cast<KORECompositePattern>(curr)) {
-            vec.reserve(vec.size() + composite->arguments.size());
-            // move all the arguments to vec
-            while(!composite->arguments.empty()) {
-                vec.push_back(std::move(composite->arguments.back()));
-                composite->arguments.pop_back();
-            }
+            vec.insert(vec.end(), std::make_move_iterator(composite->arguments.begin()), std::make_move_iterator(composite->arguments.end()));
         }
     }
 }

--- a/runtime/configurationparser/ConfigurationParser.cpp
+++ b/runtime/configurationparser/ConfigurationParser.cpp
@@ -110,5 +110,7 @@ block *parseConfiguration(const char *filename) {
   //InitialConfiguration->print(std::cout);
 
   // Allocate the llvm KORE datastructures for the configuration
-  return (block *) constructInitialConfiguration(InitialConfiguration.get());
+  auto b = (block *) constructInitialConfiguration(InitialConfiguration.get());
+  deallocateSPtrKorePattern(std::move(InitialConfiguration));
+  return b;
 }


### PR DESCRIPTION
When executing one cFS OSAL test case with the new c-semantics, the default destructor of `KOREPattern` was causing a stack overflow right after the translated program in KORE was parsed. I propose an alternative destruction scheme for `KOREPattern` - one which does not do recursive calls and thus does not overflow.

This was tested only with the c-semantics. @dwightguth do you have any idea how and where to write a test case for parsing which would be a part of this repository?