### PR TITLE
maven relative path

### DIFF
--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.runtimeverification.k</groupId>
     <artifactId>parent</artifactId>
     <version>1.0-SNAPSHOT</version>
+    <relativePath>../../../../../..</relativePath>
   </parent>
   <artifactId>llvm-backend-matching</artifactId>
   <packaging>jar</packaging>


### PR DESCRIPTION
This fixes a relatively simple bug where building the llvm backend scala code as part of the k frontend maven reactor would not correctly pick up the parent pom. This can lead to version sync issues if the parent pom is changed in the frontend.