### PR TITLE
Add hook for kompiled directory metadata

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+DisableFormat: true
+SortIncludes: false

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -60,7 +60,7 @@ public:
 /* Creates a new llvm::Module with the predefined declarations common to all llvm modules
    in the llvm backend. */
 std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Context);
-void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod);
+void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod, bool debug);
 
 llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol);
 llvm::Value *getBlockHeader(llvm::Module *Module, KOREDefinition *definition,

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1,20 +1,20 @@
 #include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Util.h"
 #include "kllvm/codegen/Debug.h"
+#include "kllvm/codegen/Util.h"
 
 #include <gmp.h>
 #include <iomanip>
 #include <iostream>
 
-#include "llvm/IRReader/IRReader.h"
+#include "runtime/header.h" //for macros
 #include "llvm/IR/BasicBlock.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
-#include "runtime/header.h" //for macros
 
 namespace kllvm {
 
@@ -108,14 +108,17 @@ std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Con
   return mod;
 }
 
-void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod) {
+void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod, bool debug) {
   auto Str = llvm::ConstantDataArray::getString(Context, dir, true);
   auto global = mod->getOrInsertGlobal("kompiled_directory", Str->getType());
   llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
-  initDebugGlobal("kompiled_directory", getCharDebugType(), globalVar);
+
+  if (debug) {
+    initDebugGlobal("kompiled_directory", getCharDebugType(), globalVar);
+  }
 }
 
 static std::string MAP_STRUCT = "map";

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -656,21 +656,6 @@ llvm::Value *CreateTerm::createHook(KORECompositePattern *hookAtt, KOREComposite
     llvm::Value *first = (*this)(pattern->getArguments()[0].get()).first;
     llvm::Value *second = (*this)(pattern->getArguments()[1].get()).first;
     return llvm::BinaryOperator::Create(llvm::Instruction::URem, first, second, "hook_MINT_urem", CurrentBlock);
-  } else if (name == "KREFLECTION.kompiledDir") {
-    auto dirString = Module->getGlobalVariable(KOMPILED_DIR);
-    auto zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
-
-    auto ptr = llvm::GetElementPtrInst::Create(
-        dirString->getValueType(), dirString, {zero, zero},
-        "hook_KREFLECTION_kompiledDir", CurrentBlock);
-
-    if (auto arrayTy = llvm::dyn_cast<llvm::ArrayType>(dirString->getValueType())) {
-      auto len = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), arrayTy->getNumElements() - 1);
-      return createFunctionCall("makeString", {SortCategory::Symbol, 0}, {ptr, len}, false, false);
-    } else {
-      assert(false && "Kompiled directory global is not a string");
-      abort();
-    }
   } else if (!name.compare(0, 5, "MINT.")) {
     std::cerr << name << std::endl;
     assert(false && "not implemented yet: MInt");

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -21,6 +21,8 @@ extern "C" {
 #define GETTAG(symbol) "Lbl'Hash'" #symbol "{}"
 #define IOBUFSIZE 1024
 
+  extern char kompiled_directory;
+
   mpz_ptr move_int(mpz_t);
   char * getTerminatedString(string * str);
 
@@ -568,6 +570,15 @@ extern "C" {
 
   block * hook_KREFLECTION_fresh(string * str) {
     throw std::invalid_argument("not implemented: KREFLECTION.fresh");
+  }
+
+  string * hook_KREFLECTION_kompiledDir() {
+    auto str_ptr = &kompiled_directory;
+    auto len = strlen(str_ptr);
+    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+    memcpy(ret->data, str_ptr, len);
+    set_len(ret, len);
+    return ret;
   }
 
   int llvm_backend_argc = 0;

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -572,7 +572,7 @@ extern "C" {
     throw std::invalid_argument("not implemented: KREFLECTION.fresh");
   }
 
-  string * hook_KREFLECTION_kompiledDir() {
+  string * hook_KREFLECTION_kompiledDir(void) {
     auto str_ptr = &kompiled_directory;
     auto len = strlen(str_ptr);
     auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,10 +1,10 @@
 #include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Decision.h"
 #include "kllvm/codegen/Debug.h"
+#include "kllvm/codegen/Decision.h"
 #include "kllvm/codegen/DecisionParser.h"
 #include "kllvm/codegen/EmitConfigParser.h"
-#include "kllvm/parser/KOREScanner.h"
 #include "kllvm/parser/KOREParser.h"
+#include "kllvm/parser/KOREScanner.h"
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
@@ -14,8 +14,8 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 using namespace kllvm;
 using namespace kllvm::parser;
@@ -44,8 +44,9 @@ int main (int argc, char **argv) {
 
   if (CODEGEN_DEBUG) {
     initDebugInfo(mod.get(), argv[1]);
-    addKompiledDirSymbol(Context, dirname(realPath), mod.get());
   }
+
+  addKompiledDirSymbol(Context, dirname(realPath), mod.get(), CODEGEN_DEBUG);
 
   for (auto axiom : definition->getAxioms()) {
     makeSideConditionFunction(axiom, definition.get(), mod.get());

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,10 +1,10 @@
 #include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Debug.h"
 #include "kllvm/codegen/Decision.h"
+#include "kllvm/codegen/Debug.h"
 #include "kllvm/codegen/DecisionParser.h"
 #include "kllvm/codegen/EmitConfigParser.h"
-#include "kllvm/parser/KOREParser.h"
 #include "kllvm/parser/KOREScanner.h"
+#include "kllvm/parser/KOREParser.h"
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
@@ -14,8 +14,8 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
-#include <fstream>
 #include <iostream>
+#include <fstream>
 
 using namespace kllvm;
 using namespace kllvm::parser;
@@ -45,7 +45,7 @@ int main (int argc, char **argv) {
   if (CODEGEN_DEBUG) {
     initDebugInfo(mod.get(), argv[1]);
   }
-
+  
   addKompiledDirSymbol(Context, dirname(realPath), mod.get(), CODEGEN_DEBUG);
 
   for (auto axiom : definition->getAxioms()) {

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -15,6 +15,8 @@
 #define KCHAR char
 extern "C" {
 
+char kompiled_directory[] = "some/test/directory/path";
+
 #define GETTAG(symbol) "Lbl'Hash'" #symbol "{}"
 #define ERRBLOCK(tag) (uint64_t)(leaf_block(tag))
 #define NUM_SYMBOLS 8
@@ -55,6 +57,7 @@ extern "C" {
   block * hook_IO_log(string * path, string * msg);
   block * hook_IO_system(string * cmd);
   mpz_ptr hook_IO_time(void);
+  string * hook_KREFLECTION_kompiledDir(void);
   list hook_KREFLECTION_argv();
 
   extern int llvm_backend_argc;
@@ -468,6 +471,11 @@ BOOST_AUTO_TEST_CASE(time) {
   BOOST_CHECK(time2 >= tt);
   BOOST_CHECK(time2 - tt < 5);
   BOOST_CHECK(tt >= 1573756117);
+}
+
+BOOST_AUTO_TEST_CASE(kompiledDir) {
+  auto dir = hook_KREFLECTION_kompiledDir();
+  BOOST_CHECK_EQUAL(0, strcmp(dir->data, kompiled_directory));
 }
 
 BOOST_AUTO_TEST_CASE(argv) {

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -477,6 +477,9 @@ BOOST_AUTO_TEST_CASE(kompiledDir) {
   auto dir = hook_KREFLECTION_kompiledDir();
   auto len = strlen(kompiled_directory);
   BOOST_CHECK_EQUAL(0, memcmp(dir->data, kompiled_directory, len));
+
+  auto returned_len = strnlen(dir->data, len);
+  BOOST_CHECK_EQUAL(returned_len, len);
 }
 
 BOOST_AUTO_TEST_CASE(argv) {

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -475,7 +475,8 @@ BOOST_AUTO_TEST_CASE(time) {
 
 BOOST_AUTO_TEST_CASE(kompiledDir) {
   auto dir = hook_KREFLECTION_kompiledDir();
-  BOOST_CHECK_EQUAL(0, strcmp(dir->data, kompiled_directory));
+  auto len = strlen(kompiled_directory);
+  BOOST_CHECK_EQUAL(0, memcmp(dir->data, kompiled_directory, len));
 }
 
 BOOST_AUTO_TEST_CASE(argv) {


### PR DESCRIPTION
This PR implements the feature suggested in [this issue](https://github.com/kframework/k/issues/1889) - that the LLVM backend should be able to provide a hooked function that returns the current `*-kompiled` directory.

The necessary information is already passed through from the command line to the LLVM backend in debug mode, so the implementation just reads the baked-in symbol and constructs a boxed K string object to return. The hook is tested with a unit test in the backend using a mocked symbol.

On the frontend side, I'll implement a matching PR that adds an appropriate function symbol to the `K-REFLECTION` module, along with an integration test.