### PR TITLE
Add documentation for local macOS builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ TAGS
 *.iml
 /result*
 test/int/*.interpreter
+
+*.dSYM

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,5 @@
 On Ubuntu 20.04:
-
-```
+```shell
 sudo apt-get update
 sudo apt-get install git cmake clang-10 llvm-10-tools lld-10 zlib1g-dev flex libboost-test-dev libgmp-dev libmpfr-dev libyaml-dev libjemalloc-dev curl maven pkg-config
 git clone https://github.com/kframework/llvm-backend --recursive
@@ -8,6 +7,29 @@ cd llvm-backend
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install # or Debug
+make -j16
+make install
+```
+
+On macos 11 (Big Sur), using Homebrew:
+```shell
+brew update
+brew install boost cmake coreutils flex git gmp jemalloc libyaml llvm@12 maven mpfr pkg-config z3
+
+git clone https://github.com/kframework/llvm-backend --recursive
+cd llvm-backend
+
+mkdir build
+cd build
+
+export PATH=$($(brew --prefix llvm)/bin/llvm-config --bindir):$PATH
+
+cmake .. \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=install \
+  -DFLEX_EXECUTABLE=$(brew --prefix flex)/bin/flex \
+  -DLLVM_DIR=$($(brew --prefix llvm@12)/bin/llvm-config --cmakedir)
+
 make -j16
 make install
 ```


### PR DESCRIPTION
This documentation mirrors the instructions for Ubuntu 20.04 that are
also given in `INSTALL.md`. The environment is configured using the
system package manager (rather than Nix, as is the case in the CI
environment).

I have verified the instructions on a clean VM install of macos 11, as
well as my own development system.

Running the unit tests via `./ciscript` creates DWARF symbol files
(`.dSYM`) on macos; this PR adds these to the git ignore list.