### PR TITLE
Fix no config vars crash

### DIFF
--- a/bin/llvm-krun
+++ b/bin/llvm-krun
@@ -188,9 +188,11 @@ Lbl'Unds'Map'Unds'{}(
 HERE
 done
 
-cat <<HERE >> $input_file
+if [ ${#params[@]} -ne 0 ]; then
+  cat <<HERE >> $input_file
 Lbl'Stop'Map{}()
 HERE
+fi
 
 for param in "${params[@]}"; do
   cat <<HERE >> $input_file


### PR DESCRIPTION
Part 1 in fixing: https://github.com/kframework/k/issues/1844

Don't print the map stop if there are no config vars
I ran the `regression-new` tests on my machine and they still pass, and the reported issue disappeared.
Added proper tests in https://github.com/kframework/k/pull/1853