### PR TITLE
Parser: update rules to reflect KORE syntax change for ensures

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1159,6 +1159,12 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
               return andPattern2->getArguments()[1].get();
             }
           }
+        } else if (andPattern->getConstructor()->getName() == "\\equals" && andPattern->getArguments().size() == 2) {
+          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
+            if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
+              return andPattern2->getArguments()[0].get();
+            }
+          }
         }
       }
     } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {

--- a/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
+++ b/matching/src/main/scala/org/kframework/backend/llvm/matching/Parser.scala
@@ -174,6 +174,10 @@ object Parser {
       case Implies(_, And(_, Equals(_, _, pat, _), args), And(_, Equals(i, o, Application(symbol, _), rhs), _)) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), Some(pat))
       case Implies(_, And(_, Not(_, _), And(_, Top(_), args)), And(_, Equals(i, o, Application(symbol, _), rhs), _)) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), None)
       case Implies(_, And(_, Not(_, _), And(_, Equals(_, _, pat, _), args)), And(_, Equals(i, o, Application(symbol, _), rhs), _)) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), Some(pat))
+      case Implies(_, And(_, Top(_), And (_, Equals(_, _, pat, _), args)), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), Some(pat))
+      case Implies(_, And(_, Not(_, _), And (_, Equals(_, _, pat, _), args)), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), Some(pat))
+      case Implies(_, And(_, Not(_, _), And (_, Top(_), args)), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), None)
+      case Implies(_, And(_, Top(_), args), Equals(i, o, Application(symbol, _), And(_, rhs, _))) => Some(Some(symbol), B.Equals(i, o, B.Application(symbol, getPatterns(args)), rhs), None)
       case eq @ Equals(_, _, Application(symbol, _), _) => Some(Some(symbol), eq, None)
       case _ => None
     }

--- a/test/defn/imp.kore
+++ b/test/defn/imp.kore
@@ -1,63 +1,66 @@
-[topCellInitializer{}(LblinitGeneratedTopCell{}())]
+[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)")]
 
 module BASIC-K
-  sort SortK{} []
-  sort SortKItem{} []
-endmodule []
-
+    sort SortK{} []
+    sort SortKItem{} []
+endmodule
+[]
 module KSEQ
-  import BASIC-K []
-
-  // TODO: Provide constructor and functional axioms for `kseq` and `dotk`.
-  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(),functional{}()]
-  symbol dotk{}() : SortK{} [constructor{}(),functional{}()]
-
-  symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
-
-  axiom{R}
-    \equals{SortK{},R}(
-      append{}(dotk{}(),K2:SortK{}),
-      K2:SortK{})
-  []
-
-  axiom{R}
-    \equals{SortK{},R}(
-      append{}(kseq{}(K1:SortKItem{},K2:SortK{}),K3:SortK{}),
-      kseq{}(K1:SortKItem{},append{}(K2:SortK{},K3:SortK{})))
-  []
-
-endmodule []
-
+    import BASIC-K []
+    symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}(), functional{}()]
+    symbol dotk{}() : SortK{} [constructor{}(), functional{}()]
+    symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, dotk{}()),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \and{R}(
+            \equals{SortK{}, R}(
+                append{}(X0:SortK{}, X1:SortK{}),
+                TAIL:SortK{}
+            ),
+            \top{R}()
+        )
+    ) []
+    axiom {R} \implies{R}(
+        \and{R}(
+            \top{R}(),
+            \and{R}(
+                \in{SortK{}, R}(X0:SortK{}, kseq{}(K:SortKItem{}, KS:SortK{})),
+            \and{R}(
+                \in{SortK{}, R}(X1:SortK{}, TAIL:SortK{}),
+                \top{R}()
+            ))
+        ),
+        \and{R}(
+            \equals{SortK{}, R}(
+                append{}(X0:SortK{}, X1:SortK{}),
+                kseq{}(K:SortKItem{}, append{}(KS:SortK{}, TAIL:SortK{}))
+            ),
+            \top{R}()
+        )
+    ) []
+endmodule
+[]
 module INJ
-  symbol inj{From,To}(From) : To [sortInjection{}()]
-
-  axiom{S1,S2,S3,R}
-    \equals{S3,R}(
-      inj{S2,S3}(inj{S1,S2}(T:S1)),
-      inj{S1,S3}(T:S1))
-  []
-
-endmodule []
-
+    symbol inj{From, To}(From) : To [sortInjection{}()]
+    axiom {S1, S2, S3, R} \equals{S3, R}(inj{S2, S3}(inj{S1, S2}(T:S1)), inj{S1, S3}(T:S1)) [simplification{}()]
+endmodule
+[]
 module K
-  import KSEQ []
-  import INJ []
-
-  // Defnitions for reachability aliases
-  // Until we will have `mu` we resort to dummy definitions
-  alias weakExistsFinally{A}(A) : A
-  where weakExistsFinally{A}(@X:A) := @X:A []
-
-  alias weakAlwaysFinally{A}(A) : A
-  where weakAlwaysFinally{A}(@X:A) := @X:A []
-
-  // Definitions for CTL aliases
-  // Until we will have `mu` we resort to dummy definitions
-  alias allPathGlobally{A}(A) : A
-  where allPathGlobally{A}(@X:A) := @X:A []
-
-endmodule []
-
+    import KSEQ []
+    import INJ []
+    alias weakExistsFinally{A}(A) : A where weakExistsFinally{A}(@X:A) := @X:A []
+    alias weakAlwaysFinally{A}(A) : A where weakAlwaysFinally{A}(@X:A) := @X:A []
+    alias allPathGlobally{A}(A) : A where allPathGlobally{A}(@X:A) := @X:A []
+endmodule
+[]
 module IMP
 
 // imports
@@ -70,108 +73,107 @@ module IMP
   sort SortIOInt{} []
   sort SortGeneratedTopCellFragment{} []
   sort SortIOFile{} []
-  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(251,3,251,31)")]
+  hooked-sort SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblListItem{}()), concat{}(Lbl'Unds'List'Unds'{}()), unit{}(Lbl'Stop'List{}()), hook{}("LIST.List"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(631,3,631,31)")]
   sort SortKCell{} []
   sort SortGeneratedTopCell{} []
   sort SortStateCell{} []
   sort SortGeneratedCounterCell{} []
-  hooked-sort SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(525,3,525,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), hook{}("FLOAT.Float"), hasDomainValues{}()]
+  hooked-sort SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1160,3,1160,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), hook{}("FLOAT.Float"), hasDomainValues{}()]
   sort SortTCellOpt{} []
   sort SortAExp{} []
-  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(99,3,99,28)")]
-  hooked-sort SortString{} [hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(605,3,605,37)"), hasDomainValues{}()]
+  hooked-sort SortMap{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), concat{}(Lbl'Unds'Map'Unds'{}()), unit{}(Lbl'Stop'Map{}()), hook{}("MAP.Map"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(227,3,227,28)")]
+  hooked-sort SortString{} [hook{}("STRING.String"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1370,3,1370,37)"), hasDomainValues{}()]
   sort SortIOString{} []
-  sort SortId{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(894,3,894,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), token{}(), hasDomainValues{}()]
+  sort SortId{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), token{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1997,3,1997,19)"), hasDomainValues{}()]
   sort SortBlock{} []
   sort SortGeneratedCounterCellOpt{} []
-  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/kast.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(12,3,12,27)"), token{}(), hasDomainValues{}()]
+  sort SortKConfigVar{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/kast.md)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(40,3,40,27)"), token{}(), hasDomainValues{}()]
   sort SortBExp{} []
-  hooked-sort SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(381,3,381,28)"), hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), hasDomainValues{}()]
+  hooked-sort SortInt{} [hook{}("INT.Int"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(888,3,888,28)"), hasDomainValues{}()]
   sort SortStateCellOpt{} []
   sort SortIOError{} []
-  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(213,3,213,28)")]
+  hooked-sort SortSet{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), concat{}(Lbl'Unds'Set'Unds'{}()), unit{}(Lbl'Stop'Set{}()), hook{}("SET.Set"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(506,3,506,28)")]
   sort SortPgm{} []
   sort SortKResult{} []
   sort SortStream{} []
-  sort SortCell{} []
   sort SortTCell{} []
   sort SortStmt{} []
-  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(325,3,325,31)"), hasDomainValues{}()]
+  hooked-sort SortBool{} [hook{}("BOOL.Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(786,3,786,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), hasDomainValues{}()]
 
 // symbols
-  symbol Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(SortBExp{}) : SortBExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), right{}(), terminals{}("10"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), left{}(), format{}("%c!%r %1"), colors{}("pink"), injective{}()]
-  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#E2BIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1004,22,1004,54)"), left{}(), format{}("%c#E2BIG%r"), injective{}()]
-  symbol Lbl'Hash'EACCES{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EACCES"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1005,22,1005,56)"), left{}(), format{}("%c#EACCES%r"), injective{}()]
-  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRINUSE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1054,22,1054,64)"), left{}(), format{}("%c#EADDRINUSE%r"), injective{}()]
-  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRNOTAVAIL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1055,22,1055,70)"), left{}(), format{}("%c#EADDRNOTAVAIL%r"), injective{}()]
-  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1053,22,1053,68)"), left{}(), format{}("%c#EAFNOSUPPORT%r"), injective{}()]
-  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAGAIN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1006,22,1006,56)"), left{}(), format{}("%c#EAGAIN%r"), injective{}()]
-  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EALREADY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1043,22,1043,60)"), left{}(), format{}("%c#EALREADY%r"), injective{}()]
-  symbol Lbl'Hash'EBADF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBADF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1007,22,1007,54)"), left{}(), format{}("%c#EBADF%r"), injective{}()]
-  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBUSY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1008,22,1008,54)"), left{}(), format{}("%c#EBUSY%r"), injective{}()]
-  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECHILD"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1009,22,1009,56)"), left{}(), format{}("%c#ECHILD%r"), injective{}()]
-  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNABORTED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1059,22,1059,68)"), left{}(), format{}("%c#ECONNABORTED%r"), injective{}()]
-  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNREFUSED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1067,22,1067,68)"), left{}(), format{}("%c#ECONNREFUSED%r"), injective{}()]
-  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1060,22,1060,64)"), left{}(), format{}("%c#ECONNRESET%r"), injective{}()]
-  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDEADLK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1010,22,1010,58)"), left{}(), format{}("%c#EDEADLK%r"), injective{}()]
-  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDESTADDRREQ"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1045,22,1045,68)"), left{}(), format{}("%c#EDESTADDRREQ%r"), injective{}()]
-  symbol Lbl'Hash'EDOM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDOM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1011,22,1011,52)"), left{}(), format{}("%c#EDOM%r"), injective{}()]
-  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EEXIST"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1012,22,1012,56)"), left{}(), format{}("%c#EEXIST%r"), injective{}()]
-  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFAULT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1013,22,1013,56)"), left{}(), format{}("%c#EFAULT%r"), injective{}()]
-  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFBIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1014,22,1014,54)"), left{}(), format{}("%c#EFBIG%r"), injective{}()]
-  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1068,22,1068,62)"), left{}(), format{}("%c#EHOSTDOWN%r"), injective{}()]
-  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1069,22,1069,68)"), left{}(), format{}("%c#EHOSTUNREACH%r"), injective{}()]
-  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINPROGRESS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1042,22,1042,66)"), left{}(), format{}("%c#EINPROGRESS%r"), injective{}()]
-  symbol Lbl'Hash'EINTR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINTR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1015,22,1015,54)"), left{}(), format{}("%c#EINTR%r"), injective{}()]
-  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINVAL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1016,22,1016,56)"), left{}(), format{}("%c#EINVAL%r"), injective{}()]
-  symbol Lbl'Hash'EIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1017,22,1017,50)"), left{}(), format{}("%c#EIO%r"), injective{}()]
-  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1062,22,1062,58)"), left{}(), format{}("%c#EISCONN%r"), injective{}()]
-  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1018,22,1018,56)"), left{}(), format{}("%c#EISDIR%r"), injective{}()]
-  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ELOOP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1070,22,1070,54)"), left{}(), format{}("%c#ELOOP%r"), injective{}()]
-  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1019,22,1019,56)"), left{}(), format{}("%c#EMFILE%r"), injective{}()]
-  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMLINK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1020,22,1020,56)"), left{}(), format{}("%c#EMLINK%r"), injective{}()]
-  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMSGSIZE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1046,22,1046,60)"), left{}(), format{}("%c#EMSGSIZE%r"), injective{}()]
-  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENAMETOOLONG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1021,22,1021,68)"), left{}(), format{}("%c#ENAMETOOLONG%r"), injective{}()]
-  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1056,22,1056,60)"), left{}(), format{}("%c#ENETDOWN%r"), injective{}()]
-  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1058,22,1058,62)"), left{}(), format{}("%c#ENETRESET%r"), injective{}()]
-  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1057,22,1057,66)"), left{}(), format{}("%c#ENETUNREACH%r"), injective{}()]
-  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1022,22,1022,56)"), left{}(), format{}("%c#ENFILE%r"), injective{}()]
-  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOBUFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1061,22,1061,58)"), left{}(), format{}("%c#ENOBUFS%r"), injective{}()]
-  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENODEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1023,22,1023,56)"), left{}(), format{}("%c#ENODEV%r"), injective{}()]
-  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOENT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1024,22,1024,56)"), left{}(), format{}("%c#ENOENT%r"), injective{}()]
-  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOEXEC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1025,22,1025,58)"), left{}(), format{}("%c#ENOEXEC%r"), injective{}()]
-  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOLCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1026,22,1026,56)"), left{}(), format{}("%c#ENOLCK%r"), injective{}()]
-  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOMEM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1027,22,1027,56)"), left{}(), format{}("%c#ENOMEM%r"), injective{}()]
-  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOPROTOOPT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1048,22,1048,66)"), left{}(), format{}("%c#ENOPROTOOPT%r"), injective{}()]
-  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSPC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1028,22,1028,56)"), left{}(), format{}("%c#ENOSPC%r"), injective{}()]
-  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSYS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1029,22,1029,56)"), left{}(), format{}("%c#ENOSYS%r"), injective{}()]
-  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1063,22,1063,60)"), left{}(), format{}("%c#ENOTCONN%r"), injective{}()]
-  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1030,22,1030,58)"), left{}(), format{}("%c#ENOTDIR%r"), injective{}()]
-  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTEMPTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1031,22,1031,62)"), left{}(), format{}("%c#ENOTEMPTY%r"), injective{}()]
-  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTSOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1044,22,1044,60)"), left{}(), format{}("%c#ENOTSOCK%r"), injective{}()]
-  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1032,22,1032,56)"), left{}(), format{}("%c#ENOTTY%r"), injective{}()]
-  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENXIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1033,22,1033,54)"), left{}(), format{}("%c#ENXIO%r"), injective{}()]
-  symbol Lbl'Hash'EOF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,22,1003,50)"), left{}(), format{}("%c#EOF%r"), injective{}()]
-  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOPNOTSUPP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1051,22,1051,64)"), left{}(), format{}("%c#EOPNOTSUPP%r"), injective{}()]
-  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOVERFLOW"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1071,22,1071,62)"), left{}(), format{}("%c#EOVERFLOW%r"), injective{}()]
-  symbol Lbl'Hash'EPERM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPERM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1034,22,1034,54)"), left{}(), format{}("%c#EPERM%r"), injective{}()]
-  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1052,22,1052,68)"), left{}(), format{}("%c#EPFNOSUPPORT%r"), injective{}()]
-  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1035,22,1035,54)"), left{}(), format{}("%c#EPIPE%r"), injective{}()]
-  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTONOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1049,22,1049,74)"), left{}(), format{}("%c#EPROTONOSUPPORT%r"), injective{}()]
-  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTOTYPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1047,22,1047,64)"), left{}(), format{}("%c#EPROTOTYPE%r"), injective{}()]
-  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ERANGE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1036,22,1036,56)"), left{}(), format{}("%c#ERANGE%r"), injective{}()]
-  symbol Lbl'Hash'EROFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EROFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1037,22,1037,54)"), left{}(), format{}("%c#EROFS%r"), injective{}()]
-  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESHUTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1064,22,1064,62)"), left{}(), format{}("%c#ESHUTDOWN%r"), injective{}()]
-  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESOCKTNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1050,22,1050,74)"), left{}(), format{}("%c#ESOCKTNOSUPPORT%r"), injective{}()]
-  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1038,22,1038,56)"), left{}(), format{}("%c#ESPIPE%r"), injective{}()]
-  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESRCH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1039,22,1039,54)"), left{}(), format{}("%c#ESRCH%r"), injective{}()]
-  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETIMEDOUT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1066,22,1066,62)"), left{}(), format{}("%c#ETIMEDOUT%r"), injective{}()]
-  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETOOMANYREFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1065,22,1065,68)"), left{}(), format{}("%c#ETOOMANYREFS%r"), injective{}()]
-  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EWOULDBLOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1041,22,1041,66)"), left{}(), format{}("%c#EWOULDBLOCK%r"), injective{}()]
-  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EXDEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1040,22,1040,54)"), left{}(), format{}("%c#EXDEV%r"), injective{}()]
-  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.accept"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1080,18,1080,78)"), left{}(), format{}("%c#accept%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#buffer"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1108,21,1108,30)"), left{}(), format{}("%c#buffer%r %c(%r %1 %c)%r"), injective{}()]
-  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.close"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1083,16,1083,74)"), left{}(), format{}("%c#close%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(SortBExp{}) : SortBExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), right{}(), terminals{}("10"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), left{}(), format{}("%c!%r %1"), colors{}("pink"), injective{}()]
+  symbol Lbl'Hash'E2BIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#E2BIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2165,22,2165,54)"), left{}(), format{}("%c#E2BIG%r"), injective{}()]
+  symbol Lbl'Hash'EACCES{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EACCES"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2166,22,2166,56)"), left{}(), format{}("%c#EACCES%r"), injective{}()]
+  symbol Lbl'Hash'EADDRINUSE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRINUSE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2215,22,2215,64)"), left{}(), format{}("%c#EADDRINUSE%r"), injective{}()]
+  symbol Lbl'Hash'EADDRNOTAVAIL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EADDRNOTAVAIL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2216,22,2216,70)"), left{}(), format{}("%c#EADDRNOTAVAIL%r"), injective{}()]
+  symbol Lbl'Hash'EAFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2214,22,2214,68)"), left{}(), format{}("%c#EAFNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EAGAIN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EAGAIN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2167,22,2167,56)"), left{}(), format{}("%c#EAGAIN%r"), injective{}()]
+  symbol Lbl'Hash'EALREADY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EALREADY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2204,22,2204,60)"), left{}(), format{}("%c#EALREADY%r"), injective{}()]
+  symbol Lbl'Hash'EBADF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBADF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2168,22,2168,54)"), left{}(), format{}("%c#EBADF%r"), injective{}()]
+  symbol Lbl'Hash'EBUSY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EBUSY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2169,22,2169,54)"), left{}(), format{}("%c#EBUSY%r"), injective{}()]
+  symbol Lbl'Hash'ECHILD{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECHILD"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2170,22,2170,56)"), left{}(), format{}("%c#ECHILD%r"), injective{}()]
+  symbol Lbl'Hash'ECONNABORTED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNABORTED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2220,22,2220,68)"), left{}(), format{}("%c#ECONNABORTED%r"), injective{}()]
+  symbol Lbl'Hash'ECONNREFUSED{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNREFUSED"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2228,22,2228,68)"), left{}(), format{}("%c#ECONNREFUSED%r"), injective{}()]
+  symbol Lbl'Hash'ECONNRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ECONNRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2221,22,2221,64)"), left{}(), format{}("%c#ECONNRESET%r"), injective{}()]
+  symbol Lbl'Hash'EDEADLK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDEADLK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2171,22,2171,58)"), left{}(), format{}("%c#EDEADLK%r"), injective{}()]
+  symbol Lbl'Hash'EDESTADDRREQ{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDESTADDRREQ"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2206,22,2206,68)"), left{}(), format{}("%c#EDESTADDRREQ%r"), injective{}()]
+  symbol Lbl'Hash'EDOM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EDOM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2172,22,2172,52)"), left{}(), format{}("%c#EDOM%r"), injective{}()]
+  symbol Lbl'Hash'EEXIST{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EEXIST"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2173,22,2173,56)"), left{}(), format{}("%c#EEXIST%r"), injective{}()]
+  symbol Lbl'Hash'EFAULT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFAULT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2174,22,2174,56)"), left{}(), format{}("%c#EFAULT%r"), injective{}()]
+  symbol Lbl'Hash'EFBIG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EFBIG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2175,22,2175,54)"), left{}(), format{}("%c#EFBIG%r"), injective{}()]
+  symbol Lbl'Hash'EHOSTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2229,22,2229,62)"), left{}(), format{}("%c#EHOSTDOWN%r"), injective{}()]
+  symbol Lbl'Hash'EHOSTUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EHOSTUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2230,22,2230,68)"), left{}(), format{}("%c#EHOSTUNREACH%r"), injective{}()]
+  symbol Lbl'Hash'EINPROGRESS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINPROGRESS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2203,22,2203,66)"), left{}(), format{}("%c#EINPROGRESS%r"), injective{}()]
+  symbol Lbl'Hash'EINTR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINTR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2176,22,2176,54)"), left{}(), format{}("%c#EINTR%r"), injective{}()]
+  symbol Lbl'Hash'EINVAL{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EINVAL"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2177,22,2177,56)"), left{}(), format{}("%c#EINVAL%r"), injective{}()]
+  symbol Lbl'Hash'EIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2178,22,2178,50)"), left{}(), format{}("%c#EIO%r"), injective{}()]
+  symbol Lbl'Hash'EISCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2223,22,2223,58)"), left{}(), format{}("%c#EISCONN%r"), injective{}()]
+  symbol Lbl'Hash'EISDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EISDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2179,22,2179,56)"), left{}(), format{}("%c#EISDIR%r"), injective{}()]
+  symbol Lbl'Hash'ELOOP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ELOOP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2231,22,2231,54)"), left{}(), format{}("%c#ELOOP%r"), injective{}()]
+  symbol Lbl'Hash'EMFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2180,22,2180,56)"), left{}(), format{}("%c#EMFILE%r"), injective{}()]
+  symbol Lbl'Hash'EMLINK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMLINK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2181,22,2181,56)"), left{}(), format{}("%c#EMLINK%r"), injective{}()]
+  symbol Lbl'Hash'EMSGSIZE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EMSGSIZE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2207,22,2207,60)"), left{}(), format{}("%c#EMSGSIZE%r"), injective{}()]
+  symbol Lbl'Hash'ENAMETOOLONG{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENAMETOOLONG"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2182,22,2182,68)"), left{}(), format{}("%c#ENAMETOOLONG%r"), injective{}()]
+  symbol Lbl'Hash'ENETDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2217,22,2217,60)"), left{}(), format{}("%c#ENETDOWN%r"), injective{}()]
+  symbol Lbl'Hash'ENETRESET{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETRESET"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2219,22,2219,62)"), left{}(), format{}("%c#ENETRESET%r"), injective{}()]
+  symbol Lbl'Hash'ENETUNREACH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENETUNREACH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2218,22,2218,66)"), left{}(), format{}("%c#ENETUNREACH%r"), injective{}()]
+  symbol Lbl'Hash'ENFILE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENFILE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2183,22,2183,56)"), left{}(), format{}("%c#ENFILE%r"), injective{}()]
+  symbol Lbl'Hash'ENOBUFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOBUFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2222,22,2222,58)"), left{}(), format{}("%c#ENOBUFS%r"), injective{}()]
+  symbol Lbl'Hash'ENODEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENODEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2184,22,2184,56)"), left{}(), format{}("%c#ENODEV%r"), injective{}()]
+  symbol Lbl'Hash'ENOENT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOENT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2185,22,2185,56)"), left{}(), format{}("%c#ENOENT%r"), injective{}()]
+  symbol Lbl'Hash'ENOEXEC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOEXEC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2186,22,2186,58)"), left{}(), format{}("%c#ENOEXEC%r"), injective{}()]
+  symbol Lbl'Hash'ENOLCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOLCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2187,22,2187,56)"), left{}(), format{}("%c#ENOLCK%r"), injective{}()]
+  symbol Lbl'Hash'ENOMEM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOMEM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2188,22,2188,56)"), left{}(), format{}("%c#ENOMEM%r"), injective{}()]
+  symbol Lbl'Hash'ENOPROTOOPT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOPROTOOPT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2209,22,2209,66)"), left{}(), format{}("%c#ENOPROTOOPT%r"), injective{}()]
+  symbol Lbl'Hash'ENOSPC{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSPC"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2189,22,2189,56)"), left{}(), format{}("%c#ENOSPC%r"), injective{}()]
+  symbol Lbl'Hash'ENOSYS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOSYS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2190,22,2190,56)"), left{}(), format{}("%c#ENOSYS%r"), injective{}()]
+  symbol Lbl'Hash'ENOTCONN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTCONN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2224,22,2224,60)"), left{}(), format{}("%c#ENOTCONN%r"), injective{}()]
+  symbol Lbl'Hash'ENOTDIR{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTDIR"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2191,22,2191,58)"), left{}(), format{}("%c#ENOTDIR%r"), injective{}()]
+  symbol Lbl'Hash'ENOTEMPTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTEMPTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2192,22,2192,62)"), left{}(), format{}("%c#ENOTEMPTY%r"), injective{}()]
+  symbol Lbl'Hash'ENOTSOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTSOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2205,22,2205,60)"), left{}(), format{}("%c#ENOTSOCK%r"), injective{}()]
+  symbol Lbl'Hash'ENOTTY{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENOTTY"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2193,22,2193,56)"), left{}(), format{}("%c#ENOTTY%r"), injective{}()]
+  symbol Lbl'Hash'ENXIO{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ENXIO"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2194,22,2194,54)"), left{}(), format{}("%c#ENXIO%r"), injective{}()]
+  symbol Lbl'Hash'EOF{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOF"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2164,22,2164,50)"), left{}(), format{}("%c#EOF%r"), injective{}()]
+  symbol Lbl'Hash'EOPNOTSUPP{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOPNOTSUPP"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2212,22,2212,64)"), left{}(), format{}("%c#EOPNOTSUPP%r"), injective{}()]
+  symbol Lbl'Hash'EOVERFLOW{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EOVERFLOW"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2232,22,2232,62)"), left{}(), format{}("%c#EOVERFLOW%r"), injective{}()]
+  symbol Lbl'Hash'EPERM{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPERM"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2195,22,2195,54)"), left{}(), format{}("%c#EPERM%r"), injective{}()]
+  symbol Lbl'Hash'EPFNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPFNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2213,22,2213,68)"), left{}(), format{}("%c#EPFNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2196,22,2196,54)"), left{}(), format{}("%c#EPIPE%r"), injective{}()]
+  symbol Lbl'Hash'EPROTONOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTONOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2210,22,2210,74)"), left{}(), format{}("%c#EPROTONOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'EPROTOTYPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EPROTOTYPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2208,22,2208,64)"), left{}(), format{}("%c#EPROTOTYPE%r"), injective{}()]
+  symbol Lbl'Hash'ERANGE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ERANGE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2197,22,2197,56)"), left{}(), format{}("%c#ERANGE%r"), injective{}()]
+  symbol Lbl'Hash'EROFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EROFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2198,22,2198,54)"), left{}(), format{}("%c#EROFS%r"), injective{}()]
+  symbol Lbl'Hash'ESHUTDOWN{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESHUTDOWN"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2225,22,2225,62)"), left{}(), format{}("%c#ESHUTDOWN%r"), injective{}()]
+  symbol Lbl'Hash'ESOCKTNOSUPPORT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESOCKTNOSUPPORT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2211,22,2211,74)"), left{}(), format{}("%c#ESOCKTNOSUPPORT%r"), injective{}()]
+  symbol Lbl'Hash'ESPIPE{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESPIPE"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2199,22,2199,56)"), left{}(), format{}("%c#ESPIPE%r"), injective{}()]
+  symbol Lbl'Hash'ESRCH{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ESRCH"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2200,22,2200,54)"), left{}(), format{}("%c#ESRCH%r"), injective{}()]
+  symbol Lbl'Hash'ETIMEDOUT{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETIMEDOUT"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2227,22,2227,62)"), left{}(), format{}("%c#ETIMEDOUT%r"), injective{}()]
+  symbol Lbl'Hash'ETOOMANYREFS{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#ETOOMANYREFS"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2226,22,2226,68)"), left{}(), format{}("%c#ETOOMANYREFS%r"), injective{}()]
+  symbol Lbl'Hash'EWOULDBLOCK{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EWOULDBLOCK"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2202,22,2202,66)"), left{}(), format{}("%c#EWOULDBLOCK%r"), injective{}()]
+  symbol Lbl'Hash'EXDEV{}() : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}("#EXDEV"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2201,22,2201,54)"), left{}(), format{}("%c#EXDEV%r"), injective{}()]
+  hooked-symbol Lbl'Hash'accept'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.accept"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2330,20,2330,80)"), left{}(), format{}("%c#accept%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(SortK{}) : SortStream{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#buffer"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2413,21,2413,30)"), left{}(), format{}("%c#buffer%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'close'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.close"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2304,16,2304,74)"), left{}(), format{}("%c#close%r %c(%r %1 %c)%r"), function{}()]
   symbol Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}() : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("111"), left{}(), format{}("%c#freezer!__IMP-SYNTAX_BExp_BExp0_%r %c(%r %c)%r"), injective{}()]
   symbol Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_&&__IMP-SYNTAX_BExp_BExp_BExp0_%r %c(%r %1 %c)%r"), injective{}()]
   symbol Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_+__IMP-SYNTAX_AExp_AExp_AExp0_%r %c(%r %1 %c)%r"), injective{}()]
@@ -182,190 +184,189 @@ module IMP
   symbol Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp1_%r %c(%r %1 %c)%r"), injective{}()]
   symbol Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%c#freezer_=_;_IMP-SYNTAX_Stmt_Id_AExp1_%r %c(%r %1 %c)%r"), injective{}()]
   symbol Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(SortK{}, SortK{}) : SortKItem{} [functional{}(), constructor{}(), priorities{}(), right{}(), terminals{}("110101"), left{}(), format{}("%c#freezerif(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block0_%r %c(%r %1 %c,%r %2 %c)%r"), injective{}()]
-  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.getc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1079,18,1079,86)"), left{}(), format{}("%c#getc%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), smt-hook{}("ite"), right{}(), terminals{}("1010101"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(931,26,931,125)"), left{}(), format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}()]
-  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.lock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1088,16,1088,90)"), left{}(), format{}("%c#lock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), impure{}(), klabel{}("#logToFile"), hook{}("IO.log"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,16,1117,120)"), left{}(), format{}("%c#logToFile%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'lstat'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.lstat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1093,20,1093,77)"), left{}(), format{}("%c#lstat%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#mkstemp"), hook{}("IO.mkstemp"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,21,1119,83)"), left{}(), format{}("%c#mkstemp%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1076,20,1076,58)"), left{}(), format{}("%c#open%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.open"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1077,18,1077,96)"), left{}(), format{}("%c#open%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'opendir'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.opendir"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1094,20,1094,81)"), left{}(), format{}("%c#opendir%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.putc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1086,16,1086,92)"), left{}(), format{}("%c#putc%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.read"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1081,23,1081,98)"), left{}(), format{}("%c#read%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#remove"), hook{}("IO.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1123,16,1123,84)"), left{}(), format{}("%c#remove%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seek"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1084,16,1084,87)"), left{}(), format{}("%c#seek%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seekEnd"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1085,16,1085,95)"), left{}(), format{}("%c#seekEnd%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.shutdownWrite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1090,16,1090,90)"), left{}(), format{}("%c#shutdownWrite%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'stat'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.stat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1092,20,1092,75)"), left{}(), format{}("%c#stat%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1102,19,1102,50)"), left{}(), format{}("%c#stderr%r"), function{}()]
-  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1100,18,1100,50)"), left{}(), format{}("%c#stdin%r"), function{}()]
-  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1101,19,1101,50)"), left{}(), format{}("%c#stdout%r"), function{}()]
-  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#system"), hook{}("IO.system"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,20,1114,73)"), left{}(), format{}("%c#system%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("#systemResult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1115,20,1115,142)"), left{}(), format{}("%c#systemResult%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), injective{}()]
-  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.tell"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1078,18,1078,74)"), left{}(), format{}("%c#tell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("#tempFile"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1121,21,1121,92)"), left{}(), format{}("%c#tempFile%r %c(%r %1 %c,%r %2 %c)%r"), injective{}()]
-  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("111"), impure{}(), hook{}("IO.time"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1096,18,1096,66)"), left{}(), format{}("%c#time%r %c(%r %c)%r"), function{}()]
-  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#unknownIOError"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,54,1003,89)"), left{}(), format{}("%c#unknownIOError%r %c(%r %1 %c)%r"), injective{}()]
-  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.unlock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1089,16,1089,94)"), left{}(), format{}("%c#unlock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.write"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1087,16,1087,92)"), left{}(), format{}("%c#write%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  symbol Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(SortInt{}) : SortAExp{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), right{}(), terminals{}("10"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(29,20,29,60)"), left{}(), format{}("%c-%r%1"), injective{}()]
-  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), terminals{}("1"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(286,19,286,146)"), left{}(), format{}("%c.List%r"), function{}()]
-  symbol Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}() : SortIds{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("1"), klabel{}(".List{\"_,__IMP-SYNTAX\"}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,63)"), left{}(), format{}("%c.Ids%r"), injective{}()]
-  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(109,18,109,128)"), left{}(), format{}("%c.Map%r"), function{}()]
-  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(221,18,221,122)"), left{}(), format{}("%c.Set%r"), function{}()]
-  symbol Lbl'-LT-'T'-GT-'{}(SortKCell{}, SortStateCell{}) : SortTCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("yellow"), cellName{}("T"), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("1001"), contentStartLine{}("88"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<T>%r%i%n%1%n%2%d%n%c</T>%r"), colors{}("yellow,yellow"), injective{}(), cell{}(), topcell{}()]
+  hooked-symbol Lbl'Hash'getc'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.getc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2285,20,2285,88)"), left{}(), format{}("%c#getc%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortSort}(SortBool{}, SortSort, SortSort) : SortSort [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), smt-hook{}("ite"), right{}(), terminals{}("1010101"), hook{}("KEQUAL.ite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2048,26,2048,125)"), left{}(), format{}("%c#if%r %1 %c#then%r %2 %c#else%r %3 %c#fi%r"), function{}()]
+  hooked-symbol Lbl'Hash'lock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.lock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2316,16,2316,90)"), left{}(), format{}("%c#lock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'logToFile{}(SortString{}, SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), returnsUnit{}(), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), impure{}(), klabel{}("#logToFile"), hook{}("IO.log"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2401,16,2401,120)"), left{}(), format{}("%c#logToFile%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'mkstemp'LParUndsRParUnds'K-IO'Unds'IOFile'Unds'String{}(SortString{}) : SortIOFile{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#mkstemp"), hook{}("IO.mkstemp"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2378,21,2378,83)"), left{}(), format{}("%c#mkstemp%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2255,20,2255,58)"), left{}(), format{}("%c#open%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.open"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2256,18,2256,96)"), left{}(), format{}("%c#open%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'putc'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.putc"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2295,16,2295,92)"), left{}(), format{}("%c#putc%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'read'LParUndsCommUndsRParUnds'K-IO'Unds'IOString'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortIOString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.read"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2286,23,2286,98)"), left{}(), format{}("%c#read%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'remove'LParUndsRParUnds'K-IO'Unds'K'Unds'String{}(SortString{}) : SortK{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#remove"), hook{}("IO.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2389,16,2389,84)"), left{}(), format{}("%c#remove%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'seek'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seek"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2271,16,2271,87)"), left{}(), format{}("%c#seek%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'seekEnd'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.seekEnd"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2272,16,2272,95)"), left{}(), format{}("%c#seekEnd%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'shutdownWrite'LParUndsRParUnds'K-IO'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.shutdownWrite"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2331,16,2331,90)"), left{}(), format{}("%c#shutdownWrite%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2351,19,2351,50)"), left{}(), format{}("%c#stderr%r"), function{}()]
+  symbol Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2349,18,2349,50)"), left{}(), format{}("%c#stdin%r"), function{}()]
+  symbol Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}() : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2350,19,2350,50)"), left{}(), format{}("%c#stdout%r"), function{}()]
+  hooked-symbol Lbl'Hash'system'LParUndsRParUnds'K-IO'Unds'KItem'Unds'String{}(SortString{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("#system"), hook{}("IO.system"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2367,20,2367,73)"), left{}(), format{}("%c#system%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'systemResult{}(SortInt{}, SortString{}, SortString{}) : SortKItem{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("#systemResult"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2368,20,2368,142)"), left{}(), format{}("%c#systemResult%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'tell'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'Int{}(SortInt{}) : SortIOInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), hook{}("IO.tell"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2270,20,2270,76)"), left{}(), format{}("%c#tell%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'Hash'tempFile{}(SortString{}, SortInt{}) : SortIOFile{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("110101"), klabel{}("#tempFile"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2380,21,2380,92)"), left{}(), format{}("%c#tempFile%r %c(%r %1 %c,%r %2 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'time'LParRParUnds'K-IO'Unds'Int{}() : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("111"), impure{}(), hook{}("IO.time"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2340,18,2340,66)"), left{}(), format{}("%c#time%r %c(%r %c)%r"), function{}()]
+  symbol Lbl'Hash'unknownIOError{}(SortInt{}) : SortIOError{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("#unknownIOError"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2164,54,2164,89)"), left{}(), format{}("%c#unknownIOError%r %c(%r %1 %c)%r"), injective{}()]
+  hooked-symbol Lbl'Hash'unlock'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.unlock"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2317,16,2317,94)"), left{}(), format{}("%c#unlock%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Hash'write'LParUndsCommUndsRParUnds'K-IO'Unds'K'Unds'Int'Unds'String{}(SortInt{}, SortString{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), impure{}(), hook{}("IO.write"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2296,16,2296,92)"), left{}(), format{}("%c#write%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(SortInt{}) : SortAExp{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), right{}(), terminals{}("10"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(29,20,29,60)"), left{}(), format{}("%c-%r%1"), injective{}()]
+  hooked-symbol Lbl'Stop'List{}() : SortList{} [latex{}("\\dotCt{List}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_nil"), terminals{}("1"), klabel{}(".List"), hook{}("LIST.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(655,19,655,146)"), left{}(), format{}("%c.List%r"), function{}()]
+  symbol Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}() : SortIds{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("1"), klabel{}(".List{\"_,__IMP-SYNTAX\"}"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,63)"), left{}(), format{}("%c.Ids%r"), injective{}()]
+  hooked-symbol Lbl'Stop'Map{}() : SortMap{} [latex{}("\\dotCt{Map}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Map"), hook{}("MAP.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(257,18,257,128)"), left{}(), format{}("%c.Map%r"), function{}()]
+  hooked-symbol Lbl'Stop'Set{}() : SortSet{} [latex{}("\\dotCt{Set}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1"), klabel{}(".Set"), hook{}("SET.unit"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(535,18,535,122)"), left{}(), format{}("%c.Set%r"), function{}()]
+  symbol Lbl'-LT-'T'-GT-'{}(SortKCell{}, SortStateCell{}) : SortTCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("yellow"), cellName{}("T"), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("1001"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<T>%r%i%n%1%n%2%d%n%c</T>%r"), colors{}("yellow,yellow"), injective{}(), cell{}(), topcell{}()]
   symbol Lbl'-LT-'T'-GT-'-fragment{}(SortKCellOpt{}, SortStateCellOpt{}) : SortTCellFragment{} [functional{}(), constructor{}(), cellFragment{}("TCell"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%c<T>-fragment%r %1 %2 %c</T>-fragment%r"), injective{}()]
   symbol Lbl'-LT-'generatedCounter'-GT-'{}(SortInt{}) : SortGeneratedCounterCell{} [functional{}(), constructor{}(), cellName{}("generatedCounter"), priorities{}(), right{}(), terminals{}("101"), left{}(), format{}("%c<generatedCounter>%r%i%n%1%d%n%c</generatedCounter>%r"), injective{}(), cell{}()]
   symbol Lbl'-LT-'generatedTop'-GT-'{}(SortTCell{}, SortGeneratedCounterCell{}) : SortGeneratedTopCell{} [functional{}(), constructor{}(), cellName{}("generatedTop"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%1"), injective{}(), cell{}(), topcell{}()]
   symbol Lbl'-LT-'generatedTop'-GT-'-fragment{}(SortTCellOpt{}, SortGeneratedCounterCellOpt{}) : SortGeneratedTopCellFragment{} [functional{}(), constructor{}(), cellFragment{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1001"), left{}(), format{}("%c<generatedTop>-fragment%r %1 %2 %c</generatedTop>-fragment%r"), injective{}()]
-  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("green"), cellName{}("k"), maincell{}(), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), contentStartLine{}("88"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), colors{}("green,green"), injective{}(), cell{}()]
-  symbol Lbl'-LT-'state'-GT-'{}(SortMap{}) : SortStateCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("red"), cellName{}("state"), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), contentStartLine{}("88"), contentStartColumn{}("17"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<state>%r%i%n%1%d%n%c</state>%r"), colors{}("red,red"), injective{}(), cell{}()]
-  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("Base2String"), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(634,21,634,98)"), left{}(), format{}("%cBase2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Float2String"), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(629,21,629,105)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("FloatFormat"), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(630,21,630,121)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Id2String"), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(901,21,901,89)"), left{}(), format{}("%cId2String%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Int2String"), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(633,21,633,103)"), left{}(), format{}("%cInt2String%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(294,20,294,98)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
-  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(305,19,305,119)"), left{}(), format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), terminals{}("1101"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(289,19,289,136)"), left{}(), format{}("%cListItem%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(120,20,120,112)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
-  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), prefer{}(), right{}(), terminals{}("010101"), klabel{}("Map:update"), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(125,18,125,144)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
-  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(232,18,232,146)"), left{}(), format{}("%1 %c-Set%r %2"), function{}()]
-  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(235,19,235,106)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
-  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(226,18,226,112)"), left{}(), format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("String2Base"), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(635,21,635,98)"), left{}(), format{}("%cString2Base%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Float"), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(631,21,631,93)"), left{}(), format{}("%cString2Float%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Id"), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(902,17,902,84)"), left{}(), format{}("%cString2Id%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Int"), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(632,21,632,91)"), left{}(), format{}("%cString2Int%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_%Int_"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,18,402,170)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %c%Int%r %2"), function{}()]
-  symbol Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(SortBExp{}, SortBExp{}) : SortBExp{} [functional{}(), constructor{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), left{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), format{}("%1 %c&&%r %2"), colors{}("pink"), injective{}()]
-  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), terminals{}("010"), klabel{}("_&Int_"), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(413,18,413,182)"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), format{}("%1 %c&Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("*"), right{}(), terminals{}("010"), klabel{}("_*Int_"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(398,18,398,181)"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c*Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("+"), right{}(), terminals{}("010"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(407,18,407,178)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c+Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(615,21,615,139)"), left{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}()), format{}("%1 %c+String%r %2"), function{}()]
-  symbol Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), left{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), format{}("%1 %c+%r %2"), colors{}("pink"), injective{}()]
-  symbol Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(SortId{}, SortIds{}) : SortIds{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,63)"), left{}(), format{}("%1%c,%r %2"), injective{}()]
-  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("-"), right{}(), terminals{}("010"), klabel{}("_-Int_"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(408,18,408,178)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c-Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(132,18,132,120)"), left{}(), format{}("%1 %c-Map%r %2"), function{}()]
-  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_/Int_"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(401,18,401,172)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c/Int%r %2"), function{}()]
-  symbol Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), format{}("%1 %c/%r %2"), colors{}("pink"), injective{}()]
-  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), terminals{}("010"), klabel{}("_<<Int_"), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(411,18,411,172)"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), format{}("%1 %c<<Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<="), right{}(), terminals{}("010"), klabel{}("_<=Int_"), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(427,19,427,176)"), left{}(Lbl'Unds-LT-Eqls'Int'Unds'{}()), format{}("%1 %c<=Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(155,19,155,91)"), left{}(), format{}("%1 %c<=Map%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(238,19,238,85)"), left{}(), format{}("%1 %c<=Set%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(647,19,647,82)"), left{}(), format{}("%1 %c<=String%r %2"), function{}()]
-  symbol Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortBExp{} [latex{}("{#1}\\leq{#2}"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), left{}(), format{}("%1 %c<=%r %2"), colors{}("pink"), injective{}(), seqstrict{}()]
-  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<"), right{}(), terminals{}("010"), klabel{}("_<Int_"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(428,19,428,171)"), left{}(Lbl'Unds-LT-'Int'Unds'{}()), format{}("%1 %c<Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(646,19,646,82)"), left{}(), format{}("%1 %c<String%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Bool_"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(342,19,342,132)"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), format{}("%1 %c=/=Bool%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Int_"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(432,19,432,188)"), left{}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}()), format{}("%1 %c=/=Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), notEqualEqualK{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}(),Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}()), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(927,19,927,170)"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), format{}("%1 %c=/=K%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(643,19,643,94)"), left{}(Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c=/=String%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Bool_"), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(341,19,341,124)"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), format{}("%1 %c==Bool%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(431,19,431,177)"), left{}(Lbl'UndsEqlsEqls'Int'Unds'{}()), format{}("%1 %c==Int%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}(),Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}()), smt-hook{}("="), right{}(), terminals{}("010"), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(926,19,926,156)"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), format{}("%1 %c==K%r %2"), function{}()]
-  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(617,19,617,88)"), left{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c==String%r %2"), function{}()]
-  symbol Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(SortId{}, SortAExp{}) : SortStmt{} [functional{}(), constructor{}(), strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("0101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), left{}(), format{}("%1 %c=%r %2%c;%r"), colors{}("pink,pink"), injective{}()]
-  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">="), right{}(), terminals{}("010"), klabel{}("_>=Int_"), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(429,19,429,176)"), left{}(Lbl'Unds-GT-Eqls'Int'Unds'{}()), format{}("%1 %c>=Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(649,19,649,82)"), left{}(), format{}("%1 %c>=String%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), terminals{}("010"), klabel{}("_>>Int_"), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(410,18,410,172)"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), format{}("%1 %c>>Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">"), right{}(), terminals{}("010"), klabel{}("_>Int_"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(430,19,430,171)"), left{}(Lbl'Unds-GT-'Int'Unds'{}()), format{}("%1 %c>Int%r %2"), function{}()]
-  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(648,19,648,82)"), left{}(), format{}("%1 %c>String%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(".List"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}("ListItem"), symbol'Kywd'{}(), priorities{}(), right{}(), assoc{}(), smtlib{}("smt_seq_concat"), terminals{}("00"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(284,19,284,192)"), left{}(Lbl'Unds'List'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(".Map"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}("_|->_"), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(107,18,107,172)"), left{}(Lbl'Unds'Map'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(".Set"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), element{}("SetItem"), symbol'Kywd'{}(), idem{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(219,18,219,176)"), left{}(Lbl'Unds'Set'Unds'{}()), format{}("%1%n%2"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010101"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(296,19,296,107)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010111"), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,18,128,121)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}()]
-  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010110"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(122,20,122,138)"), left{}(), format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}()]
-  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("(mod (^ #1 #2) #3)"), right{}(), terminals{}("0100"), klabel{}("_^%Int__"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(396,18,396,138)"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), format{}("%1 %c^%Int%r %2 %3"), function{}()]
-  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("^"), right{}(), terminals{}("010"), klabel{}("_^Int_"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(395,18,395,177)"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), format{}("%1 %c^Int%r %2"), function{}()]
-  symbol Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(SortStmt{}, SortStmt{}) : SortStmt{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("00"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(45,20,45,68)"), left{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), format{}("%1%n%2"), injective{}()]
-  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(334,19,334,189)"), left{}(Lbl'Unds'andBool'Unds'{}()), format{}("%1 %candBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andThenBool_"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(335,19,335,151)"), left{}(Lbl'Unds'andThenBool'Unds'{}()), format{}("%1 %candThenBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_divInt_"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(404,18,404,121)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), format{}("%1 %cdivInt%r %2"), function{}()]
-  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(433,19,433,52)"), left{}(), format{}("%1 %cdividesInt%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("=>"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_impliesBool_"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(339,19,339,150)"), left{}(Lbl'Unds'impliesBool'Unds'{}()), format{}("%1 %cimpliesBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("010"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(308,19,308,101)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("01101"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(146,19,146,93)"), left{}(), format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}()]
-  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_modInt_"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(405,18,405,121)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %cmodInt%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orBool_"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(337,19,337,176)"), left{}(Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}()), format{}("%1 %corBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orElseBool_"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(338,19,338,148)"), left{}(Lbl'Unds'orElseBool'Unds'{}()), format{}("%1 %corElseBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("xor"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_xorBool_"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(336,19,336,143)"), left{}(Lbl'Unds'xorBool'Unds'{}()), format{}("%1 %cxorBool%r %2"), function{}()]
-  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), terminals{}("010"), klabel{}("_xorInt_"), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(415,18,415,188)"), left{}(Lbl'Unds'xorInt'Unds'{}()), format{}("%1 %cxorInt%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), terminals{}("010"), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(114,18,114,144)"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1 %c|->%r %2"), function{}()]
-  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("orInt"), terminals{}("010"), klabel{}("_|Int_"), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(417,18,417,179)"), left{}(Lbl'UndsPipe'Int'Unds'{}()), format{}("%1 %c|Int%r %2"), function{}()]
-  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), right{}(), terminals{}("1101"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(421,18,421,123)"), left{}(), format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(424,18,424,102)"), left{}(), format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("categoryChar"), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(651,21,651,80)"), left{}(), format{}("%ccategoryChar%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(158,20,158,100)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(244,20,244,94)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("chrChar"), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(620,21,620,69)"), left{}(), format{}("%cchrChar%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(641,18,641,150)"), left{}(), format{}("%ccountAllOccurrences%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("directionalityChar"), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(652,21,652,86)"), left{}(), format{}("%cdirectionalityChar%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101010101"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(302,19,302,99)"), left{}(), format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
-  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findChar"), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(626,18,626,115)"), left{}(), format{}("%cfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findString"), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(624,18,624,110)"), left{}(), format{}("%cfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshId"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(903,17,903,70)"), left{}(), format{}("%cfreshId%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(517,18,517,72)"), left{}(), format{}("%cfreshInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lbl'-LT-'k'-GT-'{}(SortK{}) : SortKCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("green"), cellName{}("k"), maincell{}(), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<k>%r%i%n%1%d%n%c</k>%r"), colors{}("green,green"), injective{}(), cell{}()]
+  symbol Lbl'-LT-'state'-GT-'{}(SortMap{}) : SortStateCell{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("red"), cellName{}("state"), priorities{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(88,17,91,21)"), left{}(), format{}("%c<state>%r%i%n%1%d%n%c</state>%r"), colors{}("red,red"), injective{}(), cell{}()]
+  hooked-symbol LblBase2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("Base2String"), hook{}("STRING.base2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1498,21,1498,98)"), left{}(), format{}("%cBase2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(SortBool{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Bool2String"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1448,21,1448,60)"), left{}(), format{}("%cBool2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(SortFloat{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Float2String"), hook{}("STRING.float2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1475,21,1475,105)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblFloat2String'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float'Unds'String{}(SortFloat{}, SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("FloatFormat"), hook{}("STRING.floatFormat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1476,21,1476,121)"), left{}(), format{}("%cFloat2String%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(SortId{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Id2String"), hook{}("STRING.token2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2004,21,2004,89)"), left{}(), format{}("%cId2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Int2String"), hook{}("STRING.int2string"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1497,21,1497,103)"), left{}(), format{}("%cInt2String%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblList'Coln'get{}(SortList{}, SortInt{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("List:get"), hook{}("LIST.get"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(674,20,674,98)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
+  hooked-symbol LblList'Coln'range{}(SortList{}, SortInt{}, SortInt{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("List:range"), hook{}("LIST.range"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(721,19,721,119)"), left{}(), format{}("%crange%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblListItem{}(SortKItem{}) : SortList{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("smt_seq_elem"), terminals{}("1101"), klabel{}("ListItem"), hook{}("LIST.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(663,19,663,136)"), left{}(), format{}("%cListItem%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblMap'Coln'lookup{}(SortMap{}, SortKItem{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("0101"), klabel{}("Map:lookup"), hook{}("MAP.lookup"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(280,20,280,112)"), left{}(), format{}("%1 %c[%r %2 %c]%r"), function{}()]
+  hooked-symbol LblMap'Coln'update{}(SortMap{}, SortKItem{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), prefer{}(), right{}(), terminals{}("010101"), klabel{}("Map:update"), hook{}("MAP.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(299,18,299,144)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
+  hooked-symbol LblSet'Coln'difference{}(SortSet{}, SortSet{}) : SortSet{} [latex{}("{#1}-_{\\it Set}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:difference"), hook{}("SET.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(575,18,575,146)"), left{}(), format{}("%1 %c-Set%r %2"), function{}()]
+  hooked-symbol LblSet'Coln'in{}(SortKItem{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010"), klabel{}("Set:in"), hook{}("SET.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(583,19,583,106)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
+  hooked-symbol LblSetItem{}(SortKItem{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("1101"), klabel{}("SetItem"), hook{}("SET.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(543,18,543,112)"), left{}(), format{}("%cSetItem%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Base'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'Int{}(SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("String2Base"), hook{}("STRING.string2base"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1499,21,1499,98)"), left{}(), format{}("%cString2Base%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(SortString{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Bool"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1454,19,1454,48)"), left{}(), format{}("%cString2Bool%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Float'LParUndsRParUnds'STRING-COMMON'Unds'Float'Unds'String{}(SortString{}) : SortFloat{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Float"), hook{}("STRING.string2float"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1477,21,1477,93)"), left{}(), format{}("%cString2Float%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(SortString{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Id"), hook{}("STRING.string2token"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2005,17,2005,84)"), left{}(), format{}("%cString2Id%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblString2Int'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("String2Int"), hook{}("STRING.string2int"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1496,21,1496,91)"), left{}(), format{}("%cString2Int%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbl'UndsPerc'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\%_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_%Int_"), hook{}("INT.tmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(936,18,936,170)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %c%%Int%r %2"), function{}()]
+  symbol Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(SortBExp{}, SortBExp{}) : SortBExp{} [functional{}(), constructor{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(37,20,37,76)"), left{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), format{}("%1 %c&&%r %2"), colors{}("pink"), injective{}()]
+  hooked-symbol Lbl'UndsAnd-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\&_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("andInt"), terminals{}("010"), klabel{}("_&Int_"), hook{}("INT.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(947,18,947,182)"), left{}(Lbl'UndsAnd-'Int'Unds'{}()), format{}("%1 %c&Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsStar'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ast_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("*"), right{}(), terminals{}("010"), klabel{}("_*Int_"), hook{}("INT.mul"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(932,18,932,181)"), left{}(Lbl'Unds'modInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c*Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPlus'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{+_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("+"), right{}(), terminals{}("010"), klabel{}("_+Int_"), hook{}("INT.add"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(941,18,941,178)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c+Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortString{} [latex{}("{#1}+_{\\scriptstyle\\it String}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1387,21,1387,139)"), left{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}()), format{}("%1 %c+String%r %2"), function{}()]
+  symbol Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,20,32,73)"), left{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), format{}("%1 %c+%r %2"), colors{}("pink"), injective{}()]
+  symbol Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(SortId{}, SortIds{}) : SortIds{} [functional{}(), constructor{}(), userList{}("*"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(54,18,54,63)"), left{}(), format{}("%1%c,%r %2"), injective{}()]
+  hooked-symbol Lbl'Unds'-Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{-_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), smt-hook{}("-"), right{}(), terminals{}("010"), klabel{}("_-Int_"), hook{}("INT.sub"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(942,18,942,178)"), left{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), format{}("%1 %c-Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'-Map'UndsUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [latex{}("{#1}-_{\\it Map}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.difference"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(320,18,320,120)"), left{}(), format{}("%1 %c-Map%r %2"), function{}()]
+  hooked-symbol Lbl'UndsSlsh'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\div_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_/Int_"), hook{}("INT.tdiv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(935,18,935,172)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}()), format{}("%1 %c/Int%r %2"), function{}()]
+  symbol Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortAExp{} [functional{}(), constructor{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), left{}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}()), format{}("%1 %c/%r %2"), colors{}("pink"), injective{}()]
+  hooked-symbol Lbl'Unds-LT--LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\ll_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shlInt"), terminals{}("010"), klabel{}("_<<Int_"), hook{}("INT.shl"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(945,18,945,172)"), left{}(Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}()), format{}("%1 %c<<Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\leq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<="), right{}(), terminals{}("010"), klabel{}("_<=Int_"), hook{}("INT.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1003,19,1003,176)"), left{}(Lbl'Unds-LT-Eqls'Int'Unds'{}()), format{}("%1 %c<=Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Map'UndsUnds'MAP'Unds'Bool'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("MAP.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(392,19,392,91)"), left{}(), format{}("%1 %c<=Map%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'Set'UndsUnds'SET'Unds'Bool'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.inclusion"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(592,19,592,85)"), left{}(), format{}("%1 %c<=Set%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.le"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1532,19,1532,82)"), left{}(), format{}("%1 %c<=String%r %2"), function{}()]
+  symbol Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(SortAExp{}, SortAExp{}) : SortBExp{} [latex{}("{#1}\\leq{#2}"), functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}()), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), left{}(), format{}("%1 %c<=%r %2"), colors{}("pink"), injective{}(), seqstrict{}()]
+  hooked-symbol Lbl'Unds-LT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{<_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("<"), right{}(), terminals{}("010"), klabel{}("_<Int_"), hook{}("INT.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1004,19,1004,171)"), left{}(Lbl'Unds-LT-'Int'Unds'{}()), format{}("%1 %c<Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.lt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1531,19,1531,82)"), left{}(), format{}("%1 %c<String%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Bool_"), hook{}("BOOL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(827,19,827,132)"), left{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}()), format{}("%1 %c=/=Bool%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{/}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=Int_"), hook{}("INT.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1008,19,1008,188)"), left{}(Lbl'UndsEqlsSlshEqls'Int'Unds'{}()), format{}("%1 %c=/=Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{\\neq_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), notEqualEqualK{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("distinct"), right{}(), terminals{}("010"), klabel{}("_=/=K_"), hook{}("KEQUAL.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2044,19,2044,170)"), left{}(Lbl'UndsEqlsEqls'K'Unds'{}(),Lbl'UndsEqlsSlshEqls'K'Unds'{}()), format{}("%1 %c=/=K%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ne"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1528,19,1528,94)"), left{}(Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c=/=String%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Bool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Bool_"), hook{}("BOOL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(826,19,826,124)"), left{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), format{}("%1 %c==Bool%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{{=}{=}_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}("="), right{}(), terminals{}("010"), klabel{}("_==Int_"), hook{}("INT.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1007,19,1007,177)"), left{}(Lbl'UndsEqlsEqls'Int'Unds'{}()), format{}("%1 %c==Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'K'Unds'{}(SortK{}, SortK{}) : SortBool{} [latex{}("{#1}\\mathrel{=_K}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),LblnotBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("="), right{}(), terminals{}("010"), equalEqualK{}(), klabel{}("_==K_"), hook{}("KEQUAL.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2043,19,2043,156)"), left{}(Lbl'UndsEqlsSlshEqls'K'Unds'{}(),Lbl'UndsEqlsEqls'K'Unds'{}()), format{}("%1 %c==K%r %2"), function{}()]
+  hooked-symbol Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.eq"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1527,19,1527,88)"), left{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}()), format{}("%1 %c==String%r %2"), function{}()]
+  symbol Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(SortId{}, SortAExp{}) : SortStmt{} [functional{}(), constructor{}(), strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("0101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), left{}(), format{}("%1 %c=%r %2%c;%r"), colors{}("pink,pink"), injective{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{\\geq_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">="), right{}(), terminals{}("010"), klabel{}("_>=Int_"), hook{}("INT.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1005,19,1005,176)"), left{}(Lbl'Unds-GT-Eqls'Int'Unds'{}()), format{}("%1 %c>=Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.ge"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1534,19,1534,82)"), left{}(), format{}("%1 %c>=String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT--GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\gg_{\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("shrInt"), terminals{}("010"), klabel{}("_>>Int_"), hook{}("INT.shr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(944,18,944,172)"), left{}(Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}()), format{}("%1 %c>>Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-'Int'Unds'{}(SortInt{}, SortInt{}) : SortBool{} [latex{}("{#1}\\mathrel{>_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), smt-hook{}(">"), right{}(), terminals{}("010"), klabel{}("_>Int_"), hook{}("INT.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1006,19,1006,171)"), left{}(Lbl'Unds-GT-'Int'Unds'{}()), format{}("%1 %c>Int%r %2"), function{}()]
+  hooked-symbol Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("STRING.gt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1533,19,1533,82)"), left{}(), format{}("%1 %c>String%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'List'Unds'{}(SortList{}, SortList{}) : SortList{} [unit{}(Lbl'Stop'List{}()), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblListItem{}()), symbol'Kywd'{}(), priorities{}(), right{}(), assoc{}(), smtlib{}("smt_seq_concat"), terminals{}("00"), klabel{}("_List_"), hook{}("LIST.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(647,19,647,192)"), left{}(Lbl'Unds'List'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'Unds'Map'Unds'{}(SortMap{}, SortMap{}) : SortMap{} [unit{}(Lbl'Stop'Map{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(Lbl'UndsPipe'-'-GT-Unds'{}()), symbol'Kywd'{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), index{}("0"), klabel{}("_Map_"), hook{}("MAP.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(249,18,249,172)"), left{}(Lbl'Unds'Map'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'Unds'Set'Unds'{}(SortSet{}, SortSet{}) : SortSet{} [unit{}(Lbl'Stop'Set{}()), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), element{}(LblSetItem{}()), symbol'Kywd'{}(), idem{}(), comm{}(), priorities{}(), right{}(), assoc{}(), terminals{}("00"), klabel{}("_Set_"), hook{}("SET.concat"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(527,18,527,176)"), left{}(Lbl'Unds'Set'Unds'{}()), format{}("%1%n%2"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-'UndsRSqBUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010101"), klabel{}("List:set"), hook{}("LIST.update"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(683,19,683,107)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %3 %c]%r"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUnds-LT-'-undef'RSqB'{}(SortMap{}, SortKItem{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), terminals{}("010111"), klabel{}("_[_<-undef]"), hook{}("MAP.remove"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(308,18,308,121)"), left{}(), format{}("%1 %c[%r %2 %c<-%r %cundef%r %c]%r"), function{}()]
+  hooked-symbol Lbl'UndsLSqBUndsRSqB'orDefault'UndsUnds'MAP'Unds'KItem'Unds'Map'Unds'KItem'Unds'KItem{}(SortMap{}, SortKItem{}, SortKItem{}) : SortKItem{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010110"), klabel{}("Map:lookupOrDefault"), hook{}("MAP.lookupOrDefault"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(290,20,290,138)"), left{}(), format{}("%1 %c[%r %2 %c]%r %corDefault%r %3"), function{}()]
+  hooked-symbol Lbl'UndsXor-Perc'Int'UndsUnds'{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("(mod (^ #1 #2) #3)"), right{}(), terminals{}("0100"), klabel{}("_^%Int__"), hook{}("INT.powmod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(930,18,930,138)"), left{}(Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'UndsXor-'Int'Unds'{}()), format{}("%1 %c^%%Int%r %2 %3"), function{}()]
+  hooked-symbol Lbl'UndsXor-'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{{\\char`\\^}_{\\!\\scriptstyle\\it Int}}{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("^"), right{}(), terminals{}("010"), klabel{}("_^Int_"), hook{}("INT.pow"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(929,18,929,177)"), left{}(Lbl'UndsXor-'Int'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}()), format{}("%1 %c^Int%r %2"), function{}()]
+  symbol Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(SortStmt{}, SortStmt{}) : SortStmt{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("00"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(45,20,45,68)"), left{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), format{}("%1%n%2"), injective{}()]
+  hooked-symbol Lbl'Unds'andBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\wedge_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andBool_"), hook{}("BOOL.and"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(819,19,819,189)"), left{}(Lbl'Unds'andBool'Unds'{}()), format{}("%1 %candBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'andThenBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("and"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_andThenBool_"), hook{}("BOOL.andThen"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(820,19,820,151)"), left{}(Lbl'Unds'andThenBool'Unds'{}()), format{}("%1 %candThenBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'divInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("div"), right{}(), terminals{}("010"), klabel{}("_divInt_"), hook{}("INT.ediv"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(938,18,938,121)"), left{}(Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}()), format{}("%1 %cdivInt%r %2"), function{}()]
+  symbol Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortBool{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1017,19,1017,52)"), left{}(), format{}("%1 %cdividesInt%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'impliesBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("=>"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_impliesBool_"), hook{}("BOOL.implies"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(824,19,824,150)"), left{}(Lbl'Unds'impliesBool'Unds'{}()), format{}("%1 %cimpliesBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(SortKItem{}, SortList{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), klabel{}("_inList_"), hook{}("LIST.in"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(730,19,730,101)"), left{}(), format{}("%1 %cin%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(SortKItem{}, SortMap{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("01101"), hook{}("MAP.in_keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(366,19,366,93)"), left{}(), format{}("%1 %cin_keys%r %c(%r %2 %c)%r"), function{}()]
+  hooked-symbol Lbl'Unds'modInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'-Int'Unds'{}()), smt-hook{}("mod"), right{}(), terminals{}("010"), klabel{}("_modInt_"), hook{}("INT.emod"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(939,18,939,121)"), left{}(Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}()), format{}("%1 %cmodInt%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'orBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [latex{}("{#1}\\vee_{\\scriptstyle\\it Bool}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orBool_"), hook{}("BOOL.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(822,19,822,184)"), left{}(Lbl'Unds'orBool'Unds'{}()), format{}("%1 %corBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'orElseBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("or"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_orElseBool_"), hook{}("BOOL.orElse"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(823,19,823,148)"), left{}(Lbl'Unds'orElseBool'Unds'{}()), format{}("%1 %corElseBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'xorBool'Unds'{}(SortBool{}, SortBool{}) : SortBool{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}()), smt-hook{}("xor"), boolOperation{}(), right{}(), terminals{}("010"), klabel{}("_xorBool_"), hook{}("BOOL.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(821,19,821,143)"), left{}(Lbl'Unds'xorBool'Unds'{}()), format{}("%1 %cxorBool%r %2"), function{}()]
+  hooked-symbol Lbl'Unds'xorInt'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{\\oplus_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPipe'Int'Unds'{}()), right{}(), smtlib{}("xorInt"), terminals{}("010"), klabel{}("_xorInt_"), hook{}("INT.xor"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(949,18,949,188)"), left{}(Lbl'Unds'xorInt'Unds'{}()), format{}("%1 %cxorInt%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPipe'-'-GT-Unds'{}(SortKItem{}, SortKItem{}) : SortMap{} [latex{}("{#1}\\mapsto{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Stop'Map{}(),Lbl'Unds'Map'Unds'{}()), right{}(Lbl'UndsPipe'-'-GT-Unds'{}()), terminals{}("010"), klabel{}("_|->_"), hook{}("MAP.element"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(266,18,266,144)"), left{}(Lbl'UndsPipe'-'-GT-Unds'{}()), format{}("%1 %c|->%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPipe'Int'Unds'{}(SortInt{}, SortInt{}) : SortInt{} [latex{}("{#1}\\mathrel{|_{\\scriptstyle\\it Int}}{#2}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(), right{}(), smtlib{}("orInt"), terminals{}("010"), klabel{}("_|Int_"), hook{}("INT.or"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(951,18,951,179)"), left{}(Lbl'UndsPipe'Int'Unds'{}()), format{}("%1 %c|Int%r %2"), function{}()]
+  hooked-symbol Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("010"), hook{}("SET.union"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(554,18,554,88)"), left{}(Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}()), format{}("%1 %c|Set%r %2"), function{}()]
+  hooked-symbol LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), smt-hook{}("(ite (< #1 0) (- 0 #1) #1)"), right{}(), terminals{}("1101"), klabel{}("absInt"), hook{}("INT.abs"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(968,18,968,123)"), left{}(), format{}("%cabsInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("bitRangeInt"), hook{}("INT.bitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(993,18,993,102)"), left{}(), format{}("%cbitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblcategoryChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("categoryChar"), hook{}("STRING.category"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1544,21,1544,80)"), left{}(), format{}("%ccategoryChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'MAP'Unds'KItem'Unds'Map{}(SortMap{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Map:choice"), hook{}("MAP.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(402,20,402,100)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblchoice'LParUndsRParUnds'SET'Unds'KItem'Unds'Set{}(SortSet{}) : SortKItem{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("Set:choice"), hook{}("SET.choice"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(610,20,610,94)"), left{}(), format{}("%cchoice%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblchrChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("chrChar"), hook{}("STRING.chr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1404,21,1404,69)"), left{}(), format{}("%cchrChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(SortString{}, SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), hook{}("STRING.countAllOccurrences"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1517,18,1517,150)"), left{}(), format{}("%ccountAllOccurrences%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LbldirectionalityChar'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'String{}(SortString{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("directionalityChar"), hook{}("STRING.directionality"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1545,21,1545,86)"), left{}(), format{}("%cdirectionalityChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblfillList'LParUndsCommUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'Int'Unds'KItem{}(SortList{}, SortInt{}, SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101"), klabel{}("fillList"), hook{}("LIST.fill"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(711,19,711,99)"), left{}(), format{}("%cfillList%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
+  hooked-symbol LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findChar"), hook{}("STRING.findChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1441,18,1441,115)"), left{}(), format{}("%cfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("findString"), hook{}("STRING.find"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1430,18,1430,110)"), left{}(), format{}("%cfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  symbol LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(SortInt{}) : SortId{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshId"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2006,17,2006,70)"), left{}(), format{}("%cfreshId%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), freshGenerator{}(), klabel{}("freshInt"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1119,18,1119,72)"), left{}(), format{}("%cfreshInt%r %c(%r %1 %c)%r"), function{}()]
   symbol LblgetGeneratedCounterCell{}(SortGeneratedTopCell{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cgetGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(SortBExp{}, SortBlock{}, SortBlock{}) : SortStmt{} [functional{}(), constructor{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("1101010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), left{}(), format{}("%cif%r %c(%r%1%c)%r %2 %celse%r %3"), colors{}("yellow, white, white, yellow"), injective{}()]
+  symbol Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(SortBExp{}, SortBlock{}, SortBlock{}) : SortStmt{} [functional{}(), constructor{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("1101010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), left{}(), format{}("%cif%r %c(%r%1%c)%r %2 %celse%r %3"), colors{}("yellow, white, white, yellow"), injective{}()]
   symbol LblinitGeneratedCounterCell{}() : SortGeneratedCounterCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1"), left{}(), initializer{}(), format{}("%cinitGeneratedCounterCell%r"), function{}()]
   symbol LblinitGeneratedTopCell{}(SortMap{}) : SortGeneratedTopCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
   symbol LblinitKCell{}(SortMap{}) : SortKCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitKCell%r %c(%r %1 %c)%r"), function{}()]
   symbol LblinitStateCell{}() : SortStateCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1"), left{}(), initializer{}(), format{}("%cinitStateCell%r"), function{}()]
   symbol LblinitTCell{}(SortMap{}) : SortTCell{} [noThread{}(), priorities{}(), right{}(), terminals{}("1101"), left{}(), initializer{}(), format{}("%cinitTCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(SortIds{}, SortStmt{}) : SortPgm{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("1010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(53,18,53,88)"), left{}(), format{}("%cint%r %1%c;%r%n%2"), colors{}("yellow,pink"), injective{}()]
-  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(229,18,229,88)"), left{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  symbol LblisAExp{}(SortK{}) : SortBool{} [predicate{}("AExp"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisAExp%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisBExp{}(SortK{}) : SortBool{} [predicate{}("BExp"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBExp%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisBlock{}(SortK{}) : SortBool{} [predicate{}("Block"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBlock%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisBool{}(SortK{}) : SortBool{} [predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBool%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisCell{}(SortK{}) : SortBool{} [predicate{}("Cell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisFloat{}(SortK{}) : SortBool{} [predicate{}("Float"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisFloat%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisIOError{}(SortK{}) : SortBool{} [predicate{}("IOError"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOError%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisIOFile{}(SortK{}) : SortBool{} [predicate{}("IOFile"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOFile%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisIOInt{}(SortK{}) : SortBool{} [predicate{}("IOInt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOInt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisIOString{}(SortK{}) : SortBool{} [predicate{}("IOString"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOString%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisId{}(SortK{}) : SortBool{} [predicate{}("Id"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisId%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisIds{}(SortK{}) : SortBool{} [predicate{}("Ids"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIds%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisInt{}(SortK{}) : SortBool{} [predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisInt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisK{}(SortK{}) : SortBool{} [predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisK%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKCell{}(SortK{}) : SortBool{} [predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKItem{}(SortK{}) : SortBool{} [predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisKResult{}(SortK{}) : SortBool{} [predicate{}("KResult"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKResult%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisList{}(SortK{}) : SortBool{} [predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisList%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisMap{}(SortK{}) : SortBool{} [predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisMap%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisPgm{}(SortK{}) : SortBool{} [predicate{}("Pgm"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisPgm%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisSet{}(SortK{}) : SortBool{} [predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisSet%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisStateCell{}(SortK{}) : SortBool{} [predicate{}("StateCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStateCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisStateCellOpt{}(SortK{}) : SortBool{} [predicate{}("StateCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStateCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisStmt{}(SortK{}) : SortBool{} [predicate{}("Stmt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStmt%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisStream{}(SortK{}) : SortBool{} [predicate{}("Stream"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStream%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisString{}(SortK{}) : SortBool{} [predicate{}("String"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisString%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisTCell{}(SortK{}) : SortBool{} [predicate{}("TCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCell%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisTCellFragment{}(SortK{}) : SortBool{} [predicate{}("TCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCellFragment%r %c(%r %1 %c)%r"), function{}()]
-  symbol LblisTCellOpt{}(SortK{}) : SortBool{} [predicate{}("TCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(143,18,143,86)"), left{}(), format{}("%ckeys%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(144,19,144,79)"), left{}(), format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("lengthString"), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(619,18,619,84)"), left{}(), format{}("%clengthString%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(422,18,422,74)"), left{}(), format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(298,19,298,81)"), left{}(), format{}("%cmakeList%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), right{}(), terminals{}("110101"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(420,18,420,118)"), left{}(), format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), right{}(), terminals{}("110101"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(419,18,419,118)"), left{}(), format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1"), impure{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(654,21,654,67)"), left{}(), format{}("%cnewUUID%r"), function{}()]
+  symbol Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(SortIds{}, SortStmt{}) : SortPgm{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("1010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(53,18,53,88)"), left{}(), format{}("%cint%r %1%c;%r%n%2"), colors{}("yellow,pink"), injective{}()]
+  hooked-symbol LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(SortSet{}, SortSet{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("intersectSet"), hook{}("SET.intersection"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(565,18,565,88)"), left{}(), format{}("%cintersectSet%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  symbol LblisAExp{}(SortK{}) : SortBool{} [functional{}(), predicate{}("AExp"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisAExp%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisBExp{}(SortK{}) : SortBool{} [functional{}(), predicate{}("BExp"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBExp%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisBlock{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Block"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBlock%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisBool{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Bool"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisBool%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisFloat{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Float"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisFloat%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedCounterCell{}(SortK{}) : SortBool{} [functional{}(), predicate{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedCounterCellOpt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("GeneratedCounterCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedTopCell{}(SortK{}) : SortBool{} [functional{}(), predicate{}("GeneratedTopCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisGeneratedTopCellFragment{}(SortK{}) : SortBool{} [functional{}(), predicate{}("GeneratedTopCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisGeneratedTopCellFragment%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOError{}(SortK{}) : SortBool{} [functional{}(), predicate{}("IOError"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOError%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOFile{}(SortK{}) : SortBool{} [functional{}(), predicate{}("IOFile"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOFile%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOInt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("IOInt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIOString{}(SortK{}) : SortBool{} [functional{}(), predicate{}("IOString"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIOString%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisId{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Id"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisId%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisIds{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Ids"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisIds%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisInt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Int"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisInt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisK{}(SortK{}) : SortBool{} [functional{}(), predicate{}("K"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisK%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKCell{}(SortK{}) : SortBool{} [functional{}(), predicate{}("KCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKCellOpt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("KCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKConfigVar{}(SortK{}) : SortBool{} [functional{}(), predicate{}("KConfigVar"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKConfigVar%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKItem{}(SortK{}) : SortBool{} [functional{}(), predicate{}("KItem"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKItem%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisKResult{}(SortK{}) : SortBool{} [functional{}(), predicate{}("KResult"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisKResult%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisList{}(SortK{}) : SortBool{} [functional{}(), predicate{}("List"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisList%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisMap{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Map"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisMap%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisPgm{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Pgm"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisPgm%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisSet{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Set"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisSet%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisStateCell{}(SortK{}) : SortBool{} [functional{}(), predicate{}("StateCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStateCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisStateCellOpt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("StateCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStateCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisStmt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Stmt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStmt%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisStream{}(SortK{}) : SortBool{} [functional{}(), predicate{}("Stream"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisStream%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisString{}(SortK{}) : SortBool{} [functional{}(), predicate{}("String"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisString%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisTCell{}(SortK{}) : SortBool{} [functional{}(), predicate{}("TCell"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCell%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisTCellFragment{}(SortK{}) : SortBool{} [functional{}(), predicate{}("TCellFragment"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCellFragment%r %c(%r %1 %c)%r"), function{}()]
+  symbol LblisTCellOpt{}(SortK{}) : SortBool{} [functional{}(), predicate{}("TCellOpt"), priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cisTCellOpt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(SortMap{}) : SortSet{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("keys"), hook{}("MAP.keys"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(350,18,350,86)"), left{}(), format{}("%ckeys%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblkeys'Unds'list'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), hook{}("MAP.keys_list"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,19,358,79)"), left{}(), format{}("%ckeys_list%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("lengthString"), hook{}("STRING.length"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1395,18,1395,84)"), left{}(), format{}("%clengthString%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lbllog2Int'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("log2Int"), hook{}("INT.log2"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(979,18,979,74)"), left{}(), format{}("%clog2Int%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblmakeList'LParUndsCommUndsRParUnds'LIST'Unds'List'Unds'Int'Unds'KItem{}(SortInt{}, SortKItem{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("makeList"), hook{}("LIST.make"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(692,19,692,81)"), left{}(), format{}("%cmakeList%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), smt-hook{}("(ite (< #1 #2) #2 #1)"), right{}(), terminals{}("110101"), hook{}("INT.max"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(960,18,960,118)"), left{}(), format{}("%cmaxInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), smt-hook{}("(ite (< #1 #2) #1 #2)"), right{}(), terminals{}("110101"), hook{}("INT.min"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(959,18,959,118)"), left{}(), format{}("%cminInt%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol LblnewUUID'Unds'STRING-COMMON'Unds'String{}() : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1"), impure{}(), hook{}("STRING.uuid"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1547,21,1547,67)"), left{}(), format{}("%cnewUUID%r"), function{}()]
   symbol LblnoGeneratedCounterCell{}() : SortGeneratedCounterCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("GeneratedCounterCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoGeneratedCounterCell%r"), injective{}()]
   symbol LblnoKCell{}() : SortKCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("KCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoKCell%r"), injective{}()]
   symbol LblnoStateCell{}() : SortStateCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("StateCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoStateCell%r"), injective{}()]
   symbol LblnoTCell{}() : SortTCellOpt{} [functional{}(), constructor{}(), cellOptAbsent{}("TCell"), priorities{}(), right{}(), terminals{}("1"), left{}(), format{}("%cnoTCell%r"), injective{}()]
-  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}(),Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}()), smt-hook{}("not"), boolOperation{}(), right{}(), terminals{}("10"), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,19,333,176)"), left{}(), format{}("%cnotBool%r %1"), function{}()]
-  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("ordChar"), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(621,18,621,69)"), left{}(), format{}("%cordChar%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblnotBool'Unds'{}(SortBool{}) : SortBool{} [latex{}("\\neg_{\\scriptstyle\\it Bool}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'Unds'orElseBool'Unds'{}(),Lbl'Unds'orBool'Unds'{}(),Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(),Lbl'Unds'andThenBool'Unds'{}(),Lbl'Unds'impliesBool'Unds'{}(),Lbl'UndsEqlsEqls'Bool'Unds'{}(),Lbl'Unds'andBool'Unds'{}(),Lbl'Unds'xorBool'Unds'{}()), smt-hook{}("not"), boolOperation{}(), right{}(), terminals{}("10"), klabel{}("notBool_"), hook{}("BOOL.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(818,19,818,176)"), left{}(), format{}("%cnotBool%r %1"), function{}()]
+  hooked-symbol LblordChar'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(SortString{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("ordChar"), hook{}("STRING.ord"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1405,18,1405,69)"), left{}(), format{}("%cordChar%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'ColnHash'tempFile'Coln'fd{}(SortIOFile{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cfd%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'ColnHash'tempFile'Coln'path{}(SortIOFile{}) : SortString{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cpath%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'ColnHash'unknownIOError'Coln'errno{}(SortIOError{}) : SortInt{} [priorities{}(), right{}(), terminals{}("1101"), left{}(), format{}("%cerrno%r %c(%r %1 %c)%r"), function{}()]
@@ -373,7 +374,6 @@ module IMP
   symbol Lblproject'Coln'BExp{}(SortK{}) : SortBExp{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:BExp%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'Block{}(SortK{}) : SortBlock{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Block%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'Bool{}(SortK{}) : SortBool{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Bool%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblproject'Coln'Cell{}(SortK{}) : SortCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Cell%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'Float{}(SortK{}) : SortFloat{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:Float%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'GeneratedCounterCell{}(SortK{}) : SortGeneratedCounterCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCell%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'GeneratedCounterCellOpt{}(SortK{}) : SortGeneratedCounterCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:GeneratedCounterCellOpt%r %c(%r %1 %c)%r"), function{}()]
@@ -403,29 +403,28 @@ module IMP
   symbol Lblproject'Coln'TCell{}(SortK{}) : SortTCell{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:TCell%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'TCellFragment{}(SortK{}) : SortTCellFragment{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:TCellFragment%r %c(%r %1 %c)%r"), function{}()]
   symbol Lblproject'Coln'TCellOpt{}(SortK{}) : SortTCellOpt{} [priorities{}(), right{}(), terminals{}("1101"), projection{}(), left{}(), format{}("%cproject:TCellOpt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblrandInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(520,18,520,56)"), left{}(), format{}("%crandInt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,18,140,91)"), left{}(), format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101010101"), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(639,21,639,145)"), left{}(), format{}("%creplace%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
-  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(638,21,638,153)"), left{}(), format{}("%creplaceAll%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(640,21,640,155)"), left{}(), format{}("%creplaceFirst%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindChar"), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(627,18,627,116)"), left{}(), format{}("%crfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindString"), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(625,18,625,111)"), left{}(), format{}("%crfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(425,18,425,112)"), left{}(), format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(311,18,311,121)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(152,18,152,103)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(241,18,241,80)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(521,16,521,56)"), left{}(), format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}()]
-  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("substrString"), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(623,21,623,121)"), left{}(), format{}("%csubstrString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(300,19,300,96)"), left{}(), format{}("%cupdateList%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
-  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(137,18,137,91)"), left{}(), format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
-  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(149,19,149,76)"), left{}(), format{}("%cvalues%r %c(%r %1 %c)%r"), function{}()]
-  symbol Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(SortBExp{}, SortBlock{}) : SortStmt{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("11010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(44,20,44,96)"), left{}(), format{}("%cwhile%r %c(%r%1%c)%r %2"), colors{}("yellow,white,white"), injective{}()]
-  symbol Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(SortStmt{}) : SortBlock{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(39,20,39,70)"), left{}(), format{}("%c{%r%i%n%1%d%n%c}%r"), injective{}()]
-  symbol Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}() : SortBlock{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), priorities{}(), right{}(), terminals{}("11"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(38,20,38,26)"), left{}(), format{}("%c{%r %c}%r"), injective{}()]
-  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), terminals{}("10"), klabel{}("~Int_"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(393,18,393,172)"), left{}(), format{}("%c~Int%r %1"), function{}()]
+  hooked-symbol LblrandInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("randInt"), hook{}("INT.rand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1122,18,1122,64)"), left{}(), format{}("%crandInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblremoveAll'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Set{}(SortMap{}, SortSet{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("removeAll"), hook{}("MAP.removeAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(342,18,342,91)"), left{}(), format{}("%cremoveAll%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortString{}, SortInt{}) : SortString{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101010101"), hook{}("STRING.replace"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1515,21,1515,145)"), left{}(), format{}("%creplace%r %c(%r %1 %c,%r %2 %c,%r %3 %c,%r %4 %c)%r"), function{}()]
+  hooked-symbol LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1514,21,1514,153)"), left{}(), format{}("%creplaceAll%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(SortString{}, SortString{}, SortString{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), hook{}("STRING.replaceFirst"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1516,21,1516,155)"), left{}(), format{}("%creplaceFirst%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindChar"), hook{}("STRING.rfindChar"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1442,18,1442,116)"), left{}(), format{}("%crfindChar%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(SortString{}, SortString{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("rfindString"), hook{}("STRING.rfind"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1431,18,1431,111)"), left{}(), format{}("%crfindString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(SortInt{}, SortInt{}, SortInt{}) : SortInt{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("signExtendBitRangeInt"), hook{}("INT.signExtendBitRange"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(994,18,994,112)"), left{}(), format{}("%csignExtendBitRangeInt%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'LIST'Unds'Int'Unds'List{}(SortList{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), smtlib{}("smt_seq_len"), terminals{}("1101"), klabel{}("sizeList"), hook{}("LIST.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(738,18,738,121)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'MAP'Unds'Int'Unds'Map{}(SortMap{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("sizeMap"), hook{}("MAP.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(382,18,382,103)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol Lblsize'LParUndsRParUnds'SET'Unds'Int'Unds'Set{}(SortSet{}) : SortInt{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("size"), hook{}("SET.size"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(600,18,600,80)"), left{}(), format{}("%csize%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblsrandInt'LParUndsRParUnds'INT'Unds'K'Unds'Int{}(SortInt{}) : SortK{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), impure{}(), klabel{}("srandInt"), hook{}("INT.srand"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1123,16,1123,64)"), left{}(), format{}("%csrandInt%r %c(%r %1 %c)%r"), function{}()]
+  hooked-symbol LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(SortString{}, SortInt{}, SortInt{}) : SortString{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("substrString"), hook{}("STRING.substr"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1420,21,1420,121)"), left{}(), format{}("%csubstrString%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblupdateList'LParUndsCommUndsCommUndsRParUnds'LIST'Unds'List'Unds'List'Unds'Int'Unds'List{}(SortList{}, SortInt{}, SortList{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("11010101"), klabel{}("updateList"), hook{}("LIST.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(702,19,702,96)"), left{}(), format{}("%cupdateList%r %c(%r %1 %c,%r %2 %c,%r %3 %c)%r"), function{}()]
+  hooked-symbol LblupdateMap'LParUndsCommUndsRParUnds'MAP'Unds'Map'Unds'Map'Unds'Map{}(SortMap{}, SortMap{}) : SortMap{} [functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("110101"), klabel{}("updateMap"), hook{}("MAP.updateAll"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(333,18,333,91)"), left{}(), format{}("%cupdateMap%r %c(%r %1 %c,%r %2 %c)%r"), function{}()]
+  hooked-symbol Lblvalues'LParUndsRParUnds'MAP'Unds'List'Unds'Map{}(SortMap{}) : SortList{} [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), priorities{}(), right{}(), terminals{}("1101"), klabel{}("values"), hook{}("MAP.values"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(374,19,374,76)"), left{}(), format{}("%cvalues%r %c(%r %1 %c)%r"), function{}()]
+  symbol Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(SortBExp{}, SortBlock{}) : SortStmt{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}()), right{}(), terminals{}("11010"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(44,20,44,96)"), left{}(), format{}("%cwhile%r %c(%r%1%c)%r %2"), colors{}("yellow,white,white"), injective{}()]
+  symbol Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(SortStmt{}) : SortBlock{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("101"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(39,20,39,70)"), left{}(), format{}("%c{%r%i%n%1%d%n%c}%r"), injective{}()]
+  symbol Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}() : SortBlock{} [functional{}(), constructor{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), priorities{}(), right{}(), terminals{}("11"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(38,20,38,26)"), left{}(), format{}("%c{%r %c}%r"), injective{}()]
+  hooked-symbol Lbl'Tild'Int'Unds'{}(SortInt{}) : SortInt{} [latex{}("\\mathop{\\sim_{\\scriptstyle\\it Int}}{#1}"), functional{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), symbol'Kywd'{}(), priorities{}(Lbl'UndsPlus'Int'Unds'{}(),Lbl'Unds'divInt'Unds'{}(),Lbl'UndsPerc'Int'Unds'{}(),Lbl'Unds-GT--GT-'Int'Unds'{}(),Lbl'Unds'xorInt'Unds'{}(),Lbl'UndsSlsh'Int'Unds'{}(),Lbl'UndsAnd-'Int'Unds'{}(),Lbl'UndsXor-'Int'Unds'{}(),Lbl'Unds-LT--LT-'Int'Unds'{}(),Lbl'UndsStar'Int'Unds'{}(),Lbl'UndsPipe'Int'Unds'{}(),Lbl'Unds'modInt'Unds'{}(),Lbl'UndsXor-Perc'Int'UndsUnds'{}(),Lbl'Unds'-Int'Unds'{}()), right{}(), smtlib{}("notInt"), terminals{}("10"), klabel{}("~Int_"), hook{}("INT.not"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(927,18,927,172)"), left{}(), format{}("%c~Int%r %1"), function{}()]
 
 // generated axioms
-  axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortCell{}, SortKItem{}} (From:SortCell{}))) [subsort{SortCell{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOString{}, SortKItem{}} (From:SortIOString{}))) [subsort{SortIOString{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortString{}, SortKItem{}} (From:SortString{}))) [subsort{SortString{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKResult{}, \equals{SortKResult{}, R} (Val:SortKResult{}, inj{SortInt{}, SortKResult{}} (From:SortInt{}))) [subsort{SortInt{}, SortKResult{}}()] // subsort
@@ -450,14 +449,12 @@ module IMP
   axiom{R} \exists{R} (Val:SortTCellOpt{}, \equals{SortTCellOpt{}, R} (Val:SortTCellOpt{}, inj{SortTCell{}, SortTCellOpt{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortTCellOpt{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortTCellFragment{}, SortKItem{}} (From:SortTCellFragment{}))) [subsort{SortTCellFragment{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortStateCellOpt{}, \equals{SortStateCellOpt{}, R} (Val:SortStateCellOpt{}, inj{SortStateCell{}, SortStateCellOpt{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortStateCellOpt{}}()] // subsort
-  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortTCell{}, SortCell{}} (From:SortTCell{}))) [subsort{SortTCell{}, SortCell{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStream{}, SortKItem{}} (From:SortStream{}))) [subsort{SortStream{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOFile{}, SortKItem{}} (From:SortIOFile{}))) [subsort{SortIOFile{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCell{}, SortKItem{}} (From:SortGeneratedTopCell{}))) [subsort{SortGeneratedTopCell{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortAExp{}, \equals{SortAExp{}, R} (Val:SortAExp{}, inj{SortInt{}, SortAExp{}} (From:SortInt{}))) [subsort{SortInt{}, SortAExp{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortIOInt{}, SortKItem{}} (From:SortIOInt{}))) [subsort{SortIOInt{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortList{}, SortKItem{}} (From:SortList{}))) [subsort{SortList{}, SortKItem{}}()] // subsort
-  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortStateCell{}, SortCell{}} (From:SortStateCell{}))) [subsort{SortStateCell{}, SortCell{}}()] // subsort
   axiom{R} \exists{R} (Val:SortIOString{}, \equals{SortIOString{}, R} (Val:SortIOString{}, inj{SortString{}, SortIOString{}} (From:SortString{}))) [subsort{SortString{}, SortIOString{}}()] // subsort
   axiom{R} \exists{R} (Val:SortStmt{}, \equals{SortStmt{}, R} (Val:SortStmt{}, inj{SortBlock{}, SortStmt{}} (From:SortBlock{}))) [subsort{SortBlock{}, SortStmt{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortId{}, SortKItem{}} (From:SortId{}))) [subsort{SortId{}, SortKItem{}}()] // subsort
@@ -465,7 +462,6 @@ module IMP
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortBool{}, SortKItem{}} (From:SortBool{}))) [subsort{SortBool{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortAExp{}, \equals{SortAExp{}, R} (Val:SortAExp{}, inj{SortId{}, SortAExp{}} (From:SortId{}))) [subsort{SortId{}, SortAExp{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortStateCellOpt{}, SortKItem{}} (From:SortStateCellOpt{}))) [subsort{SortStateCellOpt{}, SortKItem{}}()] // subsort
-  axiom{R} \exists{R} (Val:SortCell{}, \equals{SortCell{}, R} (Val:SortCell{}, inj{SortKCell{}, SortCell{}} (From:SortKCell{}))) [subsort{SortKCell{}, SortCell{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortInt{}, SortKItem{}} (From:SortInt{}))) [subsort{SortInt{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (From:SortGeneratedTopCellFragment{}))) [subsort{SortGeneratedTopCellFragment{}, SortKItem{}}()] // subsort
   axiom{R} \exists{R} (Val:SortKItem{}, \equals{SortKItem{}, R} (Val:SortKItem{}, inj{SortPgm{}, SortKItem{}} (From:SortPgm{}))) [subsort{SortPgm{}, SortKItem{}}()] // subsort
@@ -3074,6 +3070,7 @@ module IMP
   axiom{}\implies{SortKCell{}} (\and{SortKCell{}} (Lbl'-LT-'k'-GT-'{}(X0:SortK{}), Lbl'-LT-'k'-GT-'{}(Y0:SortK{})), Lbl'-LT-'k'-GT-'{}(\and{SortK{}} (X0:SortK{}, Y0:SortK{}))) [constructor{}()] // no confusion same constructor
   axiom{R} \exists{R} (Val:SortStateCell{}, \equals{SortStateCell{}, R} (Val:SortStateCell{}, Lbl'-LT-'state'-GT-'{}(K0:SortMap{}))) [functional{}()] // functional
   axiom{}\implies{SortStateCell{}} (\and{SortStateCell{}} (Lbl'-LT-'state'-GT-'{}(X0:SortMap{}), Lbl'-LT-'state'-GT-'{}(Y0:SortMap{})), Lbl'-LT-'state'-GT-'{}(\and{SortMap{}} (X0:SortMap{}, Y0:SortMap{}))) [constructor{}()] // no confusion same constructor
+  axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(K0:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblFloat2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Float{}(K0:SortFloat{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblId2String'LParUndsRParUnds'ID-COMMON'Unds'String'Unds'Id{}(K0:SortId{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortString{}, \equals{SortString{}, R} (Val:SortString{}, LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
@@ -3149,12 +3146,13 @@ module IMP
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'impliesBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'UndsUnds'LIST'Unds'Bool'Unds'KItem'Unds'List{}(K0:SortKItem{}, K1:SortList{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'in'Unds'keys'LParUndsRParUnds'MAP'Unds'Bool'Unds'KItem'Unds'Map{}(K0:SortKItem{}, K1:SortMap{}))) [functional{}()] // functional
-  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'orElseBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, Lbl'Unds'xorBool'Unds'{}(K0:SortBool{}, K1:SortBool{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Unds'xorInt'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortMap{}, \equals{SortMap{}, R} (Val:SortMap{}, Lbl'UndsPipe'-'-GT-Unds'{}(K0:SortKItem{}, K1:SortKItem{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'UndsPipe'Int'Unds'{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(K0:SortString{}, K1:SortString{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortId{}, \equals{SortId{}, R} (Val:SortId{}, LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(K0:SortInt{}))) [functional{}()] // functional
@@ -3165,6 +3163,40 @@ module IMP
   axiom{R} \exists{R} (Val:SortPgm{}, \equals{SortPgm{}, R} (Val:SortPgm{}, Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(K0:SortIds{}, K1:SortStmt{}))) [functional{}()] // functional
   axiom{}\implies{SortPgm{}} (\and{SortPgm{}} (Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(X0:SortIds{}, X1:SortStmt{}), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Y0:SortIds{}, Y1:SortStmt{})), Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(\and{SortIds{}} (X0:SortIds{}, Y0:SortIds{}), \and{SortStmt{}} (X1:SortStmt{}, Y1:SortStmt{}))) [constructor{}()] // no confusion same constructor
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, LblintersectSet'LParUndsCommUndsRParUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(K0:SortSet{}, K1:SortSet{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisAExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBExp{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBlock{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisBool{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisFloat{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedCounterCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisGeneratedTopCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOError{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOFile{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIOString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisId{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisIds{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisInt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisK{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKConfigVar{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKItem{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisKResult{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisList{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisMap{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisPgm{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisSet{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStateCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStateCellOpt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStmt{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisStream{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisString{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisTCell{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisTCellFragment{}(K0:SortK{}))) [functional{}()] // functional
+  axiom{R} \exists{R} (Val:SortBool{}, \equals{SortBool{}, R} (Val:SortBool{}, LblisTCellOpt{}(K0:SortK{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortSet{}, \equals{SortSet{}, R} (Val:SortSet{}, Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(K0:SortMap{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(K0:SortString{}))) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(K0:SortInt{}, K1:SortInt{}))) [functional{}()] // functional
@@ -3189,7 +3221,7 @@ module IMP
   axiom{}\not{SortBlock{}} (\and{SortBlock{}} (Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(X0:SortStmt{}), Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())) [constructor{}()] // no confusion different constructors
   axiom{R} \exists{R} (Val:SortBlock{}, \equals{SortBlock{}, R} (Val:SortBlock{}, Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())) [functional{}()] // functional
   axiom{R} \exists{R} (Val:SortInt{}, \equals{SortInt{}, R} (Val:SortInt{}, Lbl'Tild'Int'Unds'{}(K0:SortInt{}))) [functional{}()] // functional
-  axiom{} \or{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(X0:SortK{}, X1:SortK{}))), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellOpt{}, inj{SortTCellOpt{}, SortKItem{}} (Val:SortTCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortKItem{}} (Val:SortTCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortKItem{}} (Val:SortStateCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCell{}, inj{SortTCell{}, SortKItem{}} (Val:SortTCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIds{}, inj{SortIds{}, SortKItem{}} (Val:SortIds{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBExp{}, inj{SortBExp{}, SortKItem{}} (Val:SortBExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortKItem{}} (Val:SortStateCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortCell{}, inj{SortCell{}, SortKItem{}} (Val:SortCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStmt{}, inj{SortStmt{}, SortKItem{}} (Val:SortStmt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortPgm{}, inj{SortPgm{}, SortKItem{}} (Val:SortPgm{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBlock{}, inj{SortBlock{}, SortKItem{}} (Val:SortBlock{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortAExp{}, inj{SortAExp{}, SortKItem{}} (Val:SortAExp{})), \bottom{SortKItem{}}()))))))))))))))))))))))))))))))))))))))))))) [constructor{}()] // no junk
+  axiom{} \or{SortKItem{}} (Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(X0:SortK{})), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortK{}, \exists{SortKItem{}} (X1:SortK{}, Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(X0:SortK{}, X1:SortK{}))), \or{SortKItem{}} (\exists{SortKItem{}} (X0:SortInt{}, \exists{SortKItem{}} (X1:SortString{}, \exists{SortKItem{}} (X2:SortString{}, Lbl'Hash'systemResult{}(X0:SortInt{}, X1:SortString{}, X2:SortString{})))), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortList{}, inj{SortList{}, SortKItem{}} (Val:SortList{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellOpt{}, inj{SortTCellOpt{}, SortKItem{}} (Val:SortTCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCellFragment{}, inj{SortTCellFragment{}, SortKItem{}} (Val:SortTCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortString{}, inj{SortString{}, SortKItem{}} (Val:SortString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortKItem{}} (Val:SortStateCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOInt{}, inj{SortIOInt{}, SortKItem{}} (Val:SortIOInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortTCell{}, inj{SortTCell{}, SortKItem{}} (Val:SortTCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIds{}, inj{SortIds{}, SortKItem{}} (Val:SortIds{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBExp{}, inj{SortBExp{}, SortKItem{}} (Val:SortBExp{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCellOpt{}, inj{SortGeneratedCounterCellOpt{}, SortKItem{}} (Val:SortGeneratedCounterCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStateCellOpt{}, inj{SortStateCellOpt{}, SortKItem{}} (Val:SortStateCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedCounterCell{}, inj{SortGeneratedCounterCell{}, SortKItem{}} (Val:SortGeneratedCounterCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortId{}, inj{SortId{}, SortKItem{}} (Val:SortId{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStream{}, inj{SortStream{}, SortKItem{}} (Val:SortStream{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBool{}, inj{SortBool{}, SortKItem{}} (Val:SortBool{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCell{}, inj{SortKCell{}, SortKItem{}} (Val:SortKCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOFile{}, inj{SortIOFile{}, SortKItem{}} (Val:SortIOFile{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKResult{}, inj{SortKResult{}, SortKItem{}} (Val:SortKResult{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortMap{}, inj{SortMap{}, SortKItem{}} (Val:SortMap{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortKCellOpt{}, inj{SortKCellOpt{}, SortKItem{}} (Val:SortKCellOpt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortStmt{}, inj{SortStmt{}, SortKItem{}} (Val:SortStmt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortInt{}, inj{SortInt{}, SortKItem{}} (Val:SortInt{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortFloat{}, inj{SortFloat{}, SortKItem{}} (Val:SortFloat{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCell{}, inj{SortGeneratedTopCell{}, SortKItem{}} (Val:SortGeneratedTopCell{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortPgm{}, inj{SortPgm{}, SortKItem{}} (Val:SortPgm{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortBlock{}, inj{SortBlock{}, SortKItem{}} (Val:SortBlock{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortSet{}, inj{SortSet{}, SortKItem{}} (Val:SortSet{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOString{}, inj{SortIOString{}, SortKItem{}} (Val:SortIOString{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortGeneratedTopCellFragment{}, inj{SortGeneratedTopCellFragment{}, SortKItem{}} (Val:SortGeneratedTopCellFragment{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortIOError{}, inj{SortIOError{}, SortKItem{}} (Val:SortIOError{})), \or{SortKItem{}} (\exists{SortKItem{}} (Val:SortAExp{}, inj{SortAExp{}, SortKItem{}} (Val:SortAExp{})), \bottom{SortKItem{}}())))))))))))))))))))))))))))))))))))))))))) [constructor{}()] // no junk
   axiom{} \bottom{SortList{}}() [constructor{}()] // no junk
   axiom{} \or{SortTCellOpt{}} (LblnoTCell{}(), \or{SortTCellOpt{}} (\exists{SortTCellOpt{}} (Val:SortTCell{}, inj{SortTCell{}, SortTCellOpt{}} (Val:SortTCell{})), \bottom{SortTCellOpt{}}())) [constructor{}()] // no junk
   axiom{} \or{SortTCellFragment{}} (\exists{SortTCellFragment{}} (X0:SortKCellOpt{}, \exists{SortTCellFragment{}} (X1:SortStateCellOpt{}, Lbl'-LT-'T'-GT-'-fragment{}(X0:SortKCellOpt{}, X1:SortStateCellOpt{}))), \bottom{SortTCellFragment{}}()) [constructor{}()] // no junk
@@ -3205,7 +3237,6 @@ module IMP
   axiom{} \or{SortGeneratedCounterCell{}} (\exists{SortGeneratedCounterCell{}} (X0:SortInt{}, Lbl'-LT-'generatedCounter'-GT-'{}(X0:SortInt{})), \bottom{SortGeneratedCounterCell{}}()) [constructor{}()] // no junk
   axiom{} \or{SortId{}} (\top{SortId{}}(), \bottom{SortId{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortStream{}} (\exists{SortStream{}} (X0:SortK{}, Lbl'Hash'buffer'LParUndsRParUnds'K-IO'Unds'Stream'Unds'K{}(X0:SortK{})), \bottom{SortStream{}}()) [constructor{}()] // no junk
-  axiom{} \or{SortCell{}} (\exists{SortCell{}} (Val:SortStateCell{}, inj{SortStateCell{}, SortCell{}} (Val:SortStateCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortTCell{}, inj{SortTCell{}, SortCell{}} (Val:SortTCell{})), \or{SortCell{}} (\exists{SortCell{}} (Val:SortKCell{}, inj{SortKCell{}, SortCell{}} (Val:SortKCell{})), \bottom{SortCell{}}()))) [constructor{}()] // no junk
   axiom{} \or{SortBool{}} (\top{SortBool{}}(), \bottom{SortBool{}}()) [constructor{}()] // no junk (TODO: fix bug with \dv)
   axiom{} \or{SortKCell{}} (\exists{SortKCell{}} (X0:SortK{}, Lbl'-LT-'k'-GT-'{}(X0:SortK{})), \bottom{SortKCell{}}()) [constructor{}()] // no junk
   axiom{} \bottom{SortK{}}() [constructor{}()] // no junk
@@ -3226,7 +3257,7 @@ module IMP
   axiom{} \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortInt{}, Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(X0:SortInt{})), \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortAExp{}, \exists{SortAExp{}} (X1:SortAExp{}, Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}))), \or{SortAExp{}} (\exists{SortAExp{}} (X0:SortAExp{}, \exists{SortAExp{}} (X1:SortAExp{}, Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(X0:SortAExp{}, X1:SortAExp{}))), \or{SortAExp{}} (\exists{SortAExp{}} (Val:SortId{}, inj{SortId{}, SortAExp{}} (Val:SortId{})), \or{SortAExp{}} (\exists{SortAExp{}} (Val:SortInt{}, inj{SortInt{}, SortAExp{}} (Val:SortInt{})), \bottom{SortAExp{}}()))))) [constructor{}()] // no junk
 
 // rules
-// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), contentStartColumn(8), contentStartLine(959), org.kframework.attributes.Location(Location(959,8,959,59)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,B1,_0)=>B1 requires C ensures #token("true","Bool") [UNIQUE_ID(2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2), org.kframework.attributes.Location(Location(2076,8,2076,59)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -3247,14 +3278,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortK{},R} (
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
-        VarB1:SortK{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("959"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(959,8,959,59)"), UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2")]
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+      \and{R} (
+        VarB1:SortK{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2076,8,2076,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("2b32069ac3f589174502fa507ebc88fab7c902854c0a9baa8ab09beb551232e2")]
 
-// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), contentStartColumn(8), contentStartLine(960), org.kframework.attributes.Location(Location(960,8,960,67)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{K}(C,_0,B2)=>B2 requires `notBool_`(C) ensures #token("true","Bool") [UNIQUE_ID(651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa), org.kframework.attributes.Location(Location(2077,8,2077,67)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -3275,14 +3306,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortK{},R} (
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
-        VarB2:SortK{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("960"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(960,8,960,67)"), UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa")]
+    \equals{SortK{},R} (
+      Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortK{}}(X0:SortBool{},X1:SortK{},X2:SortK{}),
+      \and{R} (
+        VarB2:SortK{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2077,8,2077,67)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("651bff3fa53d464ac7dd7aa77e1ef6071e14c959eb6df97baa325e2ad300daaa")]
 
-// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), contentStartColumn(8), contentStartLine(1098), org.kframework.attributes.Location(Location(1098,8,1098,48)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `#open(_)_K-IO_IOInt_String`(S)=>`#open(_,_)_K-IO_IOInt_String_String`(S,#token("\"r+\"","String")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9), org.kframework.attributes.Location(Location(2258,8,2258,48)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3293,552 +3324,616 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIOInt{},R} (
-        Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
-        Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+"))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("1098"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1098,8,1098,48)"), UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9")]
+    \equals{SortIOInt{},R} (
+      Lbl'Hash'open'LParUndsRParUnds'K-IO'Unds'IOInt'Unds'String{}(X0:SortString{}),
+      \and{R} (
+        Lbl'Hash'open'LParUndsCommUndsRParUnds'K-IO'Unds'IOInt'Unds'String'Unds'String{}(VarS:SortString{},\dv{SortString{}}("r+")),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2258,8,2258,48)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("7ad2779cd54b9009119458217cae5138026cc4ff244e54c28e64db21100f63d9")]
 
-// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), contentStartColumn(8), contentStartLine(1106), org.kframework.attributes.Location(Location(1106,8,1106,20)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `#stderr_K-IO_Int`(.KList)=>#token("2","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162), org.kframework.attributes.Location(Location(2355,8,2355,20)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
       
           \top{R} ()
         ),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
-        \dv{SortInt{}}("2")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("1106"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1106,8,1106,20)"), UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162")]
+    \equals{SortInt{},R} (
+      Lbl'Hash'stderr'Unds'K-IO'Unds'Int{}(),
+      \and{R} (
+        \dv{SortInt{}}("2"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2355,8,2355,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("75e0a8082acda4cf1e29caa6aaafb7f9a421e16421a41f2006943d6fab17a162")]
 
-// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), contentStartColumn(8), contentStartLine(1104), org.kframework.attributes.Location(Location(1104,8,1104,19)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `#stdin_K-IO_Int`(.KList)=>#token("0","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3), org.kframework.attributes.Location(Location(2353,8,2353,19)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
       
           \top{R} ()
         ),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
-        \dv{SortInt{}}("0")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("1104"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1104,8,1104,19)"), UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3")]
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdin'Unds'K-IO'Unds'Int{}(),
+      \and{R} (
+        \dv{SortInt{}}("0"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2353,8,2353,19)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c7ffdc9908c28a954521816d680f4e5ec44a679c7231a8dd09d4700f50b6d8c3")]
 
-// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), contentStartColumn(8), contentStartLine(1105), org.kframework.attributes.Location(Location(1105,8,1105,20)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `#stdout_K-IO_Int`(.KList)=>#token("1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c), org.kframework.attributes.Location(Location(2354,8,2354,20)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
       
           \top{R} ()
         ),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
-        \dv{SortInt{}}("1")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("1105"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,8,1105,20)"), UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c")]
+    \equals{SortInt{},R} (
+      Lbl'Hash'stdout'Unds'K-IO'Unds'Int{}(),
+      \and{R} (
+        \dv{SortInt{}}("1"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2354,8,2354,20)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4ad4f379ff9db687ff9dfd1b15052edbcd3342a2ed262ecdd38c769e177a592c")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezer!__IMP-SYNTAX_BExp_BExp0_`(.KList)~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(HOLE))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(046d60c057d139673331558d0eff1ad1f6facf0730255938ec566a001adf3afa), color(pink), cool, cool-like, org.kframework.attributes.Location(Location(35,20,35,67)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule6LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule6LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezer!__IMP-SYNTAX_BExp_BExp0_`(.KList)~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(HOLE))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(046d60c057d139673331558d0eff1ad1f6facf0730255938ec566a001adf3afa), color(pink), cool, cool-like, org.kframework.attributes.Location(Location(35,20,35,67)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule6LHS{}(SortBExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule6LHS{}(VarHOLE:SortBExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule6LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},Var'Unds'3:SortKItem{}),
+    rule6LHS{}(VarHOLE:SortBExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), UNIQUE'Unds'ID{}("046d60c057d139673331558d0eff1ad1f6facf0730255938ec566a001adf3afa")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), UNIQUE'Unds'ID{}("046d60c057d139673331558d0eff1ad1f6facf0730255938ec566a001adf3afa")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezer_&&__IMP-SYNTAX_BExp_BExp_BExp0_`(inj{BExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(8b530b30ac880d6fa64dbe1811bc5c4babea10e4c3d1ac265b3e7de95facc118), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(36,20,36,76)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(1)]
-  alias rule7LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortBExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule7LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezer_&&__IMP-SYNTAX_BExp_BExp_BExp0_`(inj{BExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(8b530b30ac880d6fa64dbe1811bc5c4babea10e4c3d1ac265b3e7de95facc118), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(37,20,37,76)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(1)]
+  alias rule7LHS{}(SortBExp{},SortBExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule7LHS{}(VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarK1:SortBExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarK1:SortBExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule7LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'3:SortKItem{}),
+    rule7LHS{}(VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), UNIQUE'Unds'ID{}("8b530b30ac880d6fa64dbe1811bc5c4babea10e4c3d1ac265b3e7de95facc118")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(37,20,37,76)"), UNIQUE'Unds'ID{}("8b530b30ac880d6fa64dbe1811bc5c4babea10e4c3d1ac265b3e7de95facc118")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(f79afd27602e94c1d3cab7c479ee62b0612347889c7941935322ede490064831), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(31,20,31,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule8LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule8LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(f79afd27602e94c1d3cab7c479ee62b0612347889c7941935322ede490064831), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(32,20,32,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule8LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule8LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule8LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule8LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), UNIQUE'Unds'ID{}("f79afd27602e94c1d3cab7c479ee62b0612347889c7941935322ede490064831")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,20,32,73)"), UNIQUE'Unds'ID{}("f79afd27602e94c1d3cab7c479ee62b0612347889c7941935322ede490064831")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(20d55dbe86aeba2a0375fcaeffd1b70463e163132d64bd344c8403e2abf48d4b), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(31,20,31,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule9LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule9LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(20d55dbe86aeba2a0375fcaeffd1b70463e163132d64bd344c8403e2abf48d4b), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(32,20,32,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule9LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule9LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule9LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule9LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), UNIQUE'Unds'ID{}("20d55dbe86aeba2a0375fcaeffd1b70463e163132d64bd344c8403e2abf48d4b")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,20,32,73)"), UNIQUE'Unds'ID{}("20d55dbe86aeba2a0375fcaeffd1b70463e163132d64bd344c8403e2abf48d4b")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(2b2e93acde009669ccf6c554a733a049140a0f9311be80cf9186665606c6c97a), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule10LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule10LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(2b2e93acde009669ccf6c554a733a049140a0f9311be80cf9186665606c6c97a), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule10LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule10LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule10LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule10LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("2b2e93acde009669ccf6c554a733a049140a0f9311be80cf9186665606c6c97a")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("2b2e93acde009669ccf6c554a733a049140a0f9311be80cf9186665606c6c97a")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(8ae6039c4a121c0d47acc683acd3940aec4e7e1e809439177fc32b7131179e5c), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule11LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule11LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(8ae6039c4a121c0d47acc683acd3940aec4e7e1e809439177fc32b7131179e5c), color(pink), cool, cool-like, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule11LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule11LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule11LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule11LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("8ae6039c4a121c0d47acc683acd3940aec4e7e1e809439177fc32b7131179e5c")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("8ae6039c4a121c0d47acc683acd3940aec4e7e1e809439177fc32b7131179e5c")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(6ce7009dfb83c0c72a89762edcf8cb8d2852d75049bdceea660f0074383548a5), color(pink), cool, cool-like, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), seqstrict]
-  alias rule12LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule12LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(6ce7009dfb83c0c72a89762edcf8cb8d2852d75049bdceea660f0074383548a5), color(pink), cool, cool-like, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), seqstrict]
+  alias rule12LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule12LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule12LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule12LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [latex{}("{#1}\\leq{#2}"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("6ce7009dfb83c0c72a89762edcf8cb8d2852d75049bdceea660f0074383548a5"), seqstrict{}()]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [latex{}("{#1}\\leq{#2}"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("6ce7009dfb83c0c72a89762edcf8cb8d2852d75049bdceea660f0074383548a5"), seqstrict{}()]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(72ed975186623c17fc2633658600368326b27ae1343270330b7b6047005ccbcd), color(pink), cool, cool-like, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), seqstrict]
-  alias rule13LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule13LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(72ed975186623c17fc2633658600368326b27ae1343270330b7b6047005ccbcd), color(pink), cool, cool-like, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), seqstrict]
+  alias rule13LHS{}(SortAExp{},SortAExp{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule13LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule13LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{}),
+    rule13LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [latex{}("{#1}\\leq{#2}"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("72ed975186623c17fc2633658600368326b27ae1343270330b7b6047005ccbcd"), seqstrict{}()]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [latex{}("{#1}\\leq{#2}"), cool{}(), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("72ed975186623c17fc2633658600368326b27ae1343270330b7b6047005ccbcd"), seqstrict{}()]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_=_;_IMP-SYNTAX_Stmt_Id_AExp1_`(inj{Id,KItem}(K0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(4f73ab093a21739df25740625bc3da16283f2a0081e0ebc697567a2c197c73cb), color(pink), cool, cool-like, format(%1 %2 %3%4), org.kframework.attributes.Location(Location(41,20,41,90)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(2)]
-  alias rule14LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortId{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule14LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{AExp,KItem}(HOLE) #as _3``~>`#freezer_=_;_IMP-SYNTAX_Stmt_Id_AExp1_`(inj{Id,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(4f73ab093a21739df25740625bc3da16283f2a0081e0ebc697567a2c197c73cb), color(pink), cool, cool-like, format(%1 %2 %3%4), org.kframework.attributes.Location(Location(41,20,41,90)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(2)]
+  alias rule14LHS{}(SortAExp{},SortId{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule14LHS{}(VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarK0:SortId{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarK0:SortId{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule14LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'3:SortKItem{}),
+    rule14LHS{}(VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), format{}("%1 %2 %3%4"), UNIQUE'Unds'ID{}("4f73ab093a21739df25740625bc3da16283f2a0081e0ebc697567a2c197c73cb")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), format{}("%1 %2 %3%4"), UNIQUE'Unds'ID{}("4f73ab093a21739df25740625bc3da16283f2a0081e0ebc697567a2c197c73cb")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezerif(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block0_`(inj{Block,KItem}(K1),inj{Block,KItem}(K2))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(HOLE,K1,K2))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(034c38e512c1256ff47aba3ef484c11ee596236ab05cedd1304cade7be3bf774), colors(yellow, white, white, yellow), cool, cool-like, format(%1 %2%3%4 %5 %6 %7), org.kframework.attributes.Location(Location(42,20,43,123)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(1)]
-  alias rule15LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortBlock{},SortBlock{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule15LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'3:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(``inj{BExp,KItem}(HOLE) #as _3``~>`#freezerif(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block0_`(inj{Block,KItem}(K1),inj{Block,KItem}(K2))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(HOLE,K1,K2))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),isKResult(_3)) ensures #token("true","Bool") [UNIQUE_ID(034c38e512c1256ff47aba3ef484c11ee596236ab05cedd1304cade7be3bf774), colors(yellow, white, white, yellow), cool, cool-like, format(%1 %2%3%4 %5 %6 %7), org.kframework.attributes.Location(Location(42,20,43,123)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(1)]
+  alias rule15LHS{}(SortBExp{},SortBlock{},SortBlock{},SortKItem{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule15LHS{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblisKResult{}(kseq{}(Var'Unds'3:SortKItem{},dotk{}()))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarK1:SortBlock{}),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(VarK2:SortBlock{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(\and{SortKItem{}}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),Var'Unds'3:SortKItem{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarK1:SortBlock{}),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(VarK2:SortBlock{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule15LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'3:SortKItem{}),
+    rule15LHS{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'3:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [cool{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), format{}("%1 %2%3%4 %5 %6 %7"), colors{}("yellow, white, white, yellow"), UNIQUE'Unds'ID{}("034c38e512c1256ff47aba3ef484c11ee596236ab05cedd1304cade7be3bf774")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [cool{}(), strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), cool-like{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), format{}("%1 %2%3%4 %5 %6 %7"), colors{}("yellow, white, white, yellow"), UNIQUE'Unds'ID{}("034c38e512c1256ff47aba3ef484c11ee596236ab05cedd1304cade7be3bf774")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`while(_)__IMP-SYNTAX_Stmt_BExp_Block`(B,S) #as _4)~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(B,`{_}_IMP-SYNTAX_Block_Stmt`(`___IMP-SYNTAX_Stmt_Stmt_Stmt`(inj{Block,Stmt}(S),_4)),`{}_IMP-SYNTAX_Block`(.KList)))~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6982fc19b573a992a91998f99dda4522de227858f7b5371a56f013b3aaaacb51), contentStartColumn(8), contentStartLine(206), org.kframework.attributes.Location(Location(206,8,206,53)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
-  alias rule16LHS{}(SortBExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBlock{},SortStmt{}) : SortGeneratedTopCell{}
-  where rule16LHS{}(VarB:SortBExp{},VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'4:SortStmt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`while(_)__IMP-SYNTAX_Stmt_BExp_Block`(B,S) #as _4)~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(B,`{_}_IMP-SYNTAX_Block_Stmt`(`___IMP-SYNTAX_Stmt_Stmt_Stmt`(inj{Block,Stmt}(S),_4)),`{}_IMP-SYNTAX_Block`(.KList)))~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(6982fc19b573a992a91998f99dda4522de227858f7b5371a56f013b3aaaacb51), org.kframework.attributes.Location(Location(206,8,206,53)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
+  alias rule16LHS{}(SortBExp{},SortBlock{},SortStmt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule16LHS{}(VarB:SortBExp{},VarS:SortBlock{},Var'Unds'4:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(\and{SortStmt{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(VarB:SortBExp{},VarS:SortBlock{}),Var'Unds'4:SortStmt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule16LHS{}(VarB:SortBExp{},VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'4:SortStmt{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarB:SortBExp{},Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(VarS:SortBlock{}),Var'Unds'4:SortStmt{})),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("206"), contentStartColumn{}("8"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(206,8,206,53)"), UNIQUE'Unds'ID{}("6982fc19b573a992a91998f99dda4522de227858f7b5371a56f013b3aaaacb51")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Id,KItem}(X)~>DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),I),DotVar3)) #as _4),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(I~>DotVar2),_4),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(947120805127502d18bbf93c574316d7677c9d91f68c2393b639fd9c18aea46a), contentStartColumn(8), contentStartLine(118), cool-like, org.kframework.attributes.Location(Location(118,8,118,60)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule17LHS{}(SortGeneratedCounterCell{},SortK{},SortMap{},SortKItem{},SortId{},SortStateCell{}) : SortGeneratedTopCell{}
-  where rule17LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar2:SortK{},VarDotVar3:SortMap{},VarI:SortKItem{},VarX:SortId{},Var'Unds'4:SortStateCell{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),VarDotVar2:SortK{})),\and{SortStateCell{}}(Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),VarI:SortKItem{}),VarDotVar3:SortMap{})),Var'Unds'4:SortStateCell{})),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(\and{SortStmt{}}(Lblwhile'LParUndsRParUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block{}(VarB:SortBExp{},VarS:SortBlock{}),Var'Unds'4:SortStmt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule17LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar2:SortK{},VarDotVar3:SortMap{},VarI:SortKItem{},VarX:SortId{},Var'Unds'4:SortStateCell{}),
+    rule16LHS{}(VarB:SortBExp{},VarS:SortBlock{},Var'Unds'4:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(VarI:SortKItem{},VarDotVar2:SortK{})),Var'Unds'4:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), cool-like{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("118"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(118,8,118,60)"), UNIQUE'Unds'ID{}("947120805127502d18bbf93c574316d7677c9d91f68c2393b639fd9c18aea46a")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarB:SortBExp{},Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(inj{SortBlock{}, SortStmt{}}(VarS:SortBlock{}),Var'Unds'4:SortStmt{})),Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}())),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(206,8,206,53)"), UNIQUE'Unds'ID{}("6982fc19b573a992a91998f99dda4522de227858f7b5371a56f013b3aaaacb51")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(HOLE))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX_BExp_BExp0_`(.KList)~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(73386cb8877936630fdb20179dc70c5cbdddb3f4ff225a19ac6719f847087f67), color(pink), heat, org.kframework.attributes.Location(Location(35,20,35,67)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule18LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{}) : SortGeneratedTopCell{}
-  where rule18LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Id,KItem}(X)~>_DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),I),_DotVar3)) #as _4),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(I~>_DotVar2),_4),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(947120805127502d18bbf93c574316d7677c9d91f68c2393b639fd9c18aea46a), cool-like, org.kframework.attributes.Location(Location(118,8,118,60)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule17LHS{}(SortKItem{},SortId{},SortStateCell{},SortGeneratedCounterCell{},SortK{},SortMap{}) : SortGeneratedTopCell{}
+  where rule17LHS{}(VarI:SortKItem{},VarX:SortId{},Var'Unds'4:SortStateCell{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar2:SortK{},Var'Unds'DotVar3:SortMap{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),Var'Unds'DotVar2:SortK{})),\and{SortStateCell{}}(Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),VarI:SortKItem{}),Var'Unds'DotVar3:SortMap{})),Var'Unds'4:SortStateCell{})),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule17LHS{}(VarI:SortKItem{},VarX:SortId{},Var'Unds'4:SortStateCell{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar2:SortK{},Var'Unds'DotVar3:SortMap{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(VarI:SortKItem{},Var'Unds'DotVar2:SortK{})),Var'Unds'4:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), cool-like{}(), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(118,8,118,60)"), UNIQUE'Unds'ID{}("947120805127502d18bbf93c574316d7677c9d91f68c2393b639fd9c18aea46a")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(HOLE))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer!__IMP-SYNTAX_BExp_BExp0_`(.KList)~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(73386cb8877936630fdb20179dc70c5cbdddb3f4ff225a19ac6719f847087f67), color(pink), heat, org.kframework.attributes.Location(Location(35,20,35,67)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule18LHS{}(SortBExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule18LHS{}(VarHOLE:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule18LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{}),
+    rule18LHS{}(VarHOLE:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), UNIQUE'Unds'ID{}("73386cb8877936630fdb20179dc70c5cbdddb3f4ff225a19ac6719f847087f67")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp0'Unds'{}(),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(35,20,35,67)"), UNIQUE'Unds'ID{}("73386cb8877936630fdb20179dc70c5cbdddb3f4ff225a19ac6719f847087f67")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(inj{Bool,BExp}(T)))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(`notBool_`(T))~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(df02fc0d0e5961db2abfb367f3e75a41da73560b1bd8104ba77b08a90463d01f), contentStartColumn(8), contentStartLine(139), org.kframework.attributes.Location(Location(139,8,139,24)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule19LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBool{}) : SortGeneratedTopCell{}
-  where rule19LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarT:SortBool{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`!__IMP-SYNTAX_BExp_BExp`(inj{Bool,BExp}(T)))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(`notBool_`(T))~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(df02fc0d0e5961db2abfb367f3e75a41da73560b1bd8104ba77b08a90463d01f), org.kframework.attributes.Location(Location(139,8,139,24)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule19LHS{}(SortBool{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule19LHS{}(VarT:SortBool{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(VarT:SortBool{}))),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule19LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarT:SortBool{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(LblnotBool'Unds'{}(VarT:SortBool{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("139"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(139,8,139,24)"), UNIQUE'Unds'ID{}("df02fc0d0e5961db2abfb367f3e75a41da73560b1bd8104ba77b08a90463d01f")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`-__IMP-SYNTAX_AExp_Int`(I1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_-Int_`(#token("0","Int"),I1))~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(11257cfa6e4acf011c9eb56e4c968dee1a99d1dcbca3fbda5360adc3c0683b80), contentStartColumn(8), contentStartLine(129), org.kframework.attributes.Location(Location(129,8,129,25)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule20LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortInt{}) : SortGeneratedTopCell{}
-  where rule20LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(VarI1:SortInt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'BangUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(VarT:SortBool{}))),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule20LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{}),
+    rule19LHS{}(VarT:SortBool{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'Unds'-Int'Unds'{}(\dv{SortInt{}}("0"),VarI1:SortInt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("129"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,8,129,25)"), UNIQUE'Unds'ID{}("11257cfa6e4acf011c9eb56e4c968dee1a99d1dcbca3fbda5360adc3c0683b80")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(LblnotBool'Unds'{}(VarT:SortBool{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(139,8,139,24)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("df02fc0d0e5961db2abfb367f3e75a41da73560b1bd8104ba77b08a90463d01f")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX_BExp_BExp_BExp0_`(inj{BExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(2447707c4c2dc4331c8d20f39d00f56ede8fed99d954198d265186c741d8be89), color(pink), heat, left, org.kframework.attributes.Location(Location(36,20,36,76)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(1)]
-  alias rule21LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortBExp{}) : SortGeneratedTopCell{}
-  where rule21LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBExp{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`-__IMP-SYNTAX_AExp_Int`(I1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_-Int_`(#token("0","Int"),I1))~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(11257cfa6e4acf011c9eb56e4c968dee1a99d1dcbca3fbda5360adc3c0683b80), org.kframework.attributes.Location(Location(129,8,129,25)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule20LHS{}(SortInt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule20LHS{}(VarI1:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl-'UndsUnds'IMP-SYNTAX'Unds'AExp'Unds'Int{}(VarI1:SortInt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule20LHS{}(VarI1:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'Unds'-Int'Unds'{}(\dv{SortInt{}}("0"),VarI1:SortInt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(129,8,129,25)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("11257cfa6e4acf011c9eb56e4c968dee1a99d1dcbca3fbda5360adc3c0683b80")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezer_&&__IMP-SYNTAX_BExp_BExp_BExp0_`(inj{BExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(2447707c4c2dc4331c8d20f39d00f56ede8fed99d954198d265186c741d8be89), color(pink), heat, left, org.kframework.attributes.Location(Location(37,20,37,76)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(1)]
+  alias rule21LHS{}(SortBExp{},SortBExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule21LHS{}(VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(VarHOLE:SortBExp{},VarK1:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule21LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBExp{}),
+    rule21LHS{}(VarHOLE:SortBExp{},VarK1:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarK1:SortBExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(36,20,36,76)"), UNIQUE'Unds'ID{}("2447707c4c2dc4331c8d20f39d00f56ede8fed99d954198d265186c741d8be89")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezer'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp0'Unds'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarK1:SortBExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(37,20,37,76)"), UNIQUE'Unds'ID{}("2447707c4c2dc4331c8d20f39d00f56ede8fed99d954198d265186c741d8be89")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(inj{Bool,BExp}(#token("false","Bool") #as _7),_0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(_7)~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(aad2bcfd509bccd60d7e25b0eec1c400a385c8a8ddd49c668f15f83eeac44567), contentStartColumn(8), contentStartLine(141), org.kframework.attributes.Location(Location(141,8,141,27)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule22LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortBool{}) : SortGeneratedTopCell{}
-  where rule22LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},Var'Unds'0:SortBExp{},Var'Unds'7:SortBool{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(inj{Bool,BExp}(#token("false","Bool") #as _7),_0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(_7)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(aad2bcfd509bccd60d7e25b0eec1c400a385c8a8ddd49c668f15f83eeac44567), org.kframework.attributes.Location(Location(141,8,141,27)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule22LHS{}(SortBExp{},SortBool{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule22LHS{}(Var'Unds'0:SortBExp{},Var'Unds'7:SortBool{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'7:SortBool{})),Var'Unds'0:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\and{SortBool{}}(\dv{SortBool{}}("false"),Var'Unds'7:SortBool{})),Var'Unds'0:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule22LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},Var'Unds'0:SortBExp{},Var'Unds'7:SortBool{}),
+    rule22LHS{}(Var'Unds'0:SortBExp{},Var'Unds'7:SortBool{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'7:SortBool{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("141"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(141,8,141,27)"), UNIQUE'Unds'ID{}("aad2bcfd509bccd60d7e25b0eec1c400a385c8a8ddd49c668f15f83eeac44567")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(Var'Unds'7:SortBool{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(141,8,141,27)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("aad2bcfd509bccd60d7e25b0eec1c400a385c8a8ddd49c668f15f83eeac44567")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(inj{Bool,BExp}(#token("true","Bool") #as _6),B))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(B)~>DotVar2),DotVar1),DotVar0) requires _6 ensures _6 [UNIQUE_ID(c78d274bec7913fb60cd62c41693aa099f25ba70160c4ab4a7af9c99043b8bd0), contentStartColumn(8), contentStartLine(140), org.kframework.attributes.Location(Location(140,8,140,22)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule23LHS{}(SortBExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBool{}) : SortGeneratedTopCell{}
-  where rule23LHS{}(VarB:SortBExp{},VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},Var'Unds'6:SortBool{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_&&__IMP-SYNTAX_BExp_BExp_BExp`(inj{Bool,BExp}(#token("true","Bool")),B))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(B)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c78d274bec7913fb60cd62c41693aa099f25ba70160c4ab4a7af9c99043b8bd0), org.kframework.attributes.Location(Location(140,8,140,22)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule23LHS{}(SortBExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule23LHS{}(VarB:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),VarB:SortBExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule23LHS{}(VarB:SortBExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarB:SortBExp{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,8,140,22)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c78d274bec7913fb60cd62c41693aa099f25ba70160c4ab4a7af9c99043b8bd0")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(4f1fc6a54f410e0c9b75aa0a8df5036933591a2e5f7c23a9f112121b049e0865), color(pink), heat, left, org.kframework.attributes.Location(Location(32,20,32,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule24LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule24LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Var'Unds'6:SortBool{},
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'UndsAnd-And-UndsUnds'IMP-SYNTAX'Unds'BExp'Unds'BExp'Unds'BExp{}(inj{SortBool{}, SortBExp{}}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'6:SortBool{})),VarB:SortBExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule23LHS{}(VarB:SortBExp{},VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},Var'Unds'6:SortBool{}),
+    rule24LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,20,32,73)"), UNIQUE'Unds'ID{}("4f1fc6a54f410e0c9b75aa0a8df5036933591a2e5f7c23a9f112121b049e0865")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(33b45f2c7611ceb1fcaaace5dcddc3e69dfb6e2412fa65018934a5feeb667428), color(pink), heat, left, org.kframework.attributes.Location(Location(32,20,32,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule25LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule25LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Var'Unds'6:SortBool{},
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarB:SortBExp{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("140"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(140,8,140,22)"), UNIQUE'Unds'ID{}("c78d274bec7913fb60cd62c41693aa099f25ba70160c4ab4a7af9c99043b8bd0")]
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(4f1fc6a54f410e0c9b75aa0a8df5036933591a2e5f7c23a9f112121b049e0865), color(pink), heat, left, org.kframework.attributes.Location(Location(31,20,31,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule24LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule24LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}) :=
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule25LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(32,20,32,73)"), UNIQUE'Unds'ID{}("33b45f2c7611ceb1fcaaace5dcddc3e69dfb6e2412fa65018934a5feeb667428")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_+Int_`(I1,I2))~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(558153b25ed67940d62fe6aba2c159725c68ef58cf9fdcd03034b94d6013593b), org.kframework.attributes.Location(Location(128,8,128,29)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule26LHS{}(SortInt{},SortInt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule26LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule26LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,8,128,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("558153b25ed67940d62fe6aba2c159725c68ef58cf9fdcd03034b94d6013593b")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(e71ca68a882d2aa4aa2475a577baf9d6960d4dc7f2dbd747ddc4efb9105e0ec6), color(pink), heat, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule27LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule27LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule24LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}),
+    rule27LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), UNIQUE'Unds'ID{}("4f1fc6a54f410e0c9b75aa0a8df5036933591a2e5f7c23a9f112121b049e0865")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("e71ca68a882d2aa4aa2475a577baf9d6960d4dc7f2dbd747ddc4efb9105e0ec6")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_+__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(33b45f2c7611ceb1fcaaace5dcddc3e69dfb6e2412fa65018934a5feeb667428), color(pink), heat, left, org.kframework.attributes.Location(Location(31,20,31,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule25LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule25LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(df1711d103a1d5fabb5655e0996e2ea62689fbc637f0bd8329c5977ee37af582), color(pink), heat, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict]
+  alias rule28LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule28LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule25LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}),
+    rule28LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(31,20,31,73)"), UNIQUE'Unds'ID{}("33b45f2c7611ceb1fcaaace5dcddc3e69dfb6e2412fa65018934a5feeb667428")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("df1711d103a1d5fabb5655e0996e2ea62689fbc637f0bd8329c5977ee37af582")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_+__IMP-SYNTAX_AExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_+Int_`(I1,I2))~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(558153b25ed67940d62fe6aba2c159725c68ef58cf9fdcd03034b94d6013593b), contentStartColumn(8), contentStartLine(128), org.kframework.attributes.Location(Location(128,8,128,29)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule26LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortInt{},SortInt{}) : SortGeneratedTopCell{}
-  where rule26LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule26LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsPlus'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("128"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(128,8,128,29)"), UNIQUE'Unds'ID{}("558153b25ed67940d62fe6aba2c159725c68ef58cf9fdcd03034b94d6013593b")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(e71ca68a882d2aa4aa2475a577baf9d6960d4dc7f2dbd747ddc4efb9105e0ec6), color(pink), heat, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule27LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule27LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule27LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("e71ca68a882d2aa4aa2475a577baf9d6960d4dc7f2dbd747ddc4efb9105e0ec6")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_/__IMP-SYNTAX_AExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(df1711d103a1d5fabb5655e0996e2ea62689fbc637f0bd8329c5977ee37af582), color(pink), heat, left, org.kframework.attributes.Location(Location(30,20,30,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict]
-  alias rule28LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule28LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule28LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}(""), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), left{}(), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(30,20,30,73)"), UNIQUE'Unds'ID{}("df1711d103a1d5fabb5655e0996e2ea62689fbc637f0bd8329c5977ee37af582")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_/Int_`(I1,I2))~>DotVar2),DotVar1),DotVar0) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(6afd6e6a38cfbe63d88684cb832028c72316c47cf3bd4a98ab50da45d8d4f338), contentStartColumn(8), contentStartLine(127), org.kframework.attributes.Location(Location(127,8,127,51)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
-  alias rule29LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortInt{},SortInt{}) : SortGeneratedTopCell{}
-  where rule29LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(`_/__IMP-SYNTAX_AExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Int,KItem}(`_/Int_`(I1,I2))~>_DotVar2),_DotVar1),_DotVar0) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(6afd6e6a38cfbe63d88684cb832028c72316c47cf3bd4a98ab50da45d8d4f338), org.kframework.attributes.Location(Location(127,8,127,51)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  alias rule29LHS{}(SortInt{},SortInt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule29LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(Lbl'UndsSlshUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule29LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}),
+    rule29LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsSlsh'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("127"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(127,8,127,51)"), UNIQUE'Unds'ID{}("6afd6e6a38cfbe63d88684cb832028c72316c47cf3bd4a98ab50da45d8d4f338")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortInt{}, SortKItem{}}(Lbl'UndsSlsh'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(127,8,127,51)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("6afd6e6a38cfbe63d88684cb832028c72316c47cf3bd4a98ab50da45d8d4f338")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(HOLE,K1))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(3ea228c13423f10a5e2a2dfe82bde4b8ecf790cd6ab3e2095ef0f66e62099a30), color(pink), heat, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), seqstrict]
-  alias rule30LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule30LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(HOLE,K1))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp0_`(inj{AExp,KItem}(K1))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(3ea228c13423f10a5e2a2dfe82bde4b8ecf790cd6ab3e2095ef0f66e62099a30), color(pink), heat, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), seqstrict]
+  alias rule30LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule30LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarHOLE:SortAExp{},VarK1:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule30LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK1:SortAExp{}),
+    rule30LHS{}(VarHOLE:SortAExp{},VarK1:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [latex{}("{#1}\\leq{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("3ea228c13423f10a5e2a2dfe82bde4b8ecf790cd6ab3e2095ef0f66e62099a30"), seqstrict{}()]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp0'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK1:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [latex{}("{#1}\\leq{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("3ea228c13423f10a5e2a2dfe82bde4b8ecf790cd6ab3e2095ef0f66e62099a30"), seqstrict{}()]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(isKResult(inj{AExp,KItem}(K0)),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(86fbfc54f768898e51293efe170369589e35695f1f2afdd6ce6a3975fbec3492), color(pink), heat, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), seqstrict]
-  alias rule31LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortAExp{}) : SortGeneratedTopCell{}
-  where rule31LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_<=__IMP-SYNTAX_BExp_AExp_AExp1_`(inj{AExp,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(`_andBool_`(isKResult(inj{AExp,KItem}(K0)),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(86fbfc54f768898e51293efe170369589e35695f1f2afdd6ce6a3975fbec3492), color(pink), heat, latex({#1}\leq{#2}), org.kframework.attributes.Location(Location(34,20,34,91)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), seqstrict]
+  alias rule31LHS{}(SortAExp{},SortAExp{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule31LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(VarK0:SortAExp{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule31LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortAExp{}),
+    rule31LHS{}(VarHOLE:SortAExp{},VarK0:SortAExp{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [latex{}("{#1}\\leq{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("86fbfc54f768898e51293efe170369589e35695f1f2afdd6ce6a3975fbec3492"), seqstrict{}()]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp1'Unds'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarK0:SortAExp{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [latex{}("{#1}\\leq{#2}"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(34,20,34,91)"), UNIQUE'Unds'ID{}("86fbfc54f768898e51293efe170369589e35695f1f2afdd6ce6a3975fbec3492"), seqstrict{}()]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(`_<=Int_`(I1,I2))~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f3294578cd4f3183bed59df22c8899bcf796bf26593a7c5e36540ac0829f6d69), contentStartColumn(8), contentStartLine(138), org.kframework.attributes.Location(Location(138,8,138,31)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule32LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortInt{},SortInt{}) : SortGeneratedTopCell{}
-  where rule32LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(`_<=__IMP-SYNTAX_BExp_AExp_AExp`(inj{Int,AExp}(I1),inj{Int,AExp}(I2)))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Bool,KItem}(`_<=Int_`(I1,I2))~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f3294578cd4f3183bed59df22c8899bcf796bf26593a7c5e36540ac0829f6d69), org.kframework.attributes.Location(Location(138,8,138,31)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule32LHS{}(SortInt{},SortInt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule32LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(Lbl'Unds-LT-EqlsUndsUnds'IMP-SYNTAX'Unds'BExp'Unds'AExp'Unds'AExp{}(inj{SortInt{}, SortAExp{}}(VarI1:SortInt{}),inj{SortInt{}, SortAExp{}}(VarI2:SortInt{}))),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule32LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarI1:SortInt{},VarI2:SortInt{}),
+    rule32LHS{}(VarI1:SortInt{},VarI2:SortInt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("138"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(138,8,138,31)"), UNIQUE'Unds'ID{}("f3294578cd4f3183bed59df22c8899bcf796bf26593a7c5e36540ac0829f6d69")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBool{}, SortKItem{}}(Lbl'Unds-LT-Eqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(138,8,138,31)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("f3294578cd4f3183bed59df22c8899bcf796bf26593a7c5e36540ac0829f6d69")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(K0,HOLE))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX_Stmt_Id_AExp1_`(inj{Id,KItem}(K0))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(80393b9820fe36769f9fec5f837918c8359fdbd6953a859c8750955cb61e6f0e), color(pink), format(%1 %2 %3%4), heat, org.kframework.attributes.Location(Location(41,20,41,90)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(2)]
-  alias rule33LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortAExp{},SortId{}) : SortGeneratedTopCell{}
-  where rule33LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortId{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(K0,HOLE))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{AExp,KItem}(HOLE)~>`#freezer_=_;_IMP-SYNTAX_Stmt_Id_AExp1_`(inj{Id,KItem}(K0))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{AExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(80393b9820fe36769f9fec5f837918c8359fdbd6953a859c8750955cb61e6f0e), color(pink), format(%1 %2 %3%4), heat, org.kframework.attributes.Location(Location(41,20,41,90)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(2)]
+  alias rule33LHS{}(SortAExp{},SortId{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule33LHS{}(VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarK0:SortId{},VarHOLE:SortAExp{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule33LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortAExp{},VarK0:SortId{}),
+    rule33LHS{}(VarHOLE:SortAExp{},VarK0:SortId{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarK0:SortId{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), format{}("%1 %2 %3%4"), UNIQUE'Unds'ID{}("80393b9820fe36769f9fec5f837918c8359fdbd6953a859c8750955cb61e6f0e")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortAExp{}, SortKItem{}}(VarHOLE:SortAExp{}),kseq{}(Lbl'Hash'freezer'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp1'Unds'{}(kseq{}(inj{SortId{}, SortKItem{}}(VarK0:SortId{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}("2"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), color{}("pink"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(41,20,41,90)"), format{}("%1 %2 %3%4"), UNIQUE'Unds'ID{}("80393b9820fe36769f9fec5f837918c8359fdbd6953a859c8750955cb61e6f0e")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(X,inj{Int,AExp}(I)))~>DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),_0),DotVar3))),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),inj{Int,KItem}(I)),DotVar3))),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a0a72505d185a6c73b32c5e8214f768a82c2d0282eda985c38900967af1e8093), contentStartColumn(8), contentStartLine(171), org.kframework.attributes.Location(Location(171,8,171,73)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule34LHS{}(SortGeneratedCounterCell{},SortK{},SortMap{},SortInt{},SortId{},SortKItem{}) : SortGeneratedTopCell{}
-  where rule34LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar2:SortK{},VarDotVar3:SortMap{},VarI:SortInt{},VarX:SortId{},Var'Unds'0:SortKItem{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`_=_;_IMP-SYNTAX_Stmt_Id_AExp`(X,inj{Int,AExp}(I)))~>_DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),_0),_DotVar3))),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(_DotVar2),`<state>`(`_Map_`(`_|->_`(inj{Id,KItem}(X),inj{Int,KItem}(I)),_DotVar3))),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(a0a72505d185a6c73b32c5e8214f768a82c2d0282eda985c38900967af1e8093), org.kframework.attributes.Location(Location(171,8,171,73)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule34LHS{}(SortInt{},SortId{},SortKItem{},SortGeneratedCounterCell{},SortK{},SortMap{}) : SortGeneratedTopCell{}
+  where rule34LHS{}(VarI:SortInt{},VarX:SortId{},Var'Unds'0:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar2:SortK{},Var'Unds'DotVar3:SortMap{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarX:SortId{},inj{SortInt{}, SortAExp{}}(VarI:SortInt{}))),VarDotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),Var'Unds'0:SortKItem{}),VarDotVar3:SortMap{}))),VarDotVar0:SortGeneratedCounterCell{})) []
-
-  axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule34LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar2:SortK{},VarDotVar3:SortMap{},VarI:SortInt{},VarX:SortId{},Var'Unds'0:SortKItem{}),
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar2:SortK{}),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),inj{SortInt{}, SortKItem{}}(VarI:SortInt{})),VarDotVar3:SortMap{}))),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("171"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(171,8,171,73)"), UNIQUE'Unds'ID{}("a0a72505d185a6c73b32c5e8214f768a82c2d0282eda985c38900967af1e8093")]
-
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`___IMP-SYNTAX_Stmt_Stmt_Stmt`(S1,S2))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S1)~>inj{Stmt,KItem}(S2)~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(918c73f4bade35ef0fa17d167dc1c6e6642bb1862db26b0ec5b54cf218535404), contentStartColumn(8), contentStartLine(186), org.kframework.attributes.Location(Location(186,8,186,35)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
-  alias rule35LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortStmt{},SortStmt{}) : SortGeneratedTopCell{}
-  where rule35LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS1:SortStmt{},VarS2:SortStmt{}) :=
-    \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(VarS1:SortStmt{},VarS2:SortStmt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp{}(VarX:SortId{},inj{SortInt{}, SortAExp{}}(VarI:SortInt{}))),Var'Unds'DotVar2:SortK{})),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),Var'Unds'0:SortKItem{}),Var'Unds'DotVar3:SortMap{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule35LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS1:SortStmt{},VarS2:SortStmt{}),
+    rule34LHS{}(VarI:SortInt{},VarX:SortId{},Var'Unds'0:SortKItem{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar2:SortK{},Var'Unds'DotVar3:SortMap{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS1:SortStmt{}),kseq{}(inj{SortStmt{}, SortKItem{}}(VarS2:SortStmt{}),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("186"), contentStartColumn{}("8"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(186,8,186,35)"), UNIQUE'Unds'ID{}("918c73f4bade35ef0fa17d167dc1c6e6642bb1862db26b0ec5b54cf218535404")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(Var'Unds'DotVar2:SortK{}),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),inj{SortInt{}, SortKItem{}}(VarI:SortInt{})),Var'Unds'DotVar3:SortMap{}))),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(171,8,171,73)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("a0a72505d185a6c73b32c5e8214f768a82c2d0282eda985c38900967af1e8093")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(HOLE,K1,K2))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block0_`(inj{Block,KItem}(K1),inj{Block,KItem}(K2))~>DotVar2),DotVar1),DotVar0) requires `_andBool_`(`_andBool_`(#token("true","Bool"),#token("true","Bool")),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(f65385a6a43e8163e2ba4db22a222ea18ec2656be0ebcc0b352c836838907221), colors(yellow, white, white, yellow), format(%1 %2%3%4 %5 %6 %7), heat, org.kframework.attributes.Location(Location(42,20,43,123)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), strict(1)]
-  alias rule36LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBExp{},SortBlock{},SortBlock{}) : SortGeneratedTopCell{}
-  where rule36LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`___IMP-SYNTAX_Stmt_Stmt_Stmt`(S1,S2))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S1)~>inj{Stmt,KItem}(S2)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(918c73f4bade35ef0fa17d167dc1c6e6642bb1862db26b0ec5b54cf218535404), org.kframework.attributes.Location(Location(186,8,186,35)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
+  alias rule35LHS{}(SortStmt{},SortStmt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule35LHS{}(VarS1:SortStmt{},VarS2:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lbl'UndsUndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'Stmt'Unds'Stmt{}(VarS1:SortStmt{},VarS2:SortStmt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
+
+  axiom{} \rewrites{SortGeneratedTopCell{}} (
+    rule35LHS{}(VarS1:SortStmt{},VarS2:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
+    \and{SortGeneratedTopCell{}} (
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS1:SortStmt{}),kseq{}(inj{SortStmt{}, SortKItem{}}(VarS2:SortStmt{}),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(186,8,186,35)"), UNIQUE'Unds'ID{}("918c73f4bade35ef0fa17d167dc1c6e6642bb1862db26b0ec5b54cf218535404")]
+
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(HOLE,K1,K2))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{BExp,KItem}(HOLE)~>`#freezerif(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block0_`(inj{Block,KItem}(K1),inj{Block,KItem}(K2))~>_DotVar2),_DotVar1),_DotVar0) requires `_andBool_`(#token("true","Bool"),`notBool_`(isKResult(inj{BExp,KItem}(HOLE)))) ensures #token("true","Bool") [UNIQUE_ID(f65385a6a43e8163e2ba4db22a222ea18ec2656be0ebcc0b352c836838907221), colors(yellow, white, white, yellow), format(%1 %2%3%4 %5 %6 %7), heat, org.kframework.attributes.Location(Location(42,20,43,123)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), strict(1)]
+  alias rule36LHS{}(SortBExp{},SortBlock{},SortBlock{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule36LHS{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
-        Lbl'Unds'andBool'Unds'{}(Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),\dv{SortBool{}}("true")),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+        Lbl'Unds'andBool'Unds'{}(\dv{SortBool{}}("true"),LblnotBool'Unds'{}(LblisKResult{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),dotk{}())))),
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule36LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{}),
+    rule36LHS{}(VarHOLE:SortBExp{},VarK1:SortBlock{},VarK2:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarK1:SortBlock{}),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(VarK2:SortBlock{}),dotk{}())),VarDotVar2:SortK{}))),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), format{}("%1 %2%3%4 %5 %6 %7"), colors{}("yellow, white, white, yellow"), UNIQUE'Unds'ID{}("f65385a6a43e8163e2ba4db22a222ea18ec2656be0ebcc0b352c836838907221")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBExp{}, SortKItem{}}(VarHOLE:SortBExp{}),kseq{}(Lbl'Hash'freezerif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block0'Unds'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarK1:SortBlock{}),dotk{}()),kseq{}(inj{SortBlock{}, SortKItem{}}(VarK2:SortBlock{}),dotk{}())),Var'Unds'DotVar2:SortK{}))),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [strict{}("1"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), heat{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(42,20,43,123)"), format{}("%1 %2%3%4 %5 %6 %7"), colors{}("yellow, white, white, yellow"), UNIQUE'Unds'ID{}("f65385a6a43e8163e2ba4db22a222ea18ec2656be0ebcc0b352c836838907221")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(inj{Bool,BExp}(#token("true","Bool") #as _7),S,_0))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar2),DotVar1),DotVar0) requires _7 ensures _7 [UNIQUE_ID(3db8362dabb3eb158afddd5722f7130eae1135170929330ee1aaf9eb2fd3dcda), contentStartColumn(8), contentStartLine(197), org.kframework.attributes.Location(Location(197,8,197,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule37LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBlock{},SortBlock{},SortBool{}) : SortGeneratedTopCell{}
-  where rule37LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'7:SortBool{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(inj{Bool,BExp}(#token("false","Bool")),_0,S))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(S)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f12ec760036f191754935e67853214c87c49da500e49c7b913ddbc732150ee1a), org.kframework.attributes.Location(Location(198,8,198,32)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule37LHS{}(SortBlock{},SortBlock{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule37LHS{}(VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \equals{SortBool{},SortGeneratedTopCell{}}(
-        Var'Unds'7:SortBool{},
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'7:SortBool{})),VarS:SortBlock{},Var'Unds'0:SortBlock{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")),Var'Unds'0:SortBlock{},VarS:SortBlock{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule37LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'7:SortBool{}),
+    rule37LHS{}(VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \equals{SortBool{},SortGeneratedTopCell{}}(
-        Var'Unds'7:SortBool{},
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("197"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,8,197,32)"), UNIQUE'Unds'ID{}("3db8362dabb3eb158afddd5722f7130eae1135170929330ee1aaf9eb2fd3dcda")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(198,8,198,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("f12ec760036f191754935e67853214c87c49da500e49c7b913ddbc732150ee1a")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(inj{Bool,BExp}(#token("false","Bool")),_0,S))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(S)~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f12ec760036f191754935e67853214c87c49da500e49c7b913ddbc732150ee1a), contentStartColumn(8), contentStartLine(198), org.kframework.attributes.Location(Location(198,8,198,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  alias rule38LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortBlock{},SortBlock{}) : SortGeneratedTopCell{}
-  where rule38LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'0:SortBlock{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(`if(_)_else__IMP-SYNTAX_Stmt_BExp_Block_Block`(inj{Bool,BExp}(#token("true","Bool")),S,_0))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(S)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3db8362dabb3eb158afddd5722f7130eae1135170929330ee1aaf9eb2fd3dcda), org.kframework.attributes.Location(Location(197,8,197,32)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  alias rule38LHS{}(SortBlock{},SortBlock{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule38LHS{}(VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("false")),Var'Unds'0:SortBlock{},VarS:SortBlock{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(Lblif'LParUndsRParUnds'else'UndsUnds'IMP-SYNTAX'Unds'Stmt'Unds'BExp'Unds'Block'Unds'Block{}(inj{SortBool{}, SortBExp{}}(\dv{SortBool{}}("true")),VarS:SortBlock{},Var'Unds'0:SortBlock{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule38LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortBlock{},Var'Unds'0:SortBlock{}),
+    rule38LHS{}(VarS:SortBlock{},Var'Unds'0:SortBlock{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("198"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(198,8,198,32)"), UNIQUE'Unds'ID{}("f12ec760036f191754935e67853214c87c49da500e49c7b913ddbc732150ee1a")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(VarS:SortBlock{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(197,8,197,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3db8362dabb3eb158afddd5722f7130eae1135170929330ee1aaf9eb2fd3dcda")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(`.List{"_,__IMP-SYNTAX_Ids_Id_Ids"}_Ids`(.KList),S))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f2ebd3e9ee3a1cdaa9c1b05b9c9f3667349ea62964ecd42377c799a78521c27f), contentStartColumn(8), contentStartLine(225), org.kframework.attributes.Location(Location(225,8,225,24)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
-  alias rule39LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortStmt{}) : SortGeneratedTopCell{}
-  where rule39LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortStmt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(`.List{"_,__IMP-SYNTAX_Ids_Id_Ids"}_Ids`(.KList),S))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f2ebd3e9ee3a1cdaa9c1b05b9c9f3667349ea62964ecd42377c799a78521c27f), org.kframework.attributes.Location(Location(225,8,225,24)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
+  alias rule39LHS{}(SortStmt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule39LHS{}(VarS:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}(),VarS:SortStmt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids{}(),VarS:SortStmt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule39LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortStmt{}),
+    rule39LHS{}(VarS:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("225"), contentStartColumn{}("8"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(225,8,225,24)"), UNIQUE'Unds'ID{}("f2ebd3e9ee3a1cdaa9c1b05b9c9f3667349ea62964ecd42377c799a78521c27f")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(225,8,225,24)"), UNIQUE'Unds'ID{}("f2ebd3e9ee3a1cdaa9c1b05b9c9f3667349ea62964ecd42377c799a78521c27f")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(`_,__IMP-SYNTAX_Ids_Id_Ids`(X,Xs),_0))),`<state>`(`_Map_`(Rho,`.Map`(.KList)))),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(Xs,_0))),`<state>`(`_Map_`(Rho,`_|->_`(inj{Id,KItem}(X),inj{Int,KItem}(#token("0","Int")))))),DotVar0) requires `notBool_`(`Set:in`(inj{Id,KItem}(X),`keys(_)_MAP_Set_Map`(Rho))) ensures #token("true","Bool") [UNIQUE_ID(8a8d39fed34974de05d217d0c7014950a846aae159a11794bd36c81db4b3ede1), contentStartColumn(8), contentStartLine(223), org.kframework.attributes.Location(Location(223,8,224,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
-  alias rule40LHS{}(SortGeneratedCounterCell{},SortMap{},SortId{},SortIds{},SortStmt{}) : SortGeneratedTopCell{}
-  where rule40LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarRho:SortMap{},VarX:SortId{},VarXs:SortIds{},Var'Unds'0:SortStmt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(`_,__IMP-SYNTAX_Ids_Id_Ids`(X,Xs),_0))),`<state>`(`_Map_`(Rho,`.Map`(.KList)))),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Pgm,KItem}(`int_;__IMP-SYNTAX_Pgm_Ids_Stmt`(Xs,_0))),`<state>`(`_Map_`(Rho,`_|->_`(inj{Id,KItem}(X),inj{Int,KItem}(#token("0","Int")))))),_DotVar0) requires `notBool_`(`Set:in`(inj{Id,KItem}(X),`keys(_)_MAP_Set_Map`(Rho))) ensures #token("true","Bool") [UNIQUE_ID(8a8d39fed34974de05d217d0c7014950a846aae159a11794bd36c81db4b3ede1), org.kframework.attributes.Location(Location(223,8,224,38)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
+  alias rule40LHS{}(SortMap{},SortId{},SortIds{},SortStmt{},SortGeneratedCounterCell{}) : SortGeneratedTopCell{}
+  where rule40LHS{}(VarRho:SortMap{},VarX:SortId{},VarXs:SortIds{},Var'Unds'0:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{}) :=
     \and{SortGeneratedTopCell{}} (
       \equals{SortBool{},SortGeneratedTopCell{}}(
         LblnotBool'Unds'{}(LblSet'Coln'in{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),Lblkeys'LParUndsRParUnds'MAP'Unds'Set'Unds'Map{}(VarRho:SortMap{}))),
-        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(VarX:SortId{},VarXs:SortIds{}),Var'Unds'0:SortStmt{})),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'Stop'Map{}()))),VarDotVar0:SortGeneratedCounterCell{})) []
+        \dv{SortBool{}}("true")), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids{}(VarX:SortId{},VarXs:SortIds{}),Var'Unds'0:SortStmt{})),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'Stop'Map{}()))),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule40LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarRho:SortMap{},VarX:SortId{},VarXs:SortIds{},Var'Unds'0:SortStmt{}),
+    rule40LHS{}(VarRho:SortMap{},VarX:SortId{},VarXs:SortIds{},Var'Unds'0:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(VarXs:SortIds{},Var'Unds'0:SortStmt{})),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("223"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(223,8,224,38)"), UNIQUE'Unds'ID{}("8a8d39fed34974de05d217d0c7014950a846aae159a11794bd36c81db4b3ede1")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt{}(VarXs:SortIds{},Var'Unds'0:SortStmt{})),dotk{}())),Lbl'-LT-'state'-GT-'{}(Lbl'Unds'Map'Unds'{}(VarRho:SortMap{},Lbl'UndsPipe'-'-GT-Unds'{}(inj{SortId{}, SortKItem{}}(VarX:SortId{}),inj{SortInt{}, SortKItem{}}(\dv{SortInt{}}("0")))))),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(223,8,224,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("8a8d39fed34974de05d217d0c7014950a846aae159a11794bd36c81db4b3ede1")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(`{_}_IMP-SYNTAX_Block_Stmt`(S))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S)~>DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dd487914e94e64fee85796be97956497cdb521583b7425a9edb1006781f5bd95), contentStartColumn(8), contentStartLine(162), org.kframework.attributes.Location(Location(162,8,162,16)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
-  alias rule41LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{},SortStmt{}) : SortGeneratedTopCell{}
-  where rule41LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortStmt{}) :=
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(`{_}_IMP-SYNTAX_Block_Stmt`(S))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(inj{Stmt,KItem}(S)~>_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(dd487914e94e64fee85796be97956497cdb521583b7425a9edb1006781f5bd95), org.kframework.attributes.Location(Location(162,8,162,16)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
+  alias rule41LHS{}(SortStmt{},SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
+  where rule41LHS{}(VarS:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(VarS:SortStmt{})),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraUndsRBraUnds'IMP-SYNTAX'Unds'Block'Unds'Stmt{}(VarS:SortStmt{})),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule41LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{},VarS:SortStmt{}),
+    rule41LHS{}(VarS:SortStmt{},Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("162"), contentStartColumn{}("8"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(162,8,162,16)"), UNIQUE'Unds'ID{}("dd487914e94e64fee85796be97956497cdb521583b7425a9edb1006781f5bd95")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortStmt{}, SortKItem{}}(VarS:SortStmt{}),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(162,8,162,16)"), UNIQUE'Unds'ID{}("dd487914e94e64fee85796be97956497cdb521583b7425a9edb1006781f5bd95")]
 
-// rule `<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(`{}_IMP-SYNTAX_Block`(.KList))~>DotVar2),DotVar1),DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(DotVar2),DotVar1),DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0255d55170b700341bb1eaef9b9a1bb9ec0b69a07978e89382ae437997a2cb1d), contentStartColumn(8), contentStartLine(161), org.kframework.attributes.Location(Location(161,8,161,15)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
+// rule `<generatedTop>`(`<T>`(`<k>`(inj{Block,KItem}(`{}_IMP-SYNTAX_Block`(.KList))~>_DotVar2),_DotVar1),_DotVar0)=>`<generatedTop>`(`<T>`(`<k>`(_DotVar2),_DotVar1),_DotVar0) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0255d55170b700341bb1eaef9b9a1bb9ec0b69a07978e89382ae437997a2cb1d), org.kframework.attributes.Location(Location(161,8,161,15)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]), structural]
   alias rule42LHS{}(SortGeneratedCounterCell{},SortStateCell{},SortK{}) : SortGeneratedTopCell{}
-  where rule42LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{}) :=
+  where rule42LHS{}(Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}) :=
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),VarDotVar2:SortK{})),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})) []
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortBlock{}, SortKItem{}}(Lbl'LBraRBraUnds'IMP-SYNTAX'Unds'Block{}()),Var'Unds'DotVar2:SortK{})),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})) []
 
   axiom{} \rewrites{SortGeneratedTopCell{}} (
-    rule42LHS{}(VarDotVar0:SortGeneratedCounterCell{},VarDotVar1:SortStateCell{},VarDotVar2:SortK{}),
+    rule42LHS{}(Var'Unds'DotVar0:SortGeneratedCounterCell{},Var'Unds'DotVar1:SortStateCell{},Var'Unds'DotVar2:SortK{}),
     \and{SortGeneratedTopCell{}} (
-      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(VarDotVar2:SortK{}),VarDotVar1:SortStateCell{}),VarDotVar0:SortGeneratedCounterCell{})))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("161"), contentStartColumn{}("8"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,8,161,15)"), UNIQUE'Unds'ID{}("0255d55170b700341bb1eaef9b9a1bb9ec0b69a07978e89382ae437997a2cb1d")]
+      \top{SortGeneratedTopCell{}}(), Lbl'-LT-'generatedTop'-GT-'{}(Lbl'-LT-'T'-GT-'{}(Lbl'-LT-'k'-GT-'{}(Var'Unds'DotVar2:SortK{}),Var'Unds'DotVar1:SortStateCell{}),Var'Unds'DotVar0:SortGeneratedCounterCell{})))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), structural{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(161,8,161,15)"), UNIQUE'Unds'ID{}("0255d55170b700341bb1eaef9b9a1bb9ec0b69a07978e89382ae437997a2cb1d")]
 
-// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), contentStartColumn(8), contentStartLine(656), org.kframework.attributes.Location(Location(656,8,656,63)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("false","Bool"))=>#token("\"false\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f), org.kframework.attributes.Location(Location(1450,8,1450,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+      \and{R} (
+        \dv{SortString{}}("false"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1450,8,1450,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("cca4780e4e7660055f781b9643f3125234a0f4f08ba76cacf8e5a18fe7fc999f")]
+
+// rule `Bool2String(_)_STRING-COMMON_String_Bool`(#token("true","Bool"))=>#token("\"true\"","String") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d), org.kframework.attributes.Location(Location(1449,8,1449,36)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortString{},R} (
+      LblBool2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Bool{}(X0:SortBool{}),
+      \and{R} (
+        \dv{SortString{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1449,8,1449,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("365df37345a5a44ac061f8741369c7bd74a49f0f6e7b716be0374806dd1add3d")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"false\"","String"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835), org.kframework.attributes.Location(Location(1456,8,1456,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("false")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1456,8,1456,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("b73b5c8e0ae45020f2b9b8170d366691fee01a63763b79653a2075703ec4e835")]
+
+// rule `String2Bool(_)_STRING-COMMON_Bool_String`(#token("\"true\"","String"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8), org.kframework.attributes.Location(Location(1455,8,1455,36)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortString{}, R} (
+            X0:SortString{},
+            \dv{SortString{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblString2Bool'LParUndsRParUnds'STRING-COMMON'Unds'Bool'Unds'String{}(X0:SortString{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1455,8,1455,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("27a5d1d7872d61f82556a4e44bda13846dde7dc2d9c54304d7858de9a8b9d6b8")]
+
+// rule `_<=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80), org.kframework.attributes.Location(Location(1549,8,1549,63)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3853,14 +3948,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("656"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(656,8,656,63)"), UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80")]
+    \equals{SortBool{},R} (
+      Lbl'Unds-LT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1549,8,1549,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9e50fb4dcba1212ee863c170298cb8b555f39fb3b4bcb649f3d1d8e321accc80")]
 
-// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), contentStartColumn(8), contentStartLine(376), org.kframework.attributes.Location(Location(376,8,376,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=Bool_`(B1,B2)=>`notBool_`(`_==Bool_`(B1,B2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f), org.kframework.attributes.Location(Location(868,8,868,57)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3875,14 +3970,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("376"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(376,8,376,57)"), UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Bool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Bool'Unds'{}(VarB1:SortBool{},VarB2:SortBool{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(868,8,868,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("31fe72efcfddcd8588a11d9d10c1b1a9f96ae3da46b647d4cb9d1e8b1bd1654f")]
 
-// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), contentStartColumn(8), contentStartLine(514), org.kframework.attributes.Location(Location(514,8,514,53)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=Int_`(I1,I2)=>`notBool_`(`_==Int_`(I1,I2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3), org.kframework.attributes.Location(Location(1116,8,1116,53)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3897,14 +3992,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("514"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(514,8,514,53)"), UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'Int'Unds'{}(X0:SortInt{},X1:SortInt{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1116,8,1116,53)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4de6e05b11cdbed7ef5cb4c952127924661af4744c1e495370e1c8a962ba7be3")]
 
-// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), contentStartColumn(8), contentStartLine(957), org.kframework.attributes.Location(Location(957,8,957,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=K_`(K1,K2)=>`notBool_`(`_==K_`(K1,K2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c), org.kframework.attributes.Location(Location(2074,8,2074,45)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3919,14 +4014,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("957"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(957,8,957,45)"), UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'K'Unds'{}(VarK1:SortK{},VarK2:SortK{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2074,8,2074,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("bccaba7335e4cd77501a0667f2f7b3eb4a2105d5f60d804915dd4b1b08902c0c")]
 
-// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), contentStartColumn(8), contentStartLine(644), org.kframework.attributes.Location(Location(644,8,644,65)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_=/=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_==String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7), org.kframework.attributes.Location(Location(1529,8,1529,65)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3941,14 +4036,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("644"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(644,8,644,65)"), UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsSlshEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1529,8,1529,65)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("f390a9b650f3de0e3a93773a46e65aae3decdeb2a10906058f204f031681c9b7")]
 
-// rule `_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2))=>`_==Int_`(I1,I2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f), contentStartColumn(8), contentStartLine(488), org.kframework.attributes.Location(Location(488,8,488,40)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_==K_`(inj{Int,KItem}(I1),inj{Int,KItem}(I2))=>`_==Int_`(I1,I2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f), org.kframework.attributes.Location(Location(1090,8,1090,40)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3963,14 +4058,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
-        Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("488"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(488,8,488,40)"), UNIQUE'Unds'ID{}("8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+      \and{R} (
+        Lbl'UndsEqlsEqls'Int'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1090,8,1090,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("8bf41fa14e6cef57ebcd77d165461911b0f45874319eafd20a311466ff77ac6f")]
 
-// rule `_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2))=>`_==Bool_`(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77), contentStartColumn(8), contentStartLine(939), org.kframework.attributes.Location(Location(939,8,939,43)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_==K_`(inj{Bool,KItem}(K1),inj{Bool,KItem}(K2))=>`_==Bool_`(K1,K2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77), org.kframework.attributes.Location(Location(2056,8,2056,43)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -3985,14 +4080,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
-        Lbl'UndsEqlsEqls'Bool'Unds'{}(VarK1:SortBool{},VarK2:SortBool{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("939"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(939,8,939,43)"), UNIQUE'Unds'ID{}("51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+      \and{R} (
+        Lbl'UndsEqlsEqls'Bool'Unds'{}(VarK1:SortBool{},VarK2:SortBool{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2056,8,2056,43)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("51ca403f7048793055685a9e3a051e86807f14b2d4901ae81d0b4eedff7b1d77")]
 
-// rule `_==K_`(inj{String,KItem}(S1),inj{String,KItem}(S2))=>`_==String__STRING-COMMON_Bool_String_String`(S1,S2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(512288fc69c52cbd01cf38881d419b391f66a3d428beddb746e0012a9f880325), contentStartColumn(8), contentStartLine(698), org.kframework.attributes.Location(Location(698,8,698,49)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_==K_`(inj{String,KItem}(S1),inj{String,KItem}(S2))=>`_==String__STRING-COMMON_Bool_String_String`(S1,S2) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(512288fc69c52cbd01cf38881d419b391f66a3d428beddb746e0012a9f880325), org.kframework.attributes.Location(Location(1591,8,1591,49)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4007,14 +4102,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
-        Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("698"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(698,8,698,49)"), UNIQUE'Unds'ID{}("512288fc69c52cbd01cf38881d419b391f66a3d428beddb746e0012a9f880325")]
+    \equals{SortBool{},R} (
+      Lbl'UndsEqlsEqls'K'Unds'{}(X0:SortK{},X1:SortK{}),
+      \and{R} (
+        Lbl'UndsEqlsEqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1591,8,1591,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("512288fc69c52cbd01cf38881d419b391f66a3d428beddb746e0012a9f880325")]
 
-// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), contentStartColumn(8), contentStartLine(658), org.kframework.attributes.Location(Location(658,8,658,63)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_>=String__STRING-COMMON_Bool_String_String`(S1,S2)=>`notBool_`(`_<String__STRING-COMMON_Bool_String_String`(S1,S2)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17), org.kframework.attributes.Location(Location(1551,8,1551,63)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4029,14 +4124,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("658"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(658,8,658,63)"), UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17")]
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-Eqls'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        LblnotBool'Unds'{}(Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS1:SortString{},VarS2:SortString{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1551,8,1551,63)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("b376ffb0925555ed27696d73fc8fe43306e2005e4cf6ad819e860958992f9f17")]
 
-// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), contentStartColumn(8), contentStartLine(657), org.kframework.attributes.Location(Location(657,8,657,52)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_>String__STRING-COMMON_Bool_String_String`(S1,S2)=>`_<String__STRING-COMMON_Bool_String_String`(S2,S1) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0), org.kframework.attributes.Location(Location(1550,8,1550,52)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4051,14 +4146,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("657"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(657,8,657,52)"), UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0")]
+    \equals{SortBool{},R} (
+      Lbl'Unds-GT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        Lbl'Unds-LT-'String'UndsUnds'STRING-COMMON'Unds'Bool'Unds'String'Unds'String{}(VarS2:SortString{},VarS1:SortString{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1550,8,1550,52)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("8e5353c0a58491f8613ad7a35d0833206c342df0c91773e42485e52f4dad0cd0")]
 
-// rule `_andBool_`(#token("false","Bool") #as _1,_0)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), contentStartColumn(8), contentStartLine(349), org.kframework.attributes.Location(Location(349,8,349,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(#token("false","Bool") #as _1,_0)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497), org.kframework.attributes.Location(Location(841,8,841,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4073,45 +4168,17 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("349"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(349,8,349,37)"), UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497")]
-
-// rule `_andBool_`(#token("true","Bool") #as _0,B)=>B requires _0 ensures _0 [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), contentStartColumn(8), contentStartLine(347), org.kframework.attributes.Location(Location(347,8,347,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
       \and{R} (
-          \in{SortBool{}, R} (
-            X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
-          ),\and{R} (
-          \in{SortBool{}, R} (
-            X1:SortBool{},
-            VarB:SortBool{}
-          ),
-          \top{R} ()
-        ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("347"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(347,8,347,37)"), UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f")]
+        Var'Unds'1:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(841,8,841,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("61fbef33b3611f1cc2aaf3b5e8ddec4a0f434c557278c38461c65c8722743497")]
 
-// rule `_andBool_`(B,#token("true","Bool") #as _0)=>B requires _0 ensures _0 [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), contentStartColumn(8), contentStartLine(348), org.kframework.attributes.Location(Location(348,8,348,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(B,#token("true","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98), org.kframework.attributes.Location(Location(840,8,840,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
@@ -4119,20 +4186,18 @@ module IMP
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
+            \dv{SortBool{}}("true")
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("348"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(348,8,348,37)"), UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(840,8,840,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("e8d4ca75a690151f99f8904b068db555782f5599b11230a9d0b97a71afb6fc98")]
 
-// rule `_andBool_`(_0,#token("false","Bool") #as _1)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), contentStartColumn(8), contentStartLine(350), org.kframework.attributes.Location(Location(350,8,350,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(_0,#token("false","Bool") #as _1)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca), org.kframework.attributes.Location(Location(842,8,842,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4147,14 +4212,36 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("350"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(350,8,350,37)"), UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        Var'Unds'1:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(842,8,842,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9c183fae7de06f560180386d14d29c609cadf0c98266ce2adbecb50100a1daca")]
 
-// rule `_andThenBool_`(#token("false","Bool") #as _1,_0)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), contentStartColumn(8), contentStartLine(354), org.kframework.attributes.Location(Location(354,8,354,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f), org.kframework.attributes.Location(Location(839,8,839,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(839,8,839,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b9db8dba12010819161cc42dadccd0adf0100a47c21f884ae66c0a3d5483a1f")]
+
+// rule `_andThenBool_`(#token("false","Bool") #as _1,_0)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d), org.kframework.attributes.Location(Location(846,8,846,36)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4169,45 +4256,17 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("354"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(354,8,354,36)"), UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d")]
-
-// rule `_andThenBool_`(#token("true","Bool") #as _0,K)=>K requires _0 ensures _0 [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), contentStartColumn(8), contentStartLine(352), org.kframework.attributes.Location(Location(352,8,352,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
       \and{R} (
-          \in{SortBool{}, R} (
-            X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
-          ),\and{R} (
-          \in{SortBool{}, R} (
-            X1:SortBool{},
-            VarK:SortBool{}
-          ),
-          \top{R} ()
-        ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarK:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("352"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(352,8,352,37)"), UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689")]
+        Var'Unds'1:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(846,8,846,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5b729746be7bf2183d9eff138d97078a7c9489def6d8b2e1495c41ce3954997d")]
 
-// rule `_andThenBool_`(K,#token("true","Bool") #as _0)=>K requires _0 ensures _0 [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), contentStartColumn(8), contentStartLine(353), org.kframework.attributes.Location(Location(353,8,353,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(K,#token("true","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c), org.kframework.attributes.Location(Location(845,8,845,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
@@ -4215,20 +4274,18 @@ module IMP
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
+            \dv{SortBool{}}("true")
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarK:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("353"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(353,8,353,37)"), UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarK:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(845,8,845,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("82ac30b094be9b12206773d87b60274e929a41ca595f4674be1d37eeff873d7c")]
 
-// rule `_andThenBool_`(_0,#token("false","Bool") #as _1)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), contentStartColumn(8), contentStartLine(355), org.kframework.attributes.Location(Location(355,8,355,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_andThenBool_`(_0,#token("false","Bool") #as _1)=>_1 requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2), org.kframework.attributes.Location(Location(847,8,847,36)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4243,14 +4300,36 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("355"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(355,8,355,36)"), UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        Var'Unds'1:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(847,8,847,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("0508592878b546cbc6eeda6ec7b322584eea5c6d6eea3f72be8418fe4f7149b2")]
 
-// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), contentStartColumn(8), contentStartLine(503), org.kframework.attributes.Location(Location(503,8,504,23)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `_andThenBool_`(#token("true","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689), org.kframework.attributes.Location(Location(844,8,844,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarK:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'andThenBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarK:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(844,8,844,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("78a3191cbbdec57b0f411f41291076c8124bb0d9b6b57905674b2c6858d78689")]
+
+// rule `_divInt_`(I1,I2)=>`_/Int_`(`_-Int_`(I1,`_modInt_`(I1,I2)),I2) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4), org.kframework.attributes.Location(Location(1105,8,1106,23)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -4267,14 +4346,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
-        Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("503"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(503,8,504,23)"), UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4")]
+    \equals{SortInt{},R} (
+      Lbl'Unds'divInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
+      \and{R} (
+        Lbl'UndsSlsh'Int'Unds'{}(Lbl'Unds'-Int'Unds'{}(VarI1:SortInt{},Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{})),VarI2:SortInt{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1105,8,1106,23)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("83dcf9bc8c69f131715bc7a92d06c99b9a2b5f4c4fdafb69e6fdb2f1822712d4")]
 
-// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), contentStartColumn(8), contentStartLine(515), org.kframework.attributes.Location(Location(515,8,515,58)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_dividesInt__INT-COMMON_Bool_Int_Int`(I1,I2)=>`_==Int_`(`_%Int_`(I2,I1),#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5), org.kframework.attributes.Location(Location(1117,8,1117,58)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4289,40 +4368,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
-        Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0"))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("515"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(515,8,515,58)"), UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5")]
-
-// rule `_impliesBool_`(#token("true","Bool") #as _0,B)=>B requires _0 ensures _0 [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), contentStartColumn(8), contentStartLine(371), org.kframework.attributes.Location(Location(371,8,371,36)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+    \equals{SortBool{},R} (
+      Lbl'Unds'dividesInt'UndsUnds'INT-COMMON'Unds'Bool'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
       \and{R} (
-          \in{SortBool{}, R} (
-            X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
-          ),\and{R} (
-          \in{SortBool{}, R} (
-            X1:SortBool{},
-            VarB:SortBool{}
-          ),
-          \top{R} ()
-        ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("371"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(371,8,371,36)"), UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d")]
+        Lbl'UndsEqlsEqls'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI2:SortInt{},VarI1:SortInt{}),\dv{SortInt{}}("0")),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1117,8,1117,58)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("fd8facae0061fe5bc5c406f7ad2ed5d8d21960bf1118c9b240451253064dadb5")]
 
-// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), contentStartColumn(8), contentStartLine(374), org.kframework.attributes.Location(Location(374,8,374,45)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(B,#token("false","Bool"))=>`notBool_`(B) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96), org.kframework.attributes.Location(Location(866,8,866,45)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4337,19 +4390,17 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        LblnotBool'Unds'{}(VarB:SortBool{})),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("374"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(374,8,374,45)"), UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        LblnotBool'Unds'{}(VarB:SortBool{}),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(866,8,866,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("022c562a21d72cedfb795607d2249b8ad14b66399b720b3b2f4a05a1da08df96")]
 
-// rule `_impliesBool_`(_0,#token("true","Bool") #as _1)=>_1 requires _1 ensures _1 [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), contentStartColumn(8), contentStartLine(373), org.kframework.attributes.Location(Location(373,8,373,39)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(_0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712), org.kframework.attributes.Location(Location(865,8,865,39)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
@@ -4357,20 +4408,18 @@ module IMP
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})
+            \dv{SortBool{}}("true")
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("373"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(373,8,373,39)"), UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(865,8,865,39)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("99ba64afc26a739953df142ccd4b486bba68107fce8c9aa356d40afa7a988712")]
 
-// rule `_impliesBool_`(#token("false","Bool"),_0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), contentStartColumn(8), contentStartLine(372), org.kframework.attributes.Location(Location(372,8,372,40)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_impliesBool_`(#token("false","Bool"),_0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e), org.kframework.attributes.Location(Location(864,8,864,40)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4385,64 +4434,48 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("372"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(372,8,372,40)"), UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(864,8,864,40)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("55bb5c83c9563c712537b95401c0a5c88255fd7cdbd18b2d4358c54aee80660e")]
 
-// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, contentStartColumn(5), contentStartLine(506), org.kframework.attributes.Location(Location(506,5,509,23)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `_impliesBool_`(#token("true","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d), org.kframework.attributes.Location(Location(863,8,863,36)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            VarB:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'impliesBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(863,8,863,36)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("da818c43c21c5fb2cced7e02a74b6b4191d323de2967a671b961ad28550f3c7d")]
+
+// rule `_modInt_`(I1,I2)=>`_%Int_`(`_+Int_`(`_%Int_`(I1,`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)),`absInt(_)_INT-COMMON_Int_Int`(I2)) requires `_=/=Int_`(I2,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6), concrete, org.kframework.attributes.Location(Location(1108,5,1111,23)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol]), simplification]
+  axiom{R} \implies{R} (
+    \equals{SortBool{},R}(
         Lbl'UndsEqlsSlshEqls'Int'Unds'{}(VarI2:SortInt{},\dv{SortInt{}}("0")),
         \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      Lbl'Unds'modInt'Unds'{}(VarI1:SortInt{},VarI2:SortInt{}),
       \and{R} (
-          \in{SortInt{}, R} (
-            X0:SortInt{},
-            VarI1:SortInt{}
-          ),\and{R} (
-          \in{SortInt{}, R} (
-            X1:SortInt{},
-            VarI2:SortInt{}
-          ),
-          \top{R} ()
-        ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lbl'Unds'modInt'Unds'{}(X0:SortInt{},X1:SortInt{}),
-        Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), concrete{}(), contentStartLine{}("506"), contentStartColumn{}("5"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(506,5,509,23)"), UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6")]
+        Lbl'UndsPerc'Int'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(Lbl'UndsPerc'Int'Unds'{}(VarI1:SortInt{},LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),LblabsInt'LParUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int{}(VarI2:SortInt{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), concrete{}(), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1108,5,1111,23)"), simplification{}(), UNIQUE'Unds'ID{}("adfacb58b0678a49f66186954229939a953c9849d5b08edc8f887c0d7514b2c6")]
 
-// rule `_orBool__BOOL_Bool_Bool_Bool`(#token("true","Bool") #as _1,_0)=>_1 requires _1 ensures _1 [UNIQUE_ID(5dfb98d49c2983e9eac3a11a13792236ca26a956835ab97349bcd01d11f63a51), contentStartColumn(8), contentStartLine(361), org.kframework.attributes.Location(Location(361,8,361,34)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true")),
-      \and{R} (
-          \in{SortBool{}, R} (
-            X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})
-          ),\and{R} (
-          \in{SortBool{}, R} (
-            X1:SortBool{},
-            Var'Unds'0:SortBool{}
-          ),
-          \top{R} ()
-        ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("361"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(361,8,361,34)"), UNIQUE'Unds'ID{}("5dfb98d49c2983e9eac3a11a13792236ca26a956835ab97349bcd01d11f63a51")]
-
-// rule `_orBool__BOOL_Bool_Bool_Bool`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c382e30c30e5d297c0dcf23e21714a4fb9ab844afff2437a995d2e4379ac22c8), contentStartColumn(8), contentStartLine(364), org.kframework.attributes.Location(Location(364,8,364,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26), org.kframework.attributes.Location(Location(856,8,856,32)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4457,19 +4490,17 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("364"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(364,8,364,32)"), UNIQUE'Unds'ID{}("c382e30c30e5d297c0dcf23e21714a4fb9ab844afff2437a995d2e4379ac22c8")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(856,8,856,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("d7245713da157cf997438091f92bb78eb51a6cefa568bb0d30560ce08d647f26")]
 
-// rule `_orBool__BOOL_Bool_Bool_Bool`(_0,#token("true","Bool") #as _1)=>_1 requires _1 ensures _1 [UNIQUE_ID(0cd71a2e6180fcbaf817fdcded5a5e68f59b5eb6d14a2dc2be83729bf264f7c6), contentStartColumn(8), contentStartLine(362), org.kframework.attributes.Location(Location(362,8,362,34)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(_0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3), org.kframework.attributes.Location(Location(854,8,854,34)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
@@ -4477,20 +4508,18 @@ module IMP
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})
+            \dv{SortBool{}}("true")
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("362"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(362,8,362,34)"), UNIQUE'Unds'ID{}("0cd71a2e6180fcbaf817fdcded5a5e68f59b5eb6d14a2dc2be83729bf264f7c6")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(854,8,854,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("47860d52c18a441b229449cd89d5464256137dc32deb5551effbac0482c883f3")]
 
-// rule `_orBool__BOOL_Bool_Bool_Bool`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(fc141041c3f424eab4159b85971a8f6888c5e602c3b29505bc623a976293d974), contentStartColumn(8), contentStartLine(363), org.kframework.attributes.Location(Location(363,8,363,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b), org.kframework.attributes.Location(Location(855,8,855,32)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4505,23 +4534,21 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orBool'UndsUnds'BOOL'Unds'Bool'Unds'Bool'Unds'Bool{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("363"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(363,8,363,32)"), UNIQUE'Unds'ID{}("fc141041c3f424eab4159b85971a8f6888c5e602c3b29505bc623a976293d974")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(855,8,855,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("991a3290bc7b6dca75d676a72a848ec6b2bd2827fb0e9626252aa1507394ca1b")]
 
-// rule `_orElseBool_`(#token("true","Bool") #as _1,_0)=>_1 requires _1 ensures _1 [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), contentStartColumn(8), contentStartLine(366), org.kframework.attributes.Location(Location(366,8,366,33)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orBool_`(#token("true","Bool"),_0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2), org.kframework.attributes.Location(Location(853,8,853,34)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})
+            \dv{SortBool{}}("true")
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
@@ -4529,16 +4556,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("366"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(366,8,366,33)"), UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(853,8,853,34)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("71744528cdad83bc729990d3af3b544d27b09630b2615ca707dd2fc6ec93e7c2")]
 
-// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), contentStartColumn(8), contentStartLine(369), org.kframework.attributes.Location(Location(369,8,369,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(K,#token("false","Bool"))=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480), org.kframework.attributes.Location(Location(861,8,861,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4553,19 +4578,17 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarK:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("369"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(369,8,369,37)"), UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarK:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(861,8,861,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("684b0444a1f711d49ff1502423a3346fb26958697423db488b05d25081fc0480")]
 
-// rule `_orElseBool_`(_0,#token("true","Bool") #as _1)=>_1 requires _1 ensures _1 [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), contentStartColumn(8), contentStartLine(367), org.kframework.attributes.Location(Location(367,8,367,33)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(_0,#token("true","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14), org.kframework.attributes.Location(Location(859,8,859,33)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true")),
+      \top{R}(),
       \and{R} (
           \in{SortBool{}, R} (
             X0:SortBool{},
@@ -4573,20 +4596,18 @@ module IMP
           ),\and{R} (
           \in{SortBool{}, R} (
             X1:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'1:SortBool{})
+            \dv{SortBool{}}("true")
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        Var'Unds'1:SortBool{}),
-      \equals{SortBool{},R}(
-        Var'Unds'1:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("367"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(367,8,367,33)"), UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(859,8,859,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("c9eccff94ecf6e810c600d4536bf1701485c13c3456c6b98c0cdab0fe7c5af14")]
 
-// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), contentStartColumn(8), contentStartLine(368), org.kframework.attributes.Location(Location(368,8,368,37)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(#token("false","Bool"),K)=>K requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf), org.kframework.attributes.Location(Location(860,8,860,37)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4601,14 +4622,36 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarK:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("368"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(368,8,368,37)"), UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarK:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(860,8,860,37)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("eb8c85dac19a5951f694b65269c2b17c80d6d126d6a367958e4a5d736a880ecf")]
 
-// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), contentStartColumn(8), contentStartLine(359), org.kframework.attributes.Location(Location(359,8,359,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_orElseBool_`(#token("true","Bool"),_0)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6), org.kframework.attributes.Location(Location(858,8,858,33)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),\and{R} (
+          \in{SortBool{}, R} (
+            X1:SortBool{},
+            Var'Unds'0:SortBool{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortBool{},R} (
+      Lbl'Unds'orElseBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(858,8,858,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("354bd0860c7f38b59e285c935fd2ea553ebddbabb4973342ad25f0dac6ea7bf6")]
+
+// rule `_xorBool_`(B,B)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f), org.kframework.attributes.Location(Location(851,8,851,38)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4623,14 +4666,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("359"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(359,8,359,38)"), UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(851,8,851,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("9a6d91cd75cd777b0d4db536b3e4b20578e74fe650e644b55294da95fd2dba7f")]
 
-// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), contentStartColumn(8), contentStartLine(358), org.kframework.attributes.Location(Location(358,8,358,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_xorBool_`(B,#token("false","Bool"))=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75), org.kframework.attributes.Location(Location(850,8,850,38)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4645,14 +4688,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("358"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(358,8,358,38)"), UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(850,8,850,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("7a2851f9d4ea4bd3f35070ee029fc3bdca36e361f7ee54addeff9d10ddeb7c75")]
 
-// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), contentStartColumn(8), contentStartLine(357), org.kframework.attributes.Location(Location(357,8,357,38)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_xorBool_`(#token("false","Bool"),B)=>B requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf), org.kframework.attributes.Location(Location(849,8,849,38)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4667,14 +4710,36 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
-        VarB:SortBool{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("357"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(357,8,357,38)"), UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf")]
+    \equals{SortBool{},R} (
+      Lbl'Unds'xorBool'Unds'{}(X0:SortBool{},X1:SortBool{}),
+      \and{R} (
+        VarB:SortBool{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(849,8,849,38)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("73513655c09a595907ab9d26d67e27f01d14a3435743b77000c02d10f35c05bf")]
 
-// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), contentStartColumn(8), contentStartLine(499), org.kframework.attributes.Location(Location(499,8,499,85)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `_|Set__SET_Set_Set_Set`(S1,S2)=>`_Set_`(S1,`Set:difference`(S2,S1)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62), org.kframework.attributes.Location(Location(555,8,555,45)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortSet{}, R} (
+            X0:SortSet{},
+            VarS1:SortSet{}
+          ),\and{R} (
+          \in{SortSet{}, R} (
+            X1:SortSet{},
+            VarS2:SortSet{}
+          ),
+          \top{R} ()
+        ))),
+    \equals{SortSet{},R} (
+      Lbl'UndsPipe'Set'UndsUnds'SET'Unds'Set'Unds'Set'Unds'Set{}(X0:SortSet{},X1:SortSet{}),
+      \and{R} (
+        Lbl'Unds'Set'Unds'{}(VarS1:SortSet{},LblSet'Coln'difference{}(VarS2:SortSet{},VarS1:SortSet{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(555,8,555,45)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("e9a710d8d1ca5c799420161879cbbff926de45a5bddd820d646f51d43eb67e62")]
+
+// rule `bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_modInt_`(`_>>Int_`(I,IDX),`_<<Int_`(#token("1","Int"),LEN)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119), org.kframework.attributes.Location(Location(1101,8,1101,85)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4693,14 +4758,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
-        Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("499"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(499,8,499,85)"), UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119")]
+    \equals{SortInt{},R} (
+      LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+      \and{R} (
+        Lbl'Unds'modInt'Unds'{}(Lbl'Unds-GT--GT-'Int'Unds'{}(VarI:SortInt{},VarIDX:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1101,8,1101,85)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("147fc15c2ec6c36de1a9c0cad6212b8acd8b224f21c0aeabd36726e9c8a06119")]
 
-// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), contentStartColumn(8), contentStartLine(667), org.kframework.attributes.Location(Location(667,8,668,60)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>`_+Int_`(#token("1","Int"),`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToCount)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToCount)) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e), org.kframework.attributes.Location(Location(1560,8,1561,60)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -4717,14 +4782,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("667"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(667,8,668,60)"), UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e")]
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToCount:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToCount:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToCount:SortString{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1560,8,1561,60)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("628cff029a6d79e4c99999c0309f91ab8cb12f0ba549bb3faa850f96304c970e")]
 
-// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), contentStartColumn(8), contentStartLine(665), org.kframework.attributes.Location(Location(665,8,666,59)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToCount)=>#token("0","Int") requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToCount,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84), org.kframework.attributes.Location(Location(1558,8,1559,59)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -4741,14 +4806,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
-        \dv{SortInt{}}("0")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("665"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(665,8,666,59)"), UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84")]
+    \equals{SortInt{},R} (
+      LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{}),
+      \and{R} (
+        \dv{SortInt{}}("0"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1558,8,1559,59)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("1c726cd81629c2e5f411539a7f9b4d297e8600e5d71a5d235d287e3001f3ec84")]
 
-// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295), contentStartColumn(8), contentStartLine(660), org.kframework.attributes.Location(Location(660,8,660,431)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),#token("-1","Int")),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),`#if_#then_#else_#fi_K-EQUAL-SYNTAX_Sort_Bool_Sort_Sort`{Int}(`_==Int_`(`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I),#token("-1","Int")),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`minInt(_,_)_INT-COMMON_Int_Int_Int`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)))) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295), org.kframework.attributes.Location(Location(1553,8,1553,431)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -4769,14 +4834,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
-        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}))))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("660"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(660,8,660,431)"), UNIQUE'Unds'ID{}("9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295")]
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+      \and{R} (
+        Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),Lbl'Hash'if'UndsHash'then'UndsHash'else'UndsHash'fi'Unds'K-EQUAL-SYNTAX'Unds'Sort'Unds'Bool'Unds'Sort'Unds'Sort{SortInt{}}(Lbl'UndsEqlsEqls'Int'Unds'{}(LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}),\dv{SortInt{}}("-1")),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})))),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1553,8,1553,431)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("9a3b7d1924363894c859ceb6bcec34fb944f01a5e0c90679d41b8430990b7295")]
 
-// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), contentStartColumn(8), contentStartLine(661), org.kframework.attributes.Location(Location(661,8,661,32)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `findChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117), org.kframework.attributes.Location(Location(1554,8,1554,32)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4795,14 +4860,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
-        \dv{SortInt{}}("-1")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("661"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(661,8,661,32)"), UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117")]
+    \equals{SortInt{},R} (
+      LblfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+      \and{R} (
+        \dv{SortInt{}}("-1"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1554,8,1554,32)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("5a6cf981f0ec2494854cd3e517b0cf645a1c9762c92a14849adfca9a6a553117")]
 
-// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), contentStartColumn(8), contentStartLine(910), org.kframework.attributes.Location(Location(910,8,910,62)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `freshId(_)_ID-COMMON_Id_Int`(I)=>`String2Id(_)_ID-COMMON_Id_String`(`_+String__STRING-COMMON_String_String_String`(#token("\"_\"","String"),`Int2String(_)_STRING-COMMON_String_Int`(I))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de), org.kframework.attributes.Location(Location(2013,8,2013,62)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4813,14 +4878,14 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortId{},R} (
-        LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
-        LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{})))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("910"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(910,8,910,62)"), UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de")]
+    \equals{SortId{},R} (
+      LblfreshId'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'Int{}(X0:SortInt{}),
+      \and{R} (
+        LblString2Id'LParUndsRParUnds'ID-COMMON'Unds'Id'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(\dv{SortString{}}("_"),LblInt2String'LParUndsRParUnds'STRING-COMMON'Unds'String'Unds'Int{}(VarI:SortInt{}))),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(2013,8,2013,62)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3965c8e65257ebae926d601fa8ac672d34e4c211d73ba594c571c6bc5960f3de")]
 
-// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), contentStartColumn(8), contentStartLine(518), org.kframework.attributes.Location(Location(518,8,518,28)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `freshInt(_)_INT_Int_Int`(I)=>I requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b), org.kframework.attributes.Location(Location(1120,8,1120,28)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4831,29 +4896,29 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
-        VarI:SortInt{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("518"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(518,8,518,28)"), UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b")]
+    \equals{SortInt{},R} (
+      LblfreshInt'LParUndsRParUnds'INT'Unds'Int'Unds'Int{}(X0:SortInt{}),
+      \and{R} (
+        VarI:SortInt{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1120,8,1120,28)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("cf2cb8f038b4bdc4edb1334a3b8ced9cd296a7af43f0a1916e082a4e1aefa08b")]
 
-// rule getGeneratedCounterCell(`<generatedTop>`(DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") 
+// rule getGeneratedCounterCell(`<generatedTop>`(_DotVar0,Cell))=>Cell requires #token("true","Bool") ensures #token("true","Bool") 
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
       \and{R} (
           \in{SortGeneratedTopCell{}, R} (
             X0:SortGeneratedTopCell{},
-            Lbl'-LT-'generatedTop'-GT-'{}(VarDotVar0:SortTCell{},VarCell:SortGeneratedCounterCell{})
+            Lbl'-LT-'generatedTop'-GT-'{}(Var'Unds'DotVar0:SortTCell{},VarCell:SortGeneratedCounterCell{})
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedCounterCell{},R} (
-        LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
-        VarCell:SortGeneratedCounterCell{}),
-      \top{R}()))
+    \equals{SortGeneratedCounterCell{},R} (
+      LblgetGeneratedCounterCell{}(X0:SortGeneratedTopCell{}),
+      \and{R} (
+        VarCell:SortGeneratedCounterCell{},
+        \top{R}())))
   []
 
 // rule initGeneratedCounterCell(.KList)=>`<generatedCounter>`(#token("0","Int")) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
@@ -4863,11 +4928,11 @@ module IMP
       
           \top{R} ()
         ),
-    \and{R} (
-      \equals{SortGeneratedCounterCell{},R} (
-        LblinitGeneratedCounterCell{}(),
-        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0"))),
-      \top{R}()))
+    \equals{SortGeneratedCounterCell{},R} (
+      LblinitGeneratedCounterCell{}(),
+      \and{R} (
+        Lbl'-LT-'generatedCounter'-GT-'{}(\dv{SortInt{}}("0")),
+        \top{R}())))
   [initializer{}()]
 
 // rule initGeneratedTopCell(Init)=>`<generatedTop>`(initTCell(Init),initGeneratedCounterCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
@@ -4881,14 +4946,14 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedTopCell{},R} (
-        LblinitGeneratedTopCell{}(X0:SortMap{}),
-        Lbl'-LT-'generatedTop'-GT-'{}(LblinitTCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}())),
-      \top{R}()))
+    \equals{SortGeneratedTopCell{},R} (
+      LblinitGeneratedTopCell{}(X0:SortMap{}),
+      \and{R} (
+        Lbl'-LT-'generatedTop'-GT-'{}(LblinitTCell{}(VarInit:SortMap{}),LblinitGeneratedCounterCell{}()),
+        \top{R}())))
   [initializer{}()]
 
-// rule initKCell(Init)=>`<k>`(inj{Pgm,KItem}(`project:Pgm`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))))) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+// rule initKCell(Init)=>`<k>`(inj{Pgm,KItem}(`project:Pgm`(`Map:lookup`(Init,inj{KConfigVar,KItem}(#token("$PGM","KConfigVar")))))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(2c27c82d95db0d013b27337c5057cdbf7d8d5ae5460c4707579c33ffff961106), initializer]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4899,28 +4964,28 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortKCell{},R} (
-        LblinitKCell{}(X0:SortMap{}),
-        Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblproject'Coln'Pgm{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),dotk{}()))),
-      \top{R}()))
-  [initializer{}()]
+    \equals{SortKCell{},R} (
+      LblinitKCell{}(X0:SortMap{}),
+      \and{R} (
+        Lbl'-LT-'k'-GT-'{}(kseq{}(inj{SortPgm{}, SortKItem{}}(Lblproject'Coln'Pgm{}(kseq{}(LblMap'Coln'lookup{}(VarInit:SortMap{},inj{SortKConfigVar{}, SortKItem{}}(\dv{SortKConfigVar{}}("$PGM"))),dotk{}()))),dotk{}())),
+        \top{R}())))
+  [initializer{}(), UNIQUE'Unds'ID{}("2c27c82d95db0d013b27337c5057cdbf7d8d5ae5460c4707579c33ffff961106")]
 
-// rule initStateCell(.KList)=>`<state>`(`.Map`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+// rule initStateCell(.KList)=>`<state>`(`.Map`(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(7293f401e67a4c1a5310b2bb8e08362f66e73646e2067fb5f94bd1eb124e0460), initializer]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
       
           \top{R} ()
         ),
-    \and{R} (
-      \equals{SortStateCell{},R} (
-        LblinitStateCell{}(),
-        Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}())),
-      \top{R}()))
-  [initializer{}()]
+    \equals{SortStateCell{},R} (
+      LblinitStateCell{}(),
+      \and{R} (
+        Lbl'-LT-'state'-GT-'{}(Lbl'Stop'Map{}()),
+        \top{R}())))
+  [initializer{}(), UNIQUE'Unds'ID{}("7293f401e67a4c1a5310b2bb8e08362f66e73646e2067fb5f94bd1eb124e0460")]
 
-// rule initTCell(Init)=>`<T>`(initKCell(Init),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [initializer]
+// rule initTCell(Init)=>`<T>`(initKCell(Init),initStateCell(.KList)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(082e738743e54caf1b2a3e9be1aa464283ccaca4c3a7d07813904226676400bf), initializer]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -4931,25 +4996,25 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortTCell{},R} (
-        LblinitTCell{}(X0:SortMap{}),
-        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitStateCell{}())),
-      \top{R}()))
-  [initializer{}()]
+    \equals{SortTCell{},R} (
+      LblinitTCell{}(X0:SortMap{}),
+      \and{R} (
+        Lbl'-LT-'T'-GT-'{}(LblinitKCell{}(VarInit:SortMap{}),LblinitStateCell{}()),
+        \top{R}())))
+  [initializer{}(), UNIQUE'Unds'ID{}("082e738743e54caf1b2a3e9be1aa464283ccaca4c3a7d07813904226676400bf")]
 
 // rule isAExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
   axiom{R} \implies{R} (
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortAExp{},
+          \exists{R} (Var'Unds'1:SortAExp{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortAExp{}, SortKItem{}}(Var'Unds'0:SortAExp{}),dotk{}())
+                  kseq{}(inj{SortAExp{}, SortKItem{}}(Var'Unds'1:SortAExp{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -4967,11 +5032,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisAExp{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisAExp{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isAExp(inj{AExp,KItem}(AExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -4985,11 +5050,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisAExp{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisAExp{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isBExp(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -4997,13 +5062,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortBExp{},
+          \exists{R} (Var'Unds'0:SortBExp{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortBExp{}, SortKItem{}}(Var'Unds'1:SortBExp{}),dotk{}())
+                  kseq{}(inj{SortBExp{}, SortKItem{}}(Var'Unds'0:SortBExp{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5021,11 +5086,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBExp{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisBExp{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isBExp(inj{BExp,KItem}(BExp))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5039,11 +5104,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBExp{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisBExp{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isBlock(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5051,13 +5116,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortBlock{},
+          \exists{R} (Var'Unds'0:SortBlock{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortBlock{}, SortKItem{}}(Var'Unds'1:SortBlock{}),dotk{}())
+                  kseq{}(inj{SortBlock{}, SortKItem{}}(Var'Unds'0:SortBlock{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5075,11 +5140,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBlock{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisBlock{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isBlock(inj{Block,KItem}(Block))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5093,11 +5158,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBlock{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisBlock{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isBool(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5129,11 +5194,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBool{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isBool(inj{Bool,KItem}(Bool))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5147,65 +5212,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisBool{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
-  []
-
-// rule isCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
-  axiom{R} \implies{R} (
-    \and{R} (
-      \not{R} (
-        \or{R} (
-          \exists{R} (Var'Unds'1:SortCell{},
-            \and{R} (
-              \top{R}(),
-              \and{R} (
-                \in{SortK{}, R} (
-                  X0:SortK{},
-                  kseq{}(inj{SortCell{}, SortKItem{}}(Var'Unds'1:SortCell{}),dotk{}())
-                ),
-                \top{R} ()
-              )
-          )),
-          \bottom{R}()
-        )
-      ),
-      \and{R}(
-        \top{R}(),
-        \and{R} (
-          \in{SortK{}, R} (
-            X0:SortK{},
-            VarK:SortK{}
-          ),
-          \top{R} ()
-        )
-    )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
-  [owise{}()]
-
-// rule isCell(inj{Cell,KItem}(Cell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
-  axiom{R} \implies{R} (
-    \and{R}(
-      \top{R}(),
+    \equals{SortBool{},R} (
+      LblisBool{}(X0:SortK{}),
       \and{R} (
-          \in{SortK{}, R} (
-            X0:SortK{},
-            kseq{}(inj{SortCell{}, SortKItem{}}(VarCell:SortCell{}),dotk{}())
-          ),
-          \top{R} ()
-        )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isFloat(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5237,11 +5248,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisFloat{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isFloat(inj{Float,KItem}(Float))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5255,11 +5266,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisFloat{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisFloat{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isGeneratedCounterCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5267,13 +5278,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortGeneratedCounterCell{},
+          \exists{R} (Var'Unds'1:SortGeneratedCounterCell{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'0:SortGeneratedCounterCell{}),dotk{}())
+                  kseq{}(inj{SortGeneratedCounterCell{}, SortKItem{}}(Var'Unds'1:SortGeneratedCounterCell{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5291,11 +5302,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedCounterCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isGeneratedCounterCell(inj{GeneratedCounterCell,KItem}(GeneratedCounterCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5309,11 +5320,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedCounterCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isGeneratedCounterCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5321,13 +5332,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortGeneratedCounterCellOpt{},
+          \exists{R} (Var'Unds'1:SortGeneratedCounterCellOpt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'0:SortGeneratedCounterCellOpt{}),dotk{}())
+                  kseq{}(inj{SortGeneratedCounterCellOpt{}, SortKItem{}}(Var'Unds'1:SortGeneratedCounterCellOpt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5345,11 +5356,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedCounterCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isGeneratedCounterCellOpt(inj{GeneratedCounterCellOpt,KItem}(GeneratedCounterCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5363,11 +5374,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedCounterCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedCounterCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isGeneratedTopCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5399,11 +5410,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedTopCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isGeneratedTopCell(inj{GeneratedTopCell,KItem}(GeneratedTopCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5417,11 +5428,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedTopCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isGeneratedTopCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5453,11 +5464,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedTopCellFragment{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isGeneratedTopCellFragment(inj{GeneratedTopCellFragment,KItem}(GeneratedTopCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5471,11 +5482,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisGeneratedTopCellFragment{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisGeneratedTopCellFragment{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isIOError(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5507,11 +5518,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOError{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isIOError(inj{IOError,KItem}(IOError))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5525,11 +5536,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOError{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOError{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isIOFile(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5537,13 +5548,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortIOFile{},
+          \exists{R} (Var'Unds'0:SortIOFile{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'1:SortIOFile{}),dotk{}())
+                  kseq{}(inj{SortIOFile{}, SortKItem{}}(Var'Unds'0:SortIOFile{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5561,11 +5572,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOFile{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isIOFile(inj{IOFile,KItem}(IOFile))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5579,11 +5590,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOFile{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOFile{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isIOInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5591,13 +5602,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortIOInt{},
+          \exists{R} (Var'Unds'0:SortIOInt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'1:SortIOInt{}),dotk{}())
+                  kseq{}(inj{SortIOInt{}, SortKItem{}}(Var'Unds'0:SortIOInt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5615,11 +5626,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOInt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isIOInt(inj{IOInt,KItem}(IOInt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5633,11 +5644,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOInt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOInt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isIOString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5669,11 +5680,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOString{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isIOString(inj{IOString,KItem}(IOString))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5687,11 +5698,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIOString{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIOString{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isId(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5699,13 +5710,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortId{},
+          \exists{R} (Var'Unds'0:SortId{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'1:SortId{}),dotk{}())
+                  kseq{}(inj{SortId{}, SortKItem{}}(Var'Unds'0:SortId{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5723,11 +5734,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisId{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isId(inj{Id,KItem}(Id))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5741,11 +5752,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisId{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisId{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isIds(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5753,13 +5764,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortIds{},
+          \exists{R} (Var'Unds'0:SortIds{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortIds{}, SortKItem{}}(Var'Unds'1:SortIds{}),dotk{}())
+                  kseq{}(inj{SortIds{}, SortKItem{}}(Var'Unds'0:SortIds{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5777,11 +5788,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIds{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIds{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isIds(inj{Ids,KItem}(Ids))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5795,11 +5806,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisIds{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisIds{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isInt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5807,13 +5818,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortInt{},
+          \exists{R} (Var'Unds'1:SortInt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'0:SortInt{}),dotk{}())
+                  kseq{}(inj{SortInt{}, SortKItem{}}(Var'Unds'1:SortInt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5831,11 +5842,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisInt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isInt(inj{Int,KItem}(Int))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5849,11 +5860,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisInt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisInt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isK(K)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5867,11 +5878,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisK{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisK{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isKCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5903,11 +5914,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isKCell(inj{KCell,KItem}(KCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5921,11 +5932,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isKCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -5933,13 +5944,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortKCellOpt{},
+          \exists{R} (Var'Unds'0:SortKCellOpt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'1:SortKCellOpt{}),dotk{}())
+                  kseq{}(inj{SortKCellOpt{}, SortKItem{}}(Var'Unds'0:SortKCellOpt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -5957,11 +5968,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isKCellOpt(inj{KCellOpt,KItem}(KCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -5975,11 +5986,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isKConfigVar(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6011,11 +6022,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKConfigVar{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isKConfigVar(inj{KConfigVar,KItem}(KConfigVar))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6029,11 +6040,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKConfigVar{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKConfigVar{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isKItem(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6041,13 +6052,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortKItem{},
+          \exists{R} (Var'Unds'1:SortKItem{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(Var'Unds'0:SortKItem{},dotk{}())
+                  kseq{}(Var'Unds'1:SortKItem{},dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6065,11 +6076,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKItem{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isKItem(KItem)=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6083,11 +6094,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKItem{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKItem{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isKResult(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6119,11 +6130,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKResult{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isKResult(inj{KResult,KItem}(KResult))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6137,11 +6148,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisKResult{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisKResult{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isList(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6173,11 +6184,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisList{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isList(inj{List,KItem}(List))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6191,11 +6202,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisList{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisList{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isMap(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6227,11 +6238,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisMap{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isMap(inj{Map,KItem}(Map))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6245,11 +6256,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisMap{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisMap{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isPgm(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6257,13 +6268,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortPgm{},
+          \exists{R} (Var'Unds'1:SortPgm{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortPgm{}, SortKItem{}}(Var'Unds'0:SortPgm{}),dotk{}())
+                  kseq{}(inj{SortPgm{}, SortKItem{}}(Var'Unds'1:SortPgm{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6281,11 +6292,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisPgm{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisPgm{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isPgm(inj{Pgm,KItem}(Pgm))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6299,11 +6310,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisPgm{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisPgm{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isSet(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6311,13 +6322,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortSet{},
+          \exists{R} (Var'Unds'0:SortSet{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'1:SortSet{}),dotk{}())
+                  kseq{}(inj{SortSet{}, SortKItem{}}(Var'Unds'0:SortSet{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6335,11 +6346,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisSet{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isSet(inj{Set,KItem}(Set))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6353,11 +6364,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisSet{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisSet{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isStateCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6389,11 +6400,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStateCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStateCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isStateCell(inj{StateCell,KItem}(StateCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6407,11 +6418,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStateCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStateCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isStateCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6443,11 +6454,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStateCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStateCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isStateCellOpt(inj{StateCellOpt,KItem}(StateCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6461,11 +6472,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStateCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStateCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isStmt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6473,13 +6484,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'1:SortStmt{},
+          \exists{R} (Var'Unds'0:SortStmt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortStmt{}, SortKItem{}}(Var'Unds'1:SortStmt{}),dotk{}())
+                  kseq{}(inj{SortStmt{}, SortKItem{}}(Var'Unds'0:SortStmt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6497,11 +6508,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStmt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStmt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isStmt(inj{Stmt,KItem}(Stmt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6515,11 +6526,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStmt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStmt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isStream(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6527,13 +6538,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortStream{},
+          \exists{R} (Var'Unds'1:SortStream{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'0:SortStream{}),dotk{}())
+                  kseq{}(inj{SortStream{}, SortKItem{}}(Var'Unds'1:SortStream{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6551,11 +6562,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStream{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isStream(inj{Stream,KItem}(Stream))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6569,11 +6580,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisStream{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisStream{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isString(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6605,11 +6616,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisString{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isString(inj{String,KItem}(String))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6623,11 +6634,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisString{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisString{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isTCell(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6659,11 +6670,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCell{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isTCell(inj{TCell,KItem}(TCell))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6677,11 +6688,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCell{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCell{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isTCellFragment(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6713,11 +6724,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCellFragment{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCellFragment{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isTCellFragment(inj{TCellFragment,KItem}(TCellFragment))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6731,11 +6742,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCellFragment{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCellFragment{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
 // rule isTCellOpt(K)=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [owise]
@@ -6743,13 +6754,13 @@ module IMP
     \and{R} (
       \not{R} (
         \or{R} (
-          \exists{R} (Var'Unds'0:SortTCellOpt{},
+          \exists{R} (Var'Unds'1:SortTCellOpt{},
             \and{R} (
               \top{R}(),
               \and{R} (
                 \in{SortK{}, R} (
                   X0:SortK{},
-                  kseq{}(inj{SortTCellOpt{}, SortKItem{}}(Var'Unds'0:SortTCellOpt{}),dotk{}())
+                  kseq{}(inj{SortTCellOpt{}, SortKItem{}}(Var'Unds'1:SortTCellOpt{}),dotk{}())
                 ),
                 \top{R} ()
               )
@@ -6767,11 +6778,11 @@ module IMP
           \top{R} ()
         )
     )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("false")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
   [owise{}()]
 
 // rule isTCellOpt(inj{TCellOpt,KItem}(TCellOpt))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6785,14 +6796,14 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblisTCellOpt{}(X0:SortK{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
+    \equals{SortBool{},R} (
+      LblisTCellOpt{}(X0:SortK{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
   []
 
-// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), contentStartColumn(8), contentStartLine(511), org.kframework.attributes.Location(Location(511,8,511,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I1 requires `_<=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6), org.kframework.attributes.Location(Location(1113,8,1113,57)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -6809,14 +6820,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
-        VarI1:SortInt{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("511"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(511,8,511,57)"), UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6")]
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
+      \and{R} (
+        VarI1:SortInt{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1113,8,1113,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("fb09b6acc4366cb77203e07c4efe8a9cf304e1bac9fb0664deea05d3eb9a80c6")]
 
-// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), contentStartColumn(8), contentStartLine(512), org.kframework.attributes.Location(Location(512,8,512,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `minInt(_,_)_INT-COMMON_Int_Int_Int`(I1,I2)=>I2 requires `_>=Int_`(I1,I2) ensures #token("true","Bool") [UNIQUE_ID(e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3), org.kframework.attributes.Location(Location(1114,8,1114,57)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -6833,36 +6844,14 @@ module IMP
           ),
           \top{R} ()
         ))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
-        VarI2:SortInt{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("512"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(512,8,512,57)"), UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3")]
-
-// rule `notBool_`(#token("true","Bool") #as _0)=>#token("false","Bool") requires _0 ensures _0 [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), contentStartColumn(8), contentStartLine(344), org.kframework.attributes.Location(Location(344,8,344,29)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true")),
+    \equals{SortInt{},R} (
+      LblminInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{}),
       \and{R} (
-          \in{SortBool{}, R} (
-            X0:SortBool{},
-            \and{SortBool{}}(\dv{SortBool{}}("true"),Var'Unds'0:SortBool{})
-          ),
-          \top{R} ()
-        )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblnotBool'Unds'{}(X0:SortBool{}),
-        \dv{SortBool{}}("false")),
-      \equals{SortBool{},R}(
-        Var'Unds'0:SortBool{},
-        \dv{SortBool{}}("true"))))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("344"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(344,8,344,29)"), UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c")]
+        VarI2:SortInt{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1114,8,1114,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("e1effeabf96bb3a3beffd5b679ad5df95c4f8bbf42872b0793331e52a8470fb3")]
 
-// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), contentStartColumn(8), contentStartLine(345), org.kframework.attributes.Location(Location(345,8,345,29)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `notBool_`(#token("false","Bool"))=>#token("true","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415), org.kframework.attributes.Location(Location(837,8,837,29)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -6873,12 +6862,30 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        LblnotBool'Unds'{}(X0:SortBool{}),
-        \dv{SortBool{}}("true")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("345"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(345,8,345,29)"), UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415")]
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("true"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(837,8,837,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("17ebc68421572b8ebe609c068fb49cbb6cbbe3246e2142257ad8befdda38f415")]
+
+// rule `notBool_`(#token("true","Bool"))=>#token("false","Bool") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c), org.kframework.attributes.Location(Location(836,8,836,29)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+  axiom{R} \implies{R} (
+    \and{R}(
+      \top{R}(),
+      \and{R} (
+          \in{SortBool{}, R} (
+            X0:SortBool{},
+            \dv{SortBool{}}("true")
+          ),
+          \top{R} ()
+        )),
+    \equals{SortBool{},R} (
+      LblnotBool'Unds'{}(X0:SortBool{}),
+      \and{R} (
+        \dv{SortBool{}}("false"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(836,8,836,29)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("53fc758ece1ff16581673016dfacc556cc30fcf6b3c35b586f001d76a1f9336c")]
 
 // rule `project:#tempFile:fd`(#tempFile(K0,K1))=>K1 requires #token("true","Bool") ensures #token("true","Bool") 
   axiom{R} \implies{R} (
@@ -6891,11 +6898,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
-        VarK1:SortInt{}),
-      \top{R}()))
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'tempFile'Coln'fd{}(X0:SortIOFile{}),
+      \and{R} (
+        VarK1:SortInt{},
+        \top{R}())))
   []
 
 // rule `project:#tempFile:path`(#tempFile(K0,K1))=>K0 requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6909,11 +6916,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortString{},R} (
-        Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
-        VarK0:SortString{}),
-      \top{R}()))
+    \equals{SortString{},R} (
+      Lblproject'ColnHash'tempFile'Coln'path{}(X0:SortIOFile{}),
+      \and{R} (
+        VarK0:SortString{},
+        \top{R}())))
   []
 
 // rule `project:#unknownIOError:errno`(#unknownIOError(K0))=>K0 requires #token("true","Bool") ensures #token("true","Bool") 
@@ -6927,11 +6934,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
-        VarK0:SortInt{}),
-      \top{R}()))
+    \equals{SortInt{},R} (
+      Lblproject'ColnHash'unknownIOError'Coln'errno{}(X0:SortIOError{}),
+      \and{R} (
+        VarK0:SortInt{},
+        \top{R}())))
   []
 
 // rule `project:AExp`(inj{AExp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -6945,11 +6952,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortAExp{},R} (
-        Lblproject'Coln'AExp{}(X0:SortK{}),
-        VarK:SortAExp{}),
-      \top{R}()))
+    \equals{SortAExp{},R} (
+      Lblproject'Coln'AExp{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortAExp{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:BExp`(inj{BExp,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -6963,11 +6970,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBExp{},R} (
-        Lblproject'Coln'BExp{}(X0:SortK{}),
-        VarK:SortBExp{}),
-      \top{R}()))
+    \equals{SortBExp{},R} (
+      Lblproject'Coln'BExp{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortBExp{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Block`(inj{Block,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -6981,11 +6988,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBlock{},R} (
-        Lblproject'Coln'Block{}(X0:SortK{}),
-        VarK:SortBlock{}),
-      \top{R}()))
+    \equals{SortBlock{},R} (
+      Lblproject'Coln'Block{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortBlock{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Bool`(inj{Bool,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -6999,29 +7006,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortBool{},R} (
-        Lblproject'Coln'Bool{}(X0:SortK{}),
-        VarK:SortBool{}),
-      \top{R}()))
-  [projection{}()]
-
-// rule `project:Cell`(inj{Cell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
-  axiom{R} \implies{R} (
-    \and{R}(
-      \top{R}(),
+    \equals{SortBool{},R} (
+      Lblproject'Coln'Bool{}(X0:SortK{}),
       \and{R} (
-          \in{SortK{}, R} (
-            X0:SortK{},
-            kseq{}(inj{SortCell{}, SortKItem{}}(VarK:SortCell{}),dotk{}())
-          ),
-          \top{R} ()
-        )),
-    \and{R} (
-      \equals{SortCell{},R} (
-        Lblproject'Coln'Cell{}(X0:SortK{}),
-        VarK:SortCell{}),
-      \top{R}()))
+        VarK:SortBool{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Float`(inj{Float,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7035,11 +7024,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortFloat{},R} (
-        Lblproject'Coln'Float{}(X0:SortK{}),
-        VarK:SortFloat{}),
-      \top{R}()))
+    \equals{SortFloat{},R} (
+      Lblproject'Coln'Float{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortFloat{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:GeneratedCounterCell`(inj{GeneratedCounterCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7053,11 +7042,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedCounterCell{},R} (
-        Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
-        VarK:SortGeneratedCounterCell{}),
-      \top{R}()))
+    \equals{SortGeneratedCounterCell{},R} (
+      Lblproject'Coln'GeneratedCounterCell{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortGeneratedCounterCell{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:GeneratedCounterCellOpt`(inj{GeneratedCounterCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7071,11 +7060,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedCounterCellOpt{},R} (
-        Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
-        VarK:SortGeneratedCounterCellOpt{}),
-      \top{R}()))
+    \equals{SortGeneratedCounterCellOpt{},R} (
+      Lblproject'Coln'GeneratedCounterCellOpt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortGeneratedCounterCellOpt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:GeneratedTopCell`(inj{GeneratedTopCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7089,11 +7078,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedTopCell{},R} (
-        Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
-        VarK:SortGeneratedTopCell{}),
-      \top{R}()))
+    \equals{SortGeneratedTopCell{},R} (
+      Lblproject'Coln'GeneratedTopCell{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortGeneratedTopCell{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:GeneratedTopCellFragment`(inj{GeneratedTopCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7107,11 +7096,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortGeneratedTopCellFragment{},R} (
-        Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
-        VarK:SortGeneratedTopCellFragment{}),
-      \top{R}()))
+    \equals{SortGeneratedTopCellFragment{},R} (
+      Lblproject'Coln'GeneratedTopCellFragment{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortGeneratedTopCellFragment{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:IOError`(inj{IOError,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7125,11 +7114,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIOError{},R} (
-        Lblproject'Coln'IOError{}(X0:SortK{}),
-        VarK:SortIOError{}),
-      \top{R}()))
+    \equals{SortIOError{},R} (
+      Lblproject'Coln'IOError{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortIOError{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:IOFile`(inj{IOFile,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7143,11 +7132,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIOFile{},R} (
-        Lblproject'Coln'IOFile{}(X0:SortK{}),
-        VarK:SortIOFile{}),
-      \top{R}()))
+    \equals{SortIOFile{},R} (
+      Lblproject'Coln'IOFile{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortIOFile{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:IOInt`(inj{IOInt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7161,11 +7150,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIOInt{},R} (
-        Lblproject'Coln'IOInt{}(X0:SortK{}),
-        VarK:SortIOInt{}),
-      \top{R}()))
+    \equals{SortIOInt{},R} (
+      Lblproject'Coln'IOInt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortIOInt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:IOString`(inj{IOString,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7179,11 +7168,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIOString{},R} (
-        Lblproject'Coln'IOString{}(X0:SortK{}),
-        VarK:SortIOString{}),
-      \top{R}()))
+    \equals{SortIOString{},R} (
+      Lblproject'Coln'IOString{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortIOString{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Id`(inj{Id,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7197,11 +7186,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortId{},R} (
-        Lblproject'Coln'Id{}(X0:SortK{}),
-        VarK:SortId{}),
-      \top{R}()))
+    \equals{SortId{},R} (
+      Lblproject'Coln'Id{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortId{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Ids`(inj{Ids,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7215,11 +7204,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortIds{},R} (
-        Lblproject'Coln'Ids{}(X0:SortK{}),
-        VarK:SortIds{}),
-      \top{R}()))
+    \equals{SortIds{},R} (
+      Lblproject'Coln'Ids{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortIds{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Int`(inj{Int,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7233,11 +7222,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortInt{},R} (
-        Lblproject'Coln'Int{}(X0:SortK{}),
-        VarK:SortInt{}),
-      \top{R}()))
+    \equals{SortInt{},R} (
+      Lblproject'Coln'Int{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortInt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:K`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7251,11 +7240,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortK{},R} (
-        Lblproject'Coln'K{}(X0:SortK{}),
-        VarK:SortK{}),
-      \top{R}()))
+    \equals{SortK{},R} (
+      Lblproject'Coln'K{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortK{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:KCell`(inj{KCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7269,11 +7258,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortKCell{},R} (
-        Lblproject'Coln'KCell{}(X0:SortK{}),
-        VarK:SortKCell{}),
-      \top{R}()))
+    \equals{SortKCell{},R} (
+      Lblproject'Coln'KCell{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortKCell{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:KCellOpt`(inj{KCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7287,11 +7276,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortKCellOpt{},R} (
-        Lblproject'Coln'KCellOpt{}(X0:SortK{}),
-        VarK:SortKCellOpt{}),
-      \top{R}()))
+    \equals{SortKCellOpt{},R} (
+      Lblproject'Coln'KCellOpt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortKCellOpt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:KItem`(K)=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7305,11 +7294,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortKItem{},R} (
-        Lblproject'Coln'KItem{}(X0:SortK{}),
-        VarK:SortKItem{}),
-      \top{R}()))
+    \equals{SortKItem{},R} (
+      Lblproject'Coln'KItem{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortKItem{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:KResult`(inj{KResult,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7323,11 +7312,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortKResult{},R} (
-        Lblproject'Coln'KResult{}(X0:SortK{}),
-        VarK:SortKResult{}),
-      \top{R}()))
+    \equals{SortKResult{},R} (
+      Lblproject'Coln'KResult{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortKResult{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:List`(inj{List,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7341,11 +7330,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortList{},R} (
-        Lblproject'Coln'List{}(X0:SortK{}),
-        VarK:SortList{}),
-      \top{R}()))
+    \equals{SortList{},R} (
+      Lblproject'Coln'List{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortList{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Map`(inj{Map,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7359,11 +7348,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortMap{},R} (
-        Lblproject'Coln'Map{}(X0:SortK{}),
-        VarK:SortMap{}),
-      \top{R}()))
+    \equals{SortMap{},R} (
+      Lblproject'Coln'Map{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortMap{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Pgm`(inj{Pgm,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7377,11 +7366,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortPgm{},R} (
-        Lblproject'Coln'Pgm{}(X0:SortK{}),
-        VarK:SortPgm{}),
-      \top{R}()))
+    \equals{SortPgm{},R} (
+      Lblproject'Coln'Pgm{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortPgm{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Set`(inj{Set,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7395,11 +7384,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortSet{},R} (
-        Lblproject'Coln'Set{}(X0:SortK{}),
-        VarK:SortSet{}),
-      \top{R}()))
+    \equals{SortSet{},R} (
+      Lblproject'Coln'Set{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortSet{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:StateCell`(inj{StateCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7413,11 +7402,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortStateCell{},R} (
-        Lblproject'Coln'StateCell{}(X0:SortK{}),
-        VarK:SortStateCell{}),
-      \top{R}()))
+    \equals{SortStateCell{},R} (
+      Lblproject'Coln'StateCell{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortStateCell{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:StateCellOpt`(inj{StateCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7431,11 +7420,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortStateCellOpt{},R} (
-        Lblproject'Coln'StateCellOpt{}(X0:SortK{}),
-        VarK:SortStateCellOpt{}),
-      \top{R}()))
+    \equals{SortStateCellOpt{},R} (
+      Lblproject'Coln'StateCellOpt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortStateCellOpt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Stmt`(inj{Stmt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7449,11 +7438,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortStmt{},R} (
-        Lblproject'Coln'Stmt{}(X0:SortK{}),
-        VarK:SortStmt{}),
-      \top{R}()))
+    \equals{SortStmt{},R} (
+      Lblproject'Coln'Stmt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortStmt{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:Stream`(inj{Stream,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7467,11 +7456,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortStream{},R} (
-        Lblproject'Coln'Stream{}(X0:SortK{}),
-        VarK:SortStream{}),
-      \top{R}()))
+    \equals{SortStream{},R} (
+      Lblproject'Coln'Stream{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortStream{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:String`(inj{String,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7485,11 +7474,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortString{},R} (
-        Lblproject'Coln'String{}(X0:SortK{}),
-        VarK:SortString{}),
-      \top{R}()))
+    \equals{SortString{},R} (
+      Lblproject'Coln'String{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortString{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:TCell`(inj{TCell,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7503,11 +7492,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortTCell{},R} (
-        Lblproject'Coln'TCell{}(X0:SortK{}),
-        VarK:SortTCell{}),
-      \top{R}()))
+    \equals{SortTCell{},R} (
+      Lblproject'Coln'TCell{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortTCell{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:TCellFragment`(inj{TCellFragment,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7521,11 +7510,11 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortTCellFragment{},R} (
-        Lblproject'Coln'TCellFragment{}(X0:SortK{}),
-        VarK:SortTCellFragment{}),
-      \top{R}()))
+    \equals{SortTCellFragment{},R} (
+      Lblproject'Coln'TCellFragment{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortTCellFragment{},
+        \top{R}())))
   [projection{}()]
 
 // rule `project:TCellOpt`(inj{TCellOpt,KItem}(K))=>K requires #token("true","Bool") ensures #token("true","Bool") [projection]
@@ -7539,14 +7528,14 @@ module IMP
           ),
           \top{R} ()
         )),
-    \and{R} (
-      \equals{SortTCellOpt{},R} (
-        Lblproject'Coln'TCellOpt{}(X0:SortK{}),
-        VarK:SortTCellOpt{}),
-      \top{R}()))
+    \equals{SortTCellOpt{},R} (
+      Lblproject'Coln'TCellOpt{}(X0:SortK{}),
+      \and{R} (
+        VarK:SortTCellOpt{},
+        \top{R}())))
   [projection{}()]
 
-// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_>Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9), contentStartColumn(8), contentStartLine(677), org.kframework.attributes.Location(Location(677,8,680,30)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,Count)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source)),ToReplace,Replacement,`_-Int_`(Count,#token("1","Int")))) requires `_>Int_`(Count,#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9), org.kframework.attributes.Location(Location(1570,8,1573,30)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -7571,14 +7560,14 @@ module IMP
           ),
           \top{R} ()
         ))))),
-    \and{R} (
-      \equals{SortString{},R} (
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
-        Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1"))))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("677"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(677,8,680,30)"), UNIQUE'Unds'ID{}("311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9")]
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+      \and{R} (
+        Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})),VarToReplace:SortString{},VarReplacement:SortString{},Lbl'Unds'-Int'Unds'{}(VarCount:SortInt{},\dv{SortInt{}}("1")))),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1570,8,1573,30)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("311b80d2cb12d368f230eba968464e1fc926bd57e304059b282b82af4d9626d9")]
 
-// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_0,_1,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5), contentStartColumn(8), contentStartLine(681), org.kframework.attributes.Location(Location(681,8,681,49)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,_0,_1,#token("0","Int"))=>Source requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5), org.kframework.attributes.Location(Location(1574,8,1574,49)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -7601,14 +7590,14 @@ module IMP
           ),
           \top{R} ()
         ))))),
-    \and{R} (
-      \equals{SortString{},R} (
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
-        VarSource:SortString{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("681"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(681,8,681,49)"), UNIQUE'Unds'ID{}("4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5")]
+    \equals{SortString{},R} (
+      Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortString{},X3:SortInt{}),
+      \and{R} (
+        VarSource:SortString{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1574,8,1574,49)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("4367434b0f61c404f7a2e926426bd23874dd547de689c5d15089967fbab2b3d5")]
 
-// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), contentStartColumn(8), contentStartLine(682), org.kframework.attributes.Location(Location(682,8,682,154)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `replaceAll(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`replace(_,_,_,_)_STRING-COMMON_String_String_String_String_Int`(Source,ToReplace,Replacement,`countAllOccurrences(_,_)_STRING-COMMON_Int_String_String`(Source,ToReplace)) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5), org.kframework.attributes.Location(Location(1575,8,1575,154)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -7627,14 +7616,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortString{},R} (
-        LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
-        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("682"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(682,8,682,154)"), UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5")]
+    \equals{SortString{},R} (
+      LblreplaceAll'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+      \and{R} (
+        Lblreplace'LParUndsCommUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},VarReplacement:SortString{},LblcountAllOccurrences'LParUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String{}(VarSource:SortString{},VarToReplace:SortString{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1575,8,1575,154)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("262167183c3ec2e214d12bac6e639d7ac1a9f973582e16eca6c1af1da7ecc0a5")]
 
-// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), contentStartColumn(8), contentStartLine(670), org.kframework.attributes.Location(Location(670,8,672,66)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,Replacement)=>`_+String__STRING-COMMON_String_String_String`(`_+String__STRING-COMMON_String_String_String`(`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,#token("0","Int"),`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int"))),Replacement),`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(Source,`_+Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),`lengthString(_)_STRING-COMMON_Int_String`(ToReplace)),`lengthString(_)_STRING-COMMON_Int_String`(Source))) requires `_>=Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c), org.kframework.attributes.Location(Location(1563,8,1565,66)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -7655,14 +7644,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortString{},R} (
-        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
-        Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{})))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("670"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(670,8,672,66)"), UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c")]
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+      \and{R} (
+        Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(Lbl'UndsPlus'String'UndsUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String{}(LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},\dv{SortInt{}}("0"),LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0"))),VarReplacement:SortString{}),LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarSource:SortString{},Lbl'UndsPlus'Int'Unds'{}(LblfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarSource:SortString{},VarToReplace:SortString{},\dv{SortInt{}}("0")),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarToReplace:SortString{})),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarSource:SortString{}))),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1563,8,1565,66)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("e290042e5b5b2f620c0ca1871e708c3713c62b63b283e317bb7568e13968fe0c")]
 
-// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), contentStartColumn(8), contentStartLine(673), org.kframework.attributes.Location(Location(673,8,674,57)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `replaceFirst(_,_,_)_STRING-COMMON_String_String_String_String`(Source,ToReplace,_0)=>Source requires `_<Int_`(`findString(_,_,_)_STRING-COMMON_Int_String_String_Int`(Source,ToReplace,#token("0","Int")),#token("0","Int")) ensures #token("true","Bool") [UNIQUE_ID(8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34), org.kframework.attributes.Location(Location(1566,8,1567,57)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -7683,14 +7672,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortString{},R} (
-        LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
-        VarSource:SortString{}),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("673"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(673,8,674,57)"), UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34")]
+    \equals{SortString{},R} (
+      LblreplaceFirst'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'String'Unds'String{}(X0:SortString{},X1:SortString{},X2:SortString{}),
+      \and{R} (
+        VarSource:SortString{},
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1566,8,1567,57)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("8fbd1c8efb9988236eddc95fc2af4a3e74f6ec94d696ee47209543fd0826dd34")]
 
-// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), contentStartColumn(8), contentStartLine(662), org.kframework.attributes.Location(Location(662,8,662,182)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" K [klabel(#ruleRequires), symbol])]
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,S2,I)=>`maxInt(_,_)_INT-COMMON_Int_Int_Int`(`rfindString(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("0","Int"),#token("1","Int")),I),`rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(S1,`substrString(_,_,_)_STRING-COMMON_String_String_Int_Int`(S2,#token("1","Int"),`lengthString(_)_STRING-COMMON_Int_String`(S2)),I)) requires `_=/=String__STRING-COMMON_Bool_String_String`(S2,#token("\"\"","String")) ensures #token("true","Bool") [UNIQUE_ID(b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205), org.kframework.attributes.Location(Location(1555,8,1555,182)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody "requires" Bool [klabel(#ruleRequires), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \equals{SortBool{},R}(
@@ -7711,14 +7700,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
-        LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{}))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" K [klabel(#ruleRequires), symbol]"), contentStartLine{}("662"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(662,8,662,182)"), UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205")]
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+      \and{R} (
+        LblmaxInt'LParUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int{}(LblrfindString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("0"),\dv{SortInt{}}("1")),VarI:SortInt{}),LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(VarS1:SortString{},LblsubstrString'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'String'Unds'String'Unds'Int'Unds'Int{}(VarS2:SortString{},\dv{SortInt{}}("1"),LbllengthString'LParUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String{}(VarS2:SortString{})),VarI:SortInt{})),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1555,8,1555,182)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody \"requires\" Bool [klabel(#ruleRequires), symbol]"), UNIQUE'Unds'ID{}("b7f740050d72a847424b022a9c8217325aba8a154a42831aa3c7a3b0727f3205")]
 
-// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), contentStartColumn(8), contentStartLine(663), org.kframework.attributes.Location(Location(663,8,663,33)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `rfindChar(_,_,_)_STRING-COMMON_Int_String_String_Int`(_0,#token("\"\"","String"),_1)=>#token("-1","Int") requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6), org.kframework.attributes.Location(Location(1556,8,1556,33)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -7737,14 +7726,14 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
-        \dv{SortInt{}}("-1")),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("663"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(663,8,663,33)"), UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6")]
+    \equals{SortInt{},R} (
+      LblrfindChar'LParUndsCommUndsCommUndsRParUnds'STRING-COMMON'Unds'Int'Unds'String'Unds'String'Unds'Int{}(X0:SortString{},X1:SortString{},X2:SortInt{}),
+      \and{R} (
+        \dv{SortInt{}}("-1"),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1556,8,1556,33)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("23b9fa88124c547d94aed32124d1ccd1069732b059f4c8b430ab4617979690f6")]
 
-// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), contentStartColumn(8), contentStartLine(501), org.kframework.attributes.Location(Location(501,8,501,164)), org.kframework.attributes.Source(Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
+// rule `signExtendBitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN)=>`_-Int_`(`_modInt_`(`_+Int_`(`bitRangeInt(_,_,_)_INT-COMMON_Int_Int_Int_Int`(I,IDX,LEN),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))),`_<<Int_`(#token("1","Int"),LEN)),`_<<Int_`(#token("1","Int"),`_-Int_`(LEN,#token("1","Int")))) requires #token("true","Bool") ensures #token("true","Bool") [UNIQUE_ID(3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f), org.kframework.attributes.Location(Location(1103,8,1103,164)), org.kframework.attributes.Source(Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)), org.kframework.definition.Production(syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol])]
   axiom{R} \implies{R} (
     \and{R}(
       \top{R}(),
@@ -7763,13 +7752,13 @@ module IMP
           ),
           \top{R} ()
         )))),
-    \and{R} (
-      \equals{SortInt{},R} (
-        LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
-        Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1"))))),
-      \top{R}()))
-  [org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/target/release/k/include/kframework/builtin/domains.k)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), contentStartLine{}("501"), contentStartColumn{}("8"), org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(501,8,501,164)"), UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f")]
+    \equals{SortInt{},R} (
+      LblsignExtendBitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(X0:SortInt{},X1:SortInt{},X2:SortInt{}),
+      \and{R} (
+        Lbl'Unds'-Int'Unds'{}(Lbl'Unds'modInt'Unds'{}(Lbl'UndsPlus'Int'Unds'{}(LblbitRangeInt'LParUndsCommUndsCommUndsRParUnds'INT-COMMON'Unds'Int'Unds'Int'Unds'Int'Unds'Int{}(VarI:SortInt{},VarIDX:SortInt{},VarLEN:SortInt{}),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),VarLEN:SortInt{})),Lbl'Unds-LT--LT-'Int'Unds'{}(\dv{SortInt{}}("1"),Lbl'Unds'-Int'Unds'{}(VarLEN:SortInt{},\dv{SortInt{}}("1")))),
+        \top{R}())))
+  [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(1103,8,1103,164)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/target/release/k/include/kframework/builtin/domains.md)"), org'Stop'kframework'Stop'definition'Stop'Production{}("syntax #RuleContent ::= #RuleBody [klabel(#ruleNoConditions), symbol]"), UNIQUE'Unds'ID{}("3b67f4bf2235fc46fc94b1d10e936100ea3fc4f2dbaa4e4a77593e8385f5004f")]
 
 
 // priority groups
-endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(63,1,226,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/dwightguth/kframework-5.0.0/k-distribution/tutorial/1_k/2_imp/lesson_5/./imp.md)")]
+endmodule [org'Stop'kframework'Stop'attributes'Stop'Location{}("Location(63,1,226,9)"), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/erik/k/k-distribution/pl-tutorial/1_k/2_imp/lesson_5/imp.md)")]


### PR DESCRIPTION
There was an [issue](kframework/k#1945) where the the rule
```
rule LEFT => RIGHT requires REQUIRES ensures ENSURES
```
is translated to
```
axiom \implies(REQUIRES, \and(\equals(LEFT, RIGHT), ENSURES))
```
so that if ENSURES is \bottom and REQUIRES is anything else, then the axiom is axiom \bottom which is unsound. Actually, we want to say
```
axiom \implies(REQUIRES, \equals(LEFT, \and(RIGHT, ENSURES)))
```

There is a [pull request](kframework/k#2061) that changes the K frontend to emit the correct KORE syntax. This commit implements the change in the KORE syntax for the llvm-backend parsers.

Fixes #417

Signed-off-by: Erik Kaneda <erik.kaneda@runtimeverification.com>