### PR TITLE
fix mac os llvm backend big sur --enable-search

### DIFF
--- a/bin/llvm-kompile-clang
+++ b/bin/llvm-kompile-clang
@@ -60,7 +60,7 @@ fi
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   libraries="-liconv -lncurses"
-  flags="-L/usr/local/opt/libffi/lib -L/usr/local/lib -Wl,-u,_sort_table"
+  flags="-L/usr/local/opt/libffi/lib -L/usr/local/lib -Wl,-u,_sort_table -I /usr/local/include"
 else
   libraries="-ltinfo"
   flags="-Wl,-u,sort_table"


### PR DESCRIPTION
This ought to fix the LLVM backend on MacOS Big Sur when the user requests search in the K frontend via --enable-search. This was broken because the llvm@12 package doesn't build /usr/local/include as a search path for the include directories anymore.