### PR TITLE
Nix: Find clang at runtime automatically

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -55,6 +55,7 @@ let
   llvm-backend = callPackage ./nix/llvm-backend.nix {
     inherit llvmPackages src;
     inherit (ttuegel) cleanSourceWith;
+    host.clang = clang;
   };
 
   mavenix = import sources."mavenix" { inherit pkgs; };
@@ -78,8 +79,9 @@ let
     '';
 
   self = {
-    inherit clang llvm-backend llvm-backend-matching llvm-kompile-testing;
-    inherit mavenix;
+    inherit llvm-backend llvm-backend-matching llvm-kompile-testing;
+    inherit clang; # for compatibility
+    inherit mavenix; # for CI
   };
 
 in self

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -3,6 +3,8 @@
   cmake, flex, pkgconfig,
   llvmPackages,
   boost, gmp, jemalloc, libffi, libiconv, libyaml, mpfr,
+  # Runtime dependencies:
+  host,
 }:
 
 let inherit (llvmPackages) stdenv llvm; in
@@ -19,7 +21,7 @@ stdenv.mkDerivation {
     cleanSourceWith {
       name = "llvm-backend-src";
       inherit src;
-      ignore = 
+      ignore =
         [
           "/nix" "*.nix" "*.nix.sh"
           "/.github"
@@ -58,4 +60,8 @@ stdenv.mkDerivation {
 
     runHook postCheck
   '';
+
+  passthru = {
+    inherit (host) clang;
+  };
 }

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -35,6 +35,11 @@ stdenv.mkDerivation {
     [ gmp jemalloc libffi mpfr ]
     ++ lib.optional stdenv.isDarwin libiconv;
 
+  postPatch = ''
+    sed -i bin/llvm-kompile \
+      -e '2a export PATH="${lib.getBin host.clang}/bin:''${PATH}"'
+  '';
+
   cmakeFlags = [
     ''-DCMAKE_C_COMPILER=${lib.getBin stdenv.cc}/bin/cc''
     ''-DCMAKE_CXX_COMPILER=${lib.getBin stdenv.cc}/bin/c++''

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -2,7 +2,7 @@
   lib, cleanSourceWith, src,
   cmake, flex, pkgconfig,
   llvmPackages,
-  boost, gmp, jemalloc, libffi, libiconv, libyaml, mpfr,
+  boost, gmp, jemalloc, libffi, libiconv, libyaml, mpfr, ncurses,
   # Runtime dependencies:
   host,
 }:
@@ -32,7 +32,7 @@ stdenv.mkDerivation {
   nativeBuildInputs = [ cmake flex llvm pkgconfig ];
   buildInputs = [ boost libyaml ];
   propagatedBuildInputs =
-    [ gmp jemalloc libffi mpfr ]
+    [ gmp jemalloc libffi mpfr ncurses ]
     ++ lib.optional stdenv.isDarwin libiconv;
 
   postPatch = ''

--- a/test.nix
+++ b/test.nix
@@ -19,8 +19,9 @@ stdenv.mkDerivation {
   src = llvm-backend.src;
   preferLocalBuild = true;
   buildInputs = [
-    diffutils
-    llvm-backend llvm-kompile-testing
+    diffutils  # for golden testing
+    llvm-kompile-testing  # for constructing test input without the frontend
+    llvm-backend  # the system under test
   ];
   configurePhase = "true";
   buildPhase = ''

--- a/test.nix
+++ b/test.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
   preferLocalBuild = true;
   buildInputs = [
     diffutils ncurses
-    clang llvm-backend llvm-kompile-testing
+    llvm-backend llvm-kompile-testing
   ];
   configurePhase = "true";
   buildPhase = ''

--- a/test.nix
+++ b/test.nix
@@ -7,7 +7,7 @@ in
 
 let
   inherit (pkgs) stdenv;
-  inherit (pkgs) diffutils ncurses;
+  inherit (pkgs) diffutils;
 
   default = import ./. { inherit pkgs; };
   inherit (default) llvm-backend llvm-kompile-testing;
@@ -19,7 +19,7 @@ stdenv.mkDerivation {
   src = llvm-backend.src;
   preferLocalBuild = true;
   buildInputs = [
-    diffutils ncurses
+    diffutils
     llvm-backend llvm-kompile-testing
   ];
   configurePhase = "true";

--- a/test.nix
+++ b/test.nix
@@ -7,10 +7,10 @@ in
 
 let
   inherit (pkgs) stdenv;
-  inherit (pkgs) diffutils ncurses gmp mpfr libffi jemalloc;
+  inherit (pkgs) diffutils ncurses;
 
   default = import ./. { inherit pkgs; };
-  inherit (default) clang llvm-backend llvm-backend-matching llvm-kompile-testing;
+  inherit (default) llvm-backend llvm-kompile-testing;
 
 in
 


### PR DESCRIPTION
This pull request patches `llvm-kompile-clang` during the Nix build so that it finds the right compiler at runtime without help from the user.