### PR TITLE
fix bug involving debug locations

### DIFF
--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -951,7 +951,8 @@ bool makeFunction(std::string name, KOREPattern *pattern, KOREDefinition *defini
       call->setCallingConv(llvm::CallingConv::Fast);
       retval = call;
     }
-    llvm::ReturnInst::Create(Module->getContext(), retval, creator.getCurrentBlock());
+    auto ret = llvm::ReturnInst::Create(Module->getContext(), retval, creator.getCurrentBlock());
+    setDebugLoc(ret);
     return true;
 }
 


### PR DESCRIPTION
If the function has no instructions aside from the return statement, it was previously impossible to break on that function. This prevented us from breaking when a rule was applied whose right hand side was an llvm constant like `true`. This should fix this by adding the location information to the `ret` instruction.