### PR TITLE
fix bug in LLVMKompile2.cmake

### DIFF
--- a/cmake/LLVMKompile2.cmake
+++ b/cmake/LLVMKompile2.cmake
@@ -20,6 +20,7 @@ add_custom_command(
 add_custom_target(definition
 	DEPENDS "${KOMPILED_DIR}/definition.o")
 add_dependencies(${TARGET_NAME} definition)
+set_target_properties(${TARGET_NAME} PROPERTIES LINK_DEPENDS "${KOMPILED_DIR}/definition.o")
 
 target_compile_options(${TARGET_NAME}
 	PUBLIC -Wno-return-type-c-linkage)


### PR DESCRIPTION
This fixes an issue reported by @malturki where if you are using LLVMKompile2.cmake to build your interpreter, and you modify a .k file and nothing else, it doesn't rerun the linking step, leading to an out of date interpreter even though make thinks everything is up to date.