### PR TITLE
Implement floating point truncation hook

### DIFF
--- a/runtime/arithmetic/float.cpp
+++ b/runtime/arithmetic/float.cpp
@@ -72,6 +72,14 @@ SortFloat hook_FLOAT_floor(SortFloat a) {
   return move_float(result);
 }
 
+SortFloat hook_FLOAT_trunc(SortFloat a) {
+  floating result[1];
+  mpfr_enter(a, result);
+  int t = mpfr_trunc(result->f, a->f);
+  mpfr_leave(t, result);
+  return move_float(result);
+}
+
 SortFloat hook_FLOAT_round(SortFloat a, SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
     throw std::invalid_argument("Precision out of range");

--- a/unittests/runtime-arithmetic/floattest.cpp
+++ b/unittests/runtime-arithmetic/floattest.cpp
@@ -9,6 +9,7 @@
 extern "C" {
   floating *hook_FLOAT_ceil(floating *);
   floating *hook_FLOAT_floor(floating *);
+  floating *hook_FLOAT_trunc(floating *);
   floating *hook_FLOAT_round(floating *, mpz_t, mpz_t);
   mpz_ptr hook_FLOAT_float2int(floating *);
   floating *hook_FLOAT_int2float(mpz_t, mpz_t, mpz_t);
@@ -79,6 +80,27 @@ BOOST_AUTO_TEST_CASE(floor) {
   set_float(a, 24, 8, 10.5);
   result = hook_FLOAT_floor(a);
   BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, 10.0), 0);
+}
+
+BOOST_AUTO_TEST_CASE(trunc) {
+  floating a[1];
+  floating *result;
+
+  set_float(a, 24, 8, 145.23);
+  result = hook_FLOAT_trunc(a);
+  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, 145.0), 0);
+
+  set_float(a, 53, 11, -0.5345);
+  result = hook_FLOAT_trunc(a);
+  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, 0.0), 0);
+
+  set_float(a, 24, 8, -2342.99);
+  result = hook_FLOAT_trunc(a);
+  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, -2342.0), 0);
+
+  set_float(a, 53, 11, 54.34);
+  result = hook_FLOAT_trunc(a);
+  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, 54.0), 0);
 }
 
 BOOST_AUTO_TEST_CASE(round) {


### PR DESCRIPTION
This is provided by the MPFR library similarly to ceil and floor, and is
a useful function to expose for the C semantics, where some rules are
specified in terms of floating-point truncation.

Test follow the same structure as the ceil / float tests.

This PR will be followed by a matching one on the frontend to expose the hooked function as a K rule.