### PR TITLE
add ifdef guard for sret change

### DIFF
--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -740,7 +740,11 @@ llvm::Value *CreateTerm::createFunctionCall(std::string name, ValueType returnCa
     call->setCallingConv(llvm::CallingConv::Fast);
   }
   if (sret) {
+#if __clang_major__ >= 12
     llvm::Attribute sretAttr = llvm::Attribute::get(Ctx, llvm::Attribute::StructRet, sretType);
+#else
+    llvm::Attribute sretAttr = llvm::Attribute::get(Ctx, llvm::Attribute::StructRet);
+#endif
     func->arg_begin()->addAttr(sretAttr);
     call->addParamAttr(0, sretAttr);
     return AllocSret;

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -325,7 +325,11 @@ void MakeIteratorNode::codegen(Decision *d) {
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
   auto call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
   setDebugLoc(call);
+#if __clang_major__ >= 12
   llvm::Attribute sretAttr = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet, sretType);
+#else
+  llvm::Attribute sretAttr = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet);
+#endif
   func->arg_begin()->addAttr(sretAttr);
   call->addParamAttr(0, sretAttr);
   d->store(std::make_pair(name, type), AllocSret);


### PR DESCRIPTION
This fixes a regression where the llvm backend would not build on older versions of LLVM. Since Debian Buster is still the latest Debian Stable and buster-backports only has llvm 8 as its newest version of llvm, we still want to support llvm 8 for the time being. Hence, this change.