### PR TITLE
Apply clang-format style to project

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,23 @@
-DisableFormat: true
-SortIncludes: false
+---
+BasedOnStyle: WebKit
+BreakBeforeBraces: Attach
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AlignOperands: true
+Cpp11BracedListStyle: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+ColumnLimit: 80
+IndentWidth: 2
+Language: Cpp
+NamespaceIndentation: None
+AlwaysBreakTemplateDeclarations: true
+FixNamespaceComments: true
+SpaceBeforeCpp11BracedList: false
+DerivePointerAlignment: false
+PointerAlignment: Right
+AllowShortCaseLabelsOnASingleLine: true
+...

--- a/include/kllvm/ast/AST.h
+++ b/include/kllvm/ast/AST.h
@@ -3,17 +3,16 @@
 
 #include <boost/functional/hash.hpp>
 
-#include <string>
-#include <vector>
+#include <iostream>
 #include <list>
 #include <map>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
-#include <iostream>
+#include <vector>
 
 namespace kllvm {
-
 
 class KORESortVariable;
 
@@ -30,7 +29,8 @@ std::string decodeKore(std::string);
 // KORESort
 class KORESort : public std::enable_shared_from_this<KORESort> {
 public:
-  using substitution = std::unordered_map<KORESortVariable, sptr<KORESort>, HashSort>;
+  using substitution
+      = std::unordered_map<KORESortVariable, sptr<KORESort>, HashSort>;
 
   virtual bool isConcrete() const = 0;
   virtual sptr<KORESort> substitute(const substitution &) = 0;
@@ -44,7 +44,10 @@ public:
   virtual ~KORESort() = default;
 };
 
-static inline std::ostream &operator<<(std::ostream &out, const KORESort &s) { s.print(out); return out; }
+static inline std::ostream &operator<<(std::ostream &out, const KORESort &s) {
+  s.print(out);
+  return out;
+}
 
 struct HashSort {
   size_t operator()(const kllvm::KORESort &s) const noexcept {
@@ -55,13 +58,13 @@ struct HashSort {
 };
 
 struct EqualSortPtr {
-  bool operator()(KORESort * const & first, KORESort * const & second) const {
+  bool operator()(KORESort *const &first, KORESort *const &second) const {
     return *first == *second;
   }
 };
 
 struct HashSortPtr {
-  size_t operator()(kllvm::KORESort * const &s) const noexcept {
+  size_t operator()(kllvm::KORESort *const &s) const noexcept {
     std::ostringstream Out;
     s->print(Out);
     return std::hash<std::string>{}(Out.str());
@@ -80,18 +83,31 @@ public:
   }
 
   virtual bool isConcrete() const override { return false; }
-  virtual sptr<KORESort> substitute(const substitution &subst) override { return subst.at(*this); }
+  virtual sptr<KORESort> substitute(const substitution &subst) override {
+    return subst.at(*this);
+  }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
   virtual void prettyPrint(std::ostream &Out) const override;
   virtual bool operator==(const KORESort &other) const override;
 
 private:
-  KORESortVariable(const std::string &Name) : name(Name) { }
+  KORESortVariable(const std::string &Name)
+      : name(Name) { }
 };
 
 enum class SortCategory {
-  Uncomputed, Map, List, Set, Int, Float, StringBuffer, Bool, Symbol, Variable, MInt
+  Uncomputed,
+  Map,
+  List,
+  Set,
+  Int,
+  Float,
+  StringBuffer,
+  Bool,
+  Symbol,
+  Variable,
+  MInt
 };
 
 // represents the syntactic category of an LLVM backend term at runtime
@@ -102,7 +118,8 @@ struct ValueType {
   uint64_t bits;
 
   bool operator<(const ValueType &that) const {
-    return std::make_tuple(this->cat, this->bits) < std::make_tuple(that.cat, that.bits);
+    return std::make_tuple(this->cat, this->bits)
+           < std::make_tuple(that.cat, that.bits);
   }
 };
 
@@ -115,7 +132,8 @@ private:
   ValueType category;
 
 public:
-  static sptr<KORECompositeSort> Create(const std::string &Name, ValueType Cat = {SortCategory::Uncomputed, 0}) {
+  static sptr<KORECompositeSort> Create(
+      const std::string &Name, ValueType Cat = {SortCategory::Uncomputed, 0}) {
     return sptr<KORECompositeSort>(new KORECompositeSort(Name, Cat));
   }
 
@@ -133,7 +151,9 @@ public:
   virtual bool operator==(const KORESort &other) const override;
 
 private:
-  KORECompositeSort(const std::string &Name, ValueType category) : name(Name), category(category) {}
+  KORECompositeSort(const std::string &Name, ValueType category)
+      : name(Name)
+      , category(category) { }
 };
 
 struct HashSymbol;
@@ -145,17 +165,19 @@ class KORESymbol {
 private:
   std::string name;
   /* At parse time, when parsed as part of a pattern,
-      this will be empty. When parsed as part of a declaration, it contains the signature
-      of the symbol. After instantiateSymbol is called on a symbol that is
-      part of a pattern, it changes from being empty to being
-      the signature of the symbol. instantiateSymbol is called on all object
-      level symbols in axioms when KOREDefinition::preprocess is called. */
+      this will be empty. When parsed as part of a declaration, it contains the
+     signature of the symbol. After instantiateSymbol is called on a symbol that
+     is part of a pattern, it changes from being empty to being the signature of
+     the symbol. instantiateSymbol is called on all object level symbols in
+     axioms when KOREDefinition::preprocess is called. */
   std::vector<sptr<KORESort>> arguments;
-  /* contains the original arguments to the symbol when parsed as parh of a pattern. */
+  /* contains the original arguments to the symbol when parsed as parh of a
+   * pattern. */
   std::vector<sptr<KORESort>> formalArguments;
   /** At parse time, when parsed as part of a pattern, this will be null.
-      When parsed as part of a declaration, it contains the return sort of the symbol.
-      See above re: the behavior of KORESymbol with respect to instantiateSymbol. */
+      When parsed as part of a declaration, it contains the return sort of the
+     symbol. See above re: the behavior of KORESymbol with respect to
+     instantiateSymbol. */
   sptr<KORESort> sort;
   /* the first integer in a continuous range representing the tags of all the
      polymorphic instantiations of this symbol. If the symbol has no parameters
@@ -180,15 +202,16 @@ public:
   void initPatternArguments(void) { arguments.swap(formalArguments); }
 
   const std::string &getName() const { return name; }
-  const std::vector<sptr<KORESort>> &getArguments() const {
-    return arguments;
-  }
+  const std::vector<sptr<KORESort>> &getArguments() const { return arguments; }
   const std::vector<sptr<KORESort>> &getFormalArguments() const {
     return formalArguments;
   }
   const sptr<KORESort> getSort() const { return sort; }
   sptr<KORESort> getSort() { return sort; }
-  uint32_t getTag() const { assert(firstTag == lastTag); return firstTag; }
+  uint32_t getTag() const {
+    assert(firstTag == lastTag);
+    return firstTag;
+  }
   uint32_t getFirstTag() const { return firstTag; }
   uint32_t getLastTag() const { return lastTag; }
   void setTag(uint32_t val) { firstTag = lastTag = val; }
@@ -206,12 +229,13 @@ public:
   bool isPolymorphic() const;
   bool isBuiltin() const;
 
-  /* instantiates this symbol (which should be parsed from a pattern in an axiom)
-     with the sorts corresponding to its actual sort parameters after instantiating
-     polymorphic parameters. This happens by replacing the variables in the arguments
-     of the specified declaration with their substitution in the arguments to the pattern
-     that were parsed in braces. The result is that the arguments and sort fields are replaced
-     with the instantiated signature of the symbol. */
+  /* instantiates this symbol (which should be parsed from a pattern in an
+     axiom) with the sorts corresponding to its actual sort parameters after
+     instantiating polymorphic parameters. This happens by replacing the
+     variables in the arguments of the specified declaration with their
+     substitution in the arguments to the pattern that were parsed in braces.
+     The result is that the arguments and sort fields are replaced with the
+     instantiated signature of the symbol. */
   void instantiateSymbol(KORESymbolDeclaration *decl);
 
   friend HashSymbol;
@@ -219,7 +243,9 @@ public:
   friend KOREDefinition;
 
 private:
-  KORESymbol(const std::string &Name) : name(Name), sort(nullptr) { }
+  KORESymbol(const std::string &Name)
+      : name(Name)
+      , sort(nullptr) { }
 };
 
 struct HashSymbol {
@@ -234,7 +260,7 @@ struct HashSymbol {
 };
 
 struct EqualSymbolPtr {
-  bool operator()(KORESymbol * const & first, KORESymbol * const & second) const {
+  bool operator()(KORESymbol *const &first, KORESymbol *const &second) const {
     std::ostringstream Out1, Out2;
     first->print(Out1);
     second->print(Out2);
@@ -243,7 +269,7 @@ struct EqualSymbolPtr {
 };
 
 struct HashSymbolPtr {
-  size_t operator()(kllvm::KORESymbol * const &s) const noexcept {
+  size_t operator()(kllvm::KORESymbol *const &s) const noexcept {
     std::ostringstream Out;
     s->print(Out);
     return std::hash<std::string>{}(Out.str());
@@ -266,19 +292,25 @@ public:
   virtual ~KOREVariable() = default;
 
 private:
-  KOREVariable(const std::string &Name) : name(Name) { }
+  KOREVariable(const std::string &Name)
+      : name(Name) { }
 };
 
 class KOREVariablePattern;
 
 using SortSet = std::unordered_set<KORESort *, HashSortPtr, EqualSortPtr>;
-using SymbolSet = std::unordered_set<KORESymbol *, HashSymbolPtr, EqualSymbolPtr>;
-using SubsortMap = std::unordered_map<KORESort *, SortSet, HashSortPtr, EqualSortPtr>;
-using SymbolMap = std::unordered_map<KORESymbol *, SymbolSet, HashSymbolPtr, EqualSymbolPtr>;
-using BracketMap = std::unordered_map<KORESort *, std::vector<KORESymbol *>, HashSortPtr, EqualSortPtr>;
+using SymbolSet
+    = std::unordered_set<KORESymbol *, HashSymbolPtr, EqualSymbolPtr>;
+using SubsortMap
+    = std::unordered_map<KORESort *, SortSet, HashSortPtr, EqualSortPtr>;
+using SymbolMap = std::unordered_map<
+    KORESymbol *, SymbolSet, HashSymbolPtr, EqualSymbolPtr>;
+using BracketMap = std::unordered_map<
+    KORESort *, std::vector<KORESymbol *>, HashSortPtr, EqualSortPtr>;
 
 struct PrettyPrintData {
-  // map from symbol name to format attribute specifying how to print that symbol
+  // map from symbol name to format attribute specifying how to print that
+  // symbol
   std::map<std::string, std::string> format;
   // map from symbol name to vector of colors for that symbol
   std::map<std::string, std::vector<std::string>> colors;
@@ -308,14 +340,17 @@ class KOREPattern : public std::enable_shared_from_this<KOREPattern> {
 public:
   virtual ~KOREPattern() = default;
 
-  virtual void print(std::ostream &Out, unsigned indent = 0) const =0;
-  /* adds all the object level symbols contained recursively in the current pattern
-     to the specified map, mapping their symbol name to the list of all instances
-     of that symbol. */
-  virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) = 0;
-  /* adds all the object level variables contained recursively in the current pattern
-     to the specified map, mapping their variable name to the variable itself. */
-  virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) = 0;
+  virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
+  /* adds all the object level symbols contained recursively in the current
+     pattern to the specified map, mapping their symbol name to the list of all
+     instances of that symbol. */
+  virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &)
+      = 0;
+  /* adds all the object level variables contained recursively in the current
+     pattern to the specified map, mapping their variable name to the variable
+     itself. */
+  virtual void markVariables(std::map<std::string, KOREVariablePattern *> &)
+      = 0;
 
   virtual sptr<KORESort> getSort(void) const = 0;
 
@@ -324,17 +359,33 @@ public:
   virtual sptr<KOREPattern> substitute(const substitution &) = 0;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) = 0;
 
-  virtual void prettyPrint(std::ostream &, PrettyPrintData const& data) const = 0;
-  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) = 0;
+  virtual void
+  prettyPrint(std::ostream &, PrettyPrintData const &data) const = 0;
+  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const &data) = 0;
   std::set<std::string> gatherSingletonVars(void);
   virtual std::map<std::string, int> gatherVarCounts(void) = 0;
-  virtual sptr<KOREPattern> filterSubstitution(PrettyPrintData const& data, std::set<std::string> const& vars) = 0;
-  virtual bool matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) = 0;
-  sptr<KOREPattern> expandMacros(SubsortMap const& subsorts, SymbolMap const& overloads, std::vector<ptr<KOREDeclaration>> const& axioms, bool reverse) { std::set<size_t> appliedRules; return expandMacros(subsorts, overloads, axioms, reverse, appliedRules); }
+  virtual sptr<KOREPattern> filterSubstitution(
+      PrettyPrintData const &data, std::set<std::string> const &vars)
+      = 0;
+  virtual bool matches(
+      substitution &subst, SubsortMap const &subsorts,
+      SymbolMap const &overloads, sptr<KOREPattern> subject)
+      = 0;
+  sptr<KOREPattern> expandMacros(
+      SubsortMap const &subsorts, SymbolMap const &overloads,
+      std::vector<ptr<KOREDeclaration>> const &axioms, bool reverse) {
+    std::set<size_t> appliedRules;
+    return expandMacros(subsorts, overloads, axioms, reverse, appliedRules);
+  }
 
   friend KORECompositePattern;
+
 private:
-  virtual sptr<KOREPattern> expandMacros(SubsortMap const& subsorts, SymbolMap const& overloads, std::vector<ptr<KOREDeclaration>> const& axioms, bool reverse, std::set<size_t> &appliedRules) = 0;
+  virtual sptr<KOREPattern> expandMacros(
+      SubsortMap const &subsorts, SymbolMap const &overloads,
+      std::vector<ptr<KOREDeclaration>> const &axioms, bool reverse,
+      std::set<size_t> &appliedRules)
+      = 0;
 };
 
 class KOREVariablePattern : public KOREPattern {
@@ -346,15 +397,20 @@ public:
   static ptr<KOREVariablePattern>
   Create(const std::string &Name, sptr<KORESort> sort) {
     ptr<KOREVariable> Var = KOREVariable::Create(Name);
-    return ptr<KOREVariablePattern>(new KOREVariablePattern(std::move(Var), sort));
+    return ptr<KOREVariablePattern>(
+        new KOREVariablePattern(std::move(Var), sort));
   }
 
   std::string getName() const;
   virtual sptr<KORESort> getSort() const override { return sort; }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override {}
-  virtual void markVariables(std::map<std::string, KOREVariablePattern *> &map) override { map.insert({name->getName(), this}); }
+  virtual void
+  markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override { }
+  virtual void
+  markVariables(std::map<std::string, KOREVariablePattern *> &map) override {
+    map.insert({name->getName(), this});
+  }
   virtual sptr<KOREPattern> substitute(const substitution &subst) override {
     auto val = subst.find(name->getName());
     if (val == subst.end()) {
@@ -362,19 +418,38 @@ public:
     }
     return val->second;
   }
-  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
-  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
-  virtual std::map<std::string, int> gatherVarCounts(void) override { return std::map<std::string, int>{{name->getName(), 1}}; }
-  virtual sptr<KOREPattern> filterSubstitution(PrettyPrintData const& data, std::set<std::string> const& vars) override { return shared_from_this(); }
-  virtual bool matches(substitution &subst, SubsortMap const&, SymbolMap const&, sptr<KOREPattern> subject) override;
-  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override;
+  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override {
+    return shared_from_this();
+  }
+  virtual sptr<KOREPattern>
+  sortCollections(PrettyPrintData const &data) override {
+    return shared_from_this();
+  }
+  virtual std::map<std::string, int> gatherVarCounts(void) override {
+    return std::map<std::string, int>{{name->getName(), 1}};
+  }
+  virtual sptr<KOREPattern> filterSubstitution(
+      PrettyPrintData const &data, std::set<std::string> const &vars) override {
+    return shared_from_this();
+  }
+  virtual bool matches(
+      substitution &subst, SubsortMap const &, SymbolMap const &,
+      sptr<KOREPattern> subject) override;
+  virtual void
+  prettyPrint(std::ostream &out, PrettyPrintData const &data) const override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(SubsortMap const&, SymbolMap const&, std::vector<ptr<KOREDeclaration>> const& macros, bool reverse, std::set<size_t> &appliedRules) override { return shared_from_this(); }  
+  virtual sptr<KOREPattern> expandMacros(
+      SubsortMap const &, SymbolMap const &,
+      std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
+      std::set<size_t> &appliedRules) override {
+    return shared_from_this();
+  }
 
 private:
   KOREVariablePattern(ptr<KOREVariable> Name, sptr<KORESort> Sort)
-  : name(std::move(Name)), sort(Sort) { }
+      : name(std::move(Name))
+      , sort(Sort) { }
 };
 
 class KOREPattern;
@@ -396,34 +471,47 @@ public:
   static ptr<KORECompositePattern> Create(KORESymbol *Sym) {
     ptr<KORESymbol> newSym = KORESymbol::Create(Sym->getName());
     *newSym = *Sym;
-    return ptr<KORECompositePattern>(new KORECompositePattern(std::move(newSym)));
+    return ptr<KORECompositePattern>(
+        new KORECompositePattern(std::move(newSym)));
   }
 
   sptr<KORESort> getSort() const override { return constructor->getSort(); }
 
   KORESymbol *getConstructor() const { return constructor.get(); }
-  const std::vector<sptr<KOREPattern>> &getArguments() const { return arguments; }
+  const std::vector<sptr<KOREPattern>> &getArguments() const {
+    return arguments;
+  }
 
   void addArgument(sptr<KOREPattern> Argument);
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override;
-  virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
-  virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) override;
+  virtual void
+  prettyPrint(std::ostream &out, PrettyPrintData const &data) const override;
+  virtual void
+  markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override;
+  virtual void
+  markVariables(std::map<std::string, KOREVariablePattern *> &) override;
   virtual sptr<KOREPattern> substitute(const substitution &) override;
   virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override;
-  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override;
+  virtual sptr<KOREPattern>
+  sortCollections(PrettyPrintData const &data) override;
   virtual std::map<std::string, int> gatherVarCounts(void) override;
-  virtual sptr<KOREPattern> filterSubstitution(PrettyPrintData const& data, std::set<std::string> const& vars) override;
-  virtual bool matches(substitution &, SubsortMap const&, SymbolMap const&, sptr<KOREPattern>) override;
+  virtual sptr<KOREPattern> filterSubstitution(
+      PrettyPrintData const &data, std::set<std::string> const &vars) override;
+  virtual bool matches(
+      substitution &, SubsortMap const &, SymbolMap const &,
+      sptr<KOREPattern>) override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(SubsortMap const&, SymbolMap const&, std::vector<ptr<KOREDeclaration>> const& macros, bool reverse, std::set<size_t> &appliedRules) override;
+  virtual sptr<KOREPattern> expandMacros(
+      SubsortMap const &, SymbolMap const &,
+      std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
+      std::set<size_t> &appliedRules) override;
 
   friend void ::kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern);
 
 private:
   KORECompositePattern(ptr<KORESymbol> Constructor)
-  : constructor(std::move(Constructor)) { }
+      : constructor(std::move(Constructor)) { }
 };
 
 class KOREStringPattern : public KOREPattern {
@@ -438,22 +526,47 @@ public:
   std::string getContents() { return contents; }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
-  virtual void prettyPrint(std::ostream &out, PrettyPrintData const& data) const override { abort(); }
-  virtual void markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override {}
-  virtual void markVariables(std::map<std::string, KOREVariablePattern *> &) override {}
+  virtual void
+  prettyPrint(std::ostream &out, PrettyPrintData const &data) const override {
+    abort();
+  }
+  virtual void
+  markSymbols(std::map<std::string, std::vector<KORESymbol *>> &) override { }
+  virtual void
+  markVariables(std::map<std::string, KOREVariablePattern *> &) override { }
   virtual sptr<KORESort> getSort(void) const override { abort(); }
-  virtual sptr<KOREPattern> substitute(const substitution &) override { return shared_from_this(); }
-  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override { return shared_from_this(); }
-  virtual sptr<KOREPattern> sortCollections(PrettyPrintData const& data) override { return shared_from_this(); }
-  virtual std::map<std::string, int> gatherVarCounts(void) override { return std::map<std::string, int>{}; }
-  virtual sptr<KOREPattern> filterSubstitution(PrettyPrintData const& data, std::set<std::string> const& var) override { return shared_from_this(); }
-  virtual bool matches(substitution &, SubsortMap const&, SymbolMap const&, sptr<KOREPattern> subject) override;
+  virtual sptr<KOREPattern> substitute(const substitution &) override {
+    return shared_from_this();
+  }
+  virtual sptr<KOREPattern> expandAliases(KOREDefinition *) override {
+    return shared_from_this();
+  }
+  virtual sptr<KOREPattern>
+  sortCollections(PrettyPrintData const &data) override {
+    return shared_from_this();
+  }
+  virtual std::map<std::string, int> gatherVarCounts(void) override {
+    return std::map<std::string, int>{};
+  }
+  virtual sptr<KOREPattern> filterSubstitution(
+      PrettyPrintData const &data, std::set<std::string> const &var) override {
+    return shared_from_this();
+  }
+  virtual bool matches(
+      substitution &, SubsortMap const &, SymbolMap const &,
+      sptr<KOREPattern> subject) override;
 
 private:
-  virtual sptr<KOREPattern> expandMacros(SubsortMap const&, SymbolMap const&, std::vector<ptr<KOREDeclaration>> const& macros, bool reverse, std::set<size_t> &appliedRules) override { return shared_from_this(); }
+  virtual sptr<KOREPattern> expandMacros(
+      SubsortMap const &, SymbolMap const &,
+      std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
+      std::set<size_t> &appliedRules) override {
+    return shared_from_this();
+  }
 
 private:
-  KOREStringPattern(const std::string &Contents) : contents(Contents) { }
+  KOREStringPattern(const std::string &Contents)
+      : contents(Contents) { }
 };
 
 // KOREDeclaration
@@ -465,9 +578,14 @@ protected:
 public:
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void addObjectSortVariable(sptr<KORESortVariable> SortVariable);
-  virtual void print(std::ostream &Out, unsigned indent = 0) const =0;
-  const std::map<std::string, ptr<KORECompositePattern>> &getAttributes() const { return attributes; }
-  const std::vector<sptr<KORESortVariable>> &getObjectSortVariables() const { return objectSortVariables; }
+  virtual void print(std::ostream &Out, unsigned indent = 0) const = 0;
+  const std::map<std::string, ptr<KORECompositePattern>> &
+  getAttributes() const {
+    return attributes;
+  }
+  const std::vector<sptr<KORESortVariable>> &getObjectSortVariables() const {
+    return objectSortVariables;
+  }
   virtual ~KOREDeclaration() = default;
 
   std::string getStringAttribute(std::string name) const;
@@ -484,7 +602,8 @@ private:
 public:
   static ptr<KORECompositeSortDeclaration>
   Create(const std::string &Name, bool isHooked = false) {
-    return ptr<KORECompositeSortDeclaration>(new KORECompositeSortDeclaration(Name, isHooked));
+    return ptr<KORECompositeSortDeclaration>(
+        new KORECompositeSortDeclaration(Name, isHooked));
   }
 
   std::string getName() const { return sortName; }
@@ -494,19 +613,18 @@ public:
 
 private:
   KORECompositeSortDeclaration(const std::string &Name, bool _isHooked)
-  : _isHooked(_isHooked), sortName(Name) { }
+      : _isHooked(_isHooked)
+      , sortName(Name) { }
 };
 
-class KORESymbolOrAliasDeclaration : public KOREDeclaration {
-
-};
+class KORESymbolOrAliasDeclaration : public KOREDeclaration { };
 
 class KORESymbolAliasDeclaration : public KORESymbolOrAliasDeclaration {
 protected:
   ptr<KORESymbol> symbol;
 
   KORESymbolAliasDeclaration(ptr<KORESymbol> Symbol)
-  : symbol(std::move(Symbol)) { }
+      : symbol(std::move(Symbol)) { }
 
 public:
   KORESymbol *getSymbol() const { return symbol.get(); }
@@ -520,7 +638,8 @@ public:
   static ptr<KORESymbolDeclaration>
   Create(const std::string &Name, bool isHooked = false) {
     ptr<KORESymbol> Sym = KORESymbol::Create(Name);
-    return ptr<KORESymbolDeclaration>(new KORESymbolDeclaration(std::move(Sym), isHooked));
+    return ptr<KORESymbolDeclaration>(
+        new KORESymbolDeclaration(std::move(Sym), isHooked));
   }
 
   bool isHooked() const { return _isHooked; }
@@ -531,7 +650,8 @@ public:
 
 private:
   KORESymbolDeclaration(ptr<KORESymbol> Symbol, bool _isHooked)
-  : KORESymbolAliasDeclaration(std::move(Symbol)), _isHooked(_isHooked) { }
+      : KORESymbolAliasDeclaration(std::move(Symbol))
+      , _isHooked(_isHooked) { }
 };
 
 class KOREAliasDeclaration : public KORESymbolAliasDeclaration {
@@ -553,7 +673,7 @@ public:
 
 private:
   KOREAliasDeclaration(ptr<KORESymbol> Symbol)
-  : KORESymbolAliasDeclaration(std::move(Symbol)) { }
+      : KORESymbolAliasDeclaration(std::move(Symbol)) { }
 };
 
 class KOREAxiomDeclaration : public KOREDeclaration {
@@ -562,10 +682,11 @@ private:
   unsigned ordinal;
   bool _isClaim;
 
-  KOREAxiomDeclaration(bool isClaim): _isClaim(isClaim) {}
+  KOREAxiomDeclaration(bool isClaim)
+      : _isClaim(isClaim) { }
 
 public:
-  static ptr<KOREAxiomDeclaration> Create(bool isClaim = false) { 
+  static ptr<KOREAxiomDeclaration> Create(bool isClaim = false) {
     return ptr<KOREAxiomDeclaration>(new KOREAxiomDeclaration(isClaim));
   }
 
@@ -594,13 +715,15 @@ private:
 
 public:
   static ptr<KOREModuleImportDeclaration> Create(const std::string &Name) {
-    return ptr<KOREModuleImportDeclaration>(new KOREModuleImportDeclaration(Name));
+    return ptr<KOREModuleImportDeclaration>(
+        new KOREModuleImportDeclaration(Name));
   }
 
   virtual void print(std::ostream &Out, unsigned indent = 0) const override;
 
 private:
-  KOREModuleImportDeclaration(const std::string &Name) : moduleName(Name) { }
+  KOREModuleImportDeclaration(const std::string &Name)
+      : moduleName(Name) { }
 };
 
 // KOREModule
@@ -619,10 +742,13 @@ public:
   void addDeclaration(ptr<KOREDeclaration> Declaration);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
-  const std::vector<ptr<KOREDeclaration>> &getDeclarations() const { return declarations; } 
+  const std::vector<ptr<KOREDeclaration>> &getDeclarations() const {
+    return declarations;
+  }
 
 private:
-  KOREModule(const std::string &Name) : name(Name) { }
+  KOREModule(const std::string &Name)
+      : name(Name) { }
 };
 
 // KOREDefinition
@@ -631,23 +757,24 @@ public:
   // Symbol table types
   using KOREModuleMapType = std::map<std::string, KOREModule *>;
 
-  using KORESortConstructorMapType =
-    std::map<std::string, KORECompositeSort *>;
+  using KORESortConstructorMapType = std::map<std::string, KORECompositeSort *>;
 
   using KORESymbolMapType = std::map<uint32_t, KORESymbol *>;
 
   using KORESymbolStringMapType = std::map<std::string, KORESymbol *>;
 
-  using KORESortVariableMapType =
-    std::map<std::string, KORESortVariable *>;
+  using KORESortVariableMapType = std::map<std::string, KORESortVariable *>;
 
   using KOREVariableMapType = std::map<std::string, KOREVariable *>;
 
-  using KORECompositeSortDeclarationMapType = std::map<std::string, KORECompositeSortDeclaration *>;
+  using KORECompositeSortDeclarationMapType
+      = std::map<std::string, KORECompositeSortDeclaration *>;
   using KORECompositeSortMapType = std::map<ValueType, sptr<KORECompositeSort>>;
 
-  using KORESymbolDeclarationMapType = std::map<std::string, KORESymbolDeclaration *>;
-  using KOREAliasDeclarationMapType = std::map<std::string, KOREAliasDeclaration *>;
+  using KORESymbolDeclarationMapType
+      = std::map<std::string, KORESymbolDeclaration *>;
+  using KOREAliasDeclarationMapType
+      = std::map<std::string, KOREAliasDeclaration *>;
 
   using KOREAxiomMapType = std::map<size_t, KOREAxiomDeclaration *>;
 
@@ -674,40 +801,61 @@ private:
   KORESymbol *injSymbol;
 
 public:
-  static ptr<KOREDefinition> Create() { return ptr<KOREDefinition>(new KOREDefinition()); }
+  static ptr<KOREDefinition> Create() {
+    return ptr<KOREDefinition>(new KOREDefinition());
+  }
 
   /* Preprocesses the definition and prepares it for translation to llvm.
      This performs the following tasks:
      * removes axioms for which isRequired() returns false
      * sets the arguments field for each KORESymbol to the actual instantiated
-       sort arguments of the symbol (rather than just their polymorphic parameters
-     * sets the tag and layout fields on all the KORESymbols declared by the user
-       in the definition. */
+       sort arguments of the symbol (rather than just their polymorphic
+     parameters
+     * sets the tag and layout fields on all the KORESymbols declared by the
+     user in the definition. */
   void preprocess();
 
   void addModule(ptr<KOREModule> Module);
   void addAttribute(ptr<KORECompositePattern> Attribute);
   void print(std::ostream &Out, unsigned indent = 0) const;
 
-  const KORECompositeSortDeclarationMapType &getSortDeclarations() const { return sortDeclarations; }
-  const KORESymbolDeclarationMapType &getSymbolDeclarations() const { return symbolDeclarations; }
-  const KOREAliasDeclarationMapType &getAliasDeclarations() const { return aliasDeclarations; }
+  const KORECompositeSortDeclarationMapType &getSortDeclarations() const {
+    return sortDeclarations;
+  }
+  const KORESymbolDeclarationMapType &getSymbolDeclarations() const {
+    return symbolDeclarations;
+  }
+  const KOREAliasDeclarationMapType &getAliasDeclarations() const {
+    return aliasDeclarations;
+  }
   const KORESymbolMapType &getSymbols() const { return objectSymbols; }
-  const KORESymbolStringMapType &getAllSymbols() const { return allObjectSymbols; }
+  const KORESymbolStringMapType &getAllSymbols() const {
+    return allObjectSymbols;
+  }
   const KORECompositeSortMapType getHookedSorts() const { return hookedSorts; }
   const std::list<KOREAxiomDeclaration *> &getAxioms() const { return axioms; }
-  KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const { return ordinals.at(ordinal); }
-  const std::map<std::string, ptr<KORECompositePattern>> &getAttributes() const {
+  KOREAxiomDeclaration *getAxiomByOrdinal(size_t ordinal) const {
+    return ordinals.at(ordinal);
+  }
+  const std::map<std::string, ptr<KORECompositePattern>> &
+  getAttributes() const {
     return attributes;
   }
-  const KORESymbolStringMapType &getFreshFunctions() const { return freshFunctions; }
+  const KORESymbolStringMapType &getFreshFunctions() const {
+    return freshFunctions;
+  }
   KORESymbol *getInjSymbol() { return injSymbol; }
 };
 
-void readMultimap(std::string, KORESymbolDeclaration *, std::map<std::string, std::set<std::string>> &, std::string);
+void readMultimap(
+    std::string, KORESymbolDeclaration *,
+    std::map<std::string, std::set<std::string>> &, std::string);
 
-template<typename Elem, typename Hash, typename Equal>
-std::unordered_map<Elem*, std::unordered_set<Elem*, Hash, Equal>, Hash, Equal> transitiveClosure(std::unordered_map<Elem*, std::unordered_set<Elem*, Hash, Equal>, Hash, Equal> relations) {
+template <typename Elem, typename Hash, typename Equal>
+std::unordered_map<Elem *, std::unordered_set<Elem *, Hash, Equal>, Hash, Equal>
+transitiveClosure(std::unordered_map<
+                  Elem *, std::unordered_set<Elem *, Hash, Equal>, Hash, Equal>
+                      relations) {
   bool dirty;
   do {
     dirty = false;

--- a/include/kllvm/codegen/CreateTerm.h
+++ b/include/kllvm/codegen/CreateTerm.h
@@ -19,62 +19,82 @@ private:
   llvm::LLVMContext &Ctx;
   bool isAnywhereOwise;
 
-  llvm::Value *createHook(KORECompositePattern *hookAtt, KORECompositePattern *pattern);
-  llvm::Value *createFunctionCall(std::string name, KORECompositePattern *pattern, bool sret, bool fastcc);
-  llvm::Value *notInjectionCase(KORECompositePattern *constructor, llvm::Value *val);
+  llvm::Value *
+  createHook(KORECompositePattern *hookAtt, KORECompositePattern *pattern);
+  llvm::Value *createFunctionCall(
+      std::string name, KORECompositePattern *pattern, bool sret, bool fastcc);
+  llvm::Value *
+  notInjectionCase(KORECompositePattern *constructor, llvm::Value *val);
+
 public:
   CreateTerm(
-    llvm::StringMap<llvm::Value *> &Substitution,
-    KOREDefinition *Definition,
-    llvm::BasicBlock *EntryBlock,
-    llvm::Module *Module,
-    bool isAnywhereOwise) :
-      Substitution(Substitution),
-      Definition(Definition),
-      CurrentBlock(EntryBlock),
-      Module(Module),
-      Ctx(Module->getContext()),
-      isAnywhereOwise(isAnywhereOwise) {}
+      llvm::StringMap<llvm::Value *> &Substitution, KOREDefinition *Definition,
+      llvm::BasicBlock *EntryBlock, llvm::Module *Module, bool isAnywhereOwise)
+      : Substitution(Substitution)
+      , Definition(Definition)
+      , CurrentBlock(EntryBlock)
+      , Module(Module)
+      , Ctx(Module->getContext())
+      , isAnywhereOwise(isAnywhereOwise) { }
 
-/* adds code to the specified basic block in the specified module which constructs
-   an llvm value corresponding to the specified KORE RHS pattern and substitution in the
-   specified definition, and returns the value itself, along with a boolean indicating whether the resulting term could be an injection. */
+  /* adds code to the specified basic block in the specified module which
+     constructs an llvm value corresponding to the specified KORE RHS pattern
+     and substitution in the
+     specified definition, and returns the value itself, along with a boolean
+     indicating whether the resulting term could be an injection. */
   std::pair<llvm::Value *, bool> operator()(KOREPattern *pattern);
   llvm::Value *createToken(ValueType sort, std::string contents);
-  /* creates a call instructin calling a particular llvm function, abstracting certain abi and calling convention details. 
-   * name: the nmae of the function to call in llvm
-   * returnCat: the value category of the return type of the function
-   * args: the arguments to pass to the functgion
-   * sret: if true, this is a function that returns a struct constant via the C abi, ie, 
-   * the function actually returns void and the return value is via a pointe. Note that this 
-   * can be set to true even if the function does not return a struct, in which case its value
-   * is ignored.
-   * load: if the function returns a struct via sret, then if load is true, we load the value 
-   * fastcc: true if we should use the fastcc calling convention
-   * returned from the function before returning it. */
-  llvm::Value *createFunctionCall(std::string name, ValueType returnCat, const std::vector<llvm::Value *> &args, bool sret, bool fastcc);
+  /* creates a call instructin calling a particular llvm function, abstracting
+   * certain abi and calling convention details. name: the nmae of the function
+   * to call in llvm returnCat: the value category of the return type of the
+   * function args: the arguments to pass to the functgion sret: if true, this
+   * is a function that returns a struct constant via the C abi, ie, the
+   * function actually returns void and the return value is via a pointe. Note
+   * that this can be set to true even if the function does not return a struct,
+   * in which case its value is ignored. load: if the function returns a struct
+   * via sret, then if load is true, we load the value fastcc: true if we should
+   * use the fastcc calling convention returned from the function before
+   * returning it. */
+  llvm::Value *createFunctionCall(
+      std::string name, ValueType returnCat,
+      const std::vector<llvm::Value *> &args, bool sret, bool fastcc);
 
   llvm::BasicBlock *getCurrentBlock() const { return CurrentBlock; }
 };
 
-/* Creates a new llvm::Module with the predefined declarations common to all llvm modules
-   in the llvm backend. */
-std::unique_ptr<llvm::Module> newModule(std::string name, llvm::LLVMContext &Context);
-void addKompiledDirSymbol(llvm::LLVMContext &Context, std::string dir, llvm::Module *mod, bool debug);
+/* Creates a new llvm::Module with the predefined declarations common to all
+   llvm modules in the llvm backend. */
+std::unique_ptr<llvm::Module>
+newModule(std::string name, llvm::LLVMContext &Context);
+void addKompiledDirSymbol(
+    llvm::LLVMContext &Context, std::string dir, llvm::Module *mod, bool debug);
 
-llvm::StructType *getBlockType(llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol);
-llvm::Value *getBlockHeader(llvm::Module *Module, KOREDefinition *definition,
-    const KORESymbol *symbol, llvm::Type *BlockType);
+llvm::StructType *getBlockType(
+    llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol);
+llvm::Value *getBlockHeader(
+    llvm::Module *Module, KOREDefinition *definition, const KORESymbol *symbol,
+    llvm::Type *BlockType);
 
-/* returns the llvm::Type corresponding to the type of the result of calling createTerm
-   on the specified pattern. */
-ValueType termType(KOREPattern *pattern, llvm::StringMap<ValueType> &substitution, KOREDefinition *definition);
+/* returns the llvm::Type corresponding to the type of the result of calling
+   createTerm on the specified pattern. */
+ValueType termType(
+    KOREPattern *pattern, llvm::StringMap<ValueType> &substitution,
+    KOREDefinition *definition);
 
-/** creates a function that applies the specified rule once it has matched, and returns the name of the function. */
-void makeApplyRuleFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *Module, bool bigStep = false);
-std::string makeApplyRuleFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *Module, std::vector<Residual> residuals);
-/** creates a function that evaluates the side condition of the specified rule, and returns the name of the function. Returns empty string if function has no side condition. */
-std::string makeSideConditionFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *Module);
+/** creates a function that applies the specified rule once it has matched, and
+ * returns the name of the function. */
+void makeApplyRuleFunction(
+    KOREAxiomDeclaration *axiom, KOREDefinition *definition,
+    llvm::Module *Module, bool bigStep = false);
+std::string makeApplyRuleFunction(
+    KOREAxiomDeclaration *axiom, KOREDefinition *definition,
+    llvm::Module *Module, std::vector<Residual> residuals);
+/** creates a function that evaluates the side condition of the specified rule,
+ * and returns the name of the function. Returns empty string if function has no
+ * side condition. */
+std::string makeSideConditionFunction(
+    KOREAxiomDeclaration *axiom, KOREDefinition *definition,
+    llvm::Module *Module);
 
 /* returns the llvm::Type corresponding to the specified KORE sort category */
 llvm::Type *getValueType(ValueType sort, llvm::Module *Module);
@@ -82,8 +102,12 @@ llvm::Type *getParamType(ValueType sort, llvm::Module *Module);
 
 void addAbort(llvm::BasicBlock *block, llvm::Module *Module);
 
-llvm::Value *allocateTerm(llvm::Type *AllocType, llvm::BasicBlock *block, const char *allocFn = "koreAlloc");
-llvm::Value *allocateTerm(llvm::Type *AllocType, llvm::Value *Len, llvm::BasicBlock *block, const char *allocFn = "koreAlloc");
-}
+llvm::Value *allocateTerm(
+    llvm::Type *AllocType, llvm::BasicBlock *block,
+    const char *allocFn = "koreAlloc");
+llvm::Value *allocateTerm(
+    llvm::Type *AllocType, llvm::Value *Len, llvm::BasicBlock *block,
+    const char *allocFn = "koreAlloc");
+} // namespace kllvm
 
 #endif // CREATE_TERM_H

--- a/include/kllvm/codegen/Debug.h
+++ b/include/kllvm/codegen/Debug.h
@@ -1,9 +1,9 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#include "llvm/IR/Module.h"
-#include "llvm/IR/DebugInfoMetadata.h"
 #include "kllvm/ast/AST.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/Module.h"
 
 namespace kllvm {
 
@@ -12,11 +12,17 @@ extern int CODEGEN_DEBUG;
 void initDebugInfo(llvm::Module *module, std::string filename);
 void finalizeDebugInfo(void);
 
-void initDebugFunction(std::string name, std::string linkageName, llvm::DISubroutineType *type, KOREDefinition *definition, llvm::Function *func);
+void initDebugFunction(
+    std::string name, std::string linkageName, llvm::DISubroutineType *type,
+    KOREDefinition *definition, llvm::Function *func);
 
-void initDebugAxiom(std::map<std::string, ptr<KORECompositePattern>> const& att);
-void initDebugParam(llvm::Function *func, unsigned argNo, std::string name, ValueType type, std::string typeName);
-void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable *var);
+void initDebugAxiom(
+    std::map<std::string, ptr<KORECompositePattern>> const &att);
+void initDebugParam(
+    llvm::Function *func, unsigned argNo, std::string name, ValueType type,
+    std::string typeName);
+void initDebugGlobal(
+    std::string name, llvm::DIType *type, llvm::GlobalVariable *var);
 
 llvm::DIType *getDebugType(ValueType type, std::string typeName);
 llvm::DIType *getIntDebugType(void);
@@ -30,10 +36,11 @@ llvm::DIType *getCharPtrDebugType(void);
 llvm::DIType *getCharDebugType(void);
 llvm::DIType *getForwardDecl(std::string name);
 
-llvm::DISubroutineType *getDebugFunctionType(llvm::Metadata *, std::vector<llvm::Metadata *>);
+llvm::DISubroutineType *
+getDebugFunctionType(llvm::Metadata *, std::vector<llvm::Metadata *>);
 
 void setDebugLoc(llvm::Instruction *instr);
 void resetDebugLoc(void);
 
-}
+} // namespace kllvm
 #endif

--- a/include/kllvm/codegen/DecisionParser.h
+++ b/include/kllvm/codegen/DecisionParser.h
@@ -21,10 +21,19 @@ struct PartialStep {
   std::vector<Residual> residuals;
 };
 
-DecisionNode *parseYamlDecisionTreeFromString(llvm::Module *, std::string yaml, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
-DecisionNode *parseYamlDecisionTree(llvm::Module *, std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
-PartialStep parseYamlSpecialDecisionTree(llvm::Module *, std::string filename, const std::map<std::string, KORESymbol *> &syms, const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+DecisionNode *parseYamlDecisionTreeFromString(
+    llvm::Module *, std::string yaml,
+    const std::map<std::string, KORESymbol *> &syms,
+    const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+DecisionNode *parseYamlDecisionTree(
+    llvm::Module *, std::string filename,
+    const std::map<std::string, KORESymbol *> &syms,
+    const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
+PartialStep parseYamlSpecialDecisionTree(
+    llvm::Module *, std::string filename,
+    const std::map<std::string, KORESymbol *> &syms,
+    const std::map<ValueType, sptr<KORECompositeSort>> &sorts);
 
-}
+} // namespace kllvm
 
 #endif // DECISION_PARSER_H

--- a/include/kllvm/codegen/EmitConfigParser.h
+++ b/include/kllvm/codegen/EmitConfigParser.h
@@ -7,8 +7,9 @@
 
 namespace kllvm {
 
-void emitConfigParserFunctions(KOREDefinition *definition, llvm::Module *module);
+void emitConfigParserFunctions(
+    KOREDefinition *definition, llvm::Module *module);
 
 }
 
-#endif // EMIT_CONFIG_PARSER_H 
+#endif // EMIT_CONFIG_PARSER_H

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -5,17 +5,18 @@
 
 namespace kllvm {
 
-// Returns a reference to the function declaration for a memory allocation function with the given
-// name, adding a declaration to the current module if one does not yet exist
-llvm::Function* koreHeapAlloc(std::string name, llvm::Module *module);
+// Returns a reference to the function declaration for a memory allocation
+// function with the given name, adding a declaration to the current module if
+// one does not yet exist
+llvm::Function *koreHeapAlloc(std::string name, llvm::Module *module);
 
-// If Value is an instance of llvm::Function, cast and return. Otherwise, print errors and abort.
-llvm::Function* castToFunctionOrAbort(llvm::Value* value);
-
+// If Value is an instance of llvm::Function, cast and return. Otherwise, print
+// errors and abort.
+llvm::Function *castToFunctionOrAbort(llvm::Value *value);
 
 // getOrInsertFunction on module, aborting on failure
-template<class...Ts>
-static llvm::Function* getOrInsertFunction(llvm::Module *module, Ts... Args) {
+template <class... Ts>
+static llvm::Function *getOrInsertFunction(llvm::Module *module, Ts... Args) {
   llvm::Value *callee;
   auto ret = module->getOrInsertFunction(Args...);
 #if LLVM_VERSION_MAJOR >= 9
@@ -28,6 +29,6 @@ static llvm::Function* getOrInsertFunction(llvm::Module *module, Ts... Args) {
 
 llvm::StructType *getTypeByName(llvm::Module *module, std::string name);
 
-}
+} // namespace kllvm
 
-#endif // KLLVM_UTIL_H 
+#endif // KLLVM_UTIL_H

--- a/include/kllvm/parser/KOREParser.h
+++ b/include/kllvm/parser/KOREParser.h
@@ -9,8 +9,9 @@ namespace parser {
 
 class KOREParser {
 public:
-  KOREParser(std::string filename) :
-	  scanner(KOREScanner(filename)), loc(location(filename)) {}
+  KOREParser(std::string filename)
+      : scanner(KOREScanner(filename))
+      , loc(location(filename)) { }
 
   ptr<KOREDefinition> definition(void);
   ptr<KOREPattern> pattern(void);
@@ -19,7 +20,7 @@ public:
 private:
   KOREScanner scanner;
   location loc;
-  [[ noreturn ]] void error(const location &loc, const std::string &err_message);
+  [[noreturn]] void error(const location &loc, const std::string &err_message);
 
   std::string consume(token next);
   token peek(void);

--- a/include/kllvm/parser/KOREScanner.h
+++ b/include/kllvm/parser/KOREScanner.h
@@ -39,9 +39,9 @@ public:
   ~KOREScanner();
   int scan();
 
-friend class KOREParser;
+  friend class KOREParser;
 
-typedef void *yyscan_t;
+  typedef void *yyscan_t;
 
 private:
   yyscan_t scanner;

--- a/include/kllvm/parser/location.h
+++ b/include/kllvm/parser/location.h
@@ -19,9 +19,7 @@ public:
     }
   }
 
-  void columns(int count = 1) {
-    column = add_(column, count, 1);
-  }
+  void columns(int count = 1) { column = add_(column, count, 1); }
 
 private:
   static unsigned add_(unsigned lhs, int rhs, int min) {
@@ -29,45 +27,37 @@ private:
   }
 };
 
-inline position&
-operator+= (position& res, int width)
-{
+inline position &operator+=(position &res, int width) {
   res.columns(width);
   return res;
 }
- 
+
 template <typename YYChar>
-std::basic_ostream<YYChar>&
-operator<< (std::basic_ostream<YYChar>& ostr, const position& pos) {
+std::basic_ostream<YYChar> &
+operator<<(std::basic_ostream<YYChar> &ostr, const position &pos) {
   ostr << pos.filename << ':';
   return ostr << pos.line << '.' << pos.column;
 }
 
 class location {
 public:
-  location(std::string filename):
-    begin({filename, 1, 1}), end({filename, 1, 1}) {}
+  location(std::string filename)
+      : begin({filename, 1, 1})
+      , end({filename, 1, 1}) { }
 
   position begin;
   position end;
 
-  void step() {
-    begin = end;
-  }
+  void step() { begin = end; }
 
-  void columns(int count = 1) {
-    end += count;
-  }
+  void columns(int count = 1) { end += count; }
 
-  void lines(int count = 1) {
-    end.lines(count);
-  }
-
+  void lines(int count = 1) { end.lines(count); }
 };
 
 template <typename YYChar>
-std::basic_ostream<YYChar>&
-operator<< (std::basic_ostream<YYChar>& ostr, const location& loc) {
+std::basic_ostream<YYChar> &
+operator<<(std::basic_ostream<YYChar> &ostr, const location &loc) {
   unsigned end_col = 0 < loc.end.column ? loc.end.column - 1 : 0;
   ostr << loc.begin;
   if (loc.begin.filename != loc.end.filename)
@@ -79,7 +69,7 @@ operator<< (std::basic_ostream<YYChar>& ostr, const location& loc) {
   return ostr;
 }
 
-}
-}
+} // namespace parser
+} // namespace kllvm
 
 #endif

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -16,46 +16,49 @@ char oldspace_collection_id(void);
 size_t youngspace_size(void);
 
 // allocates exactly requested bytes into the young generation
-void* koreAlloc(size_t requested);
-// allocates enough space for a string token whose raw size is requested into the young generation.
-// rounds up to the nearest 8 bytes and always allocates at least 16 bytes
-void* koreAllocToken(size_t requested);
+void *koreAlloc(size_t requested);
+// allocates enough space for a string token whose raw size is requested into
+// the young generation. rounds up to the nearest 8 bytes and always allocates
+// at least 16 bytes
+void *koreAllocToken(size_t requested);
 // allocates exactly requested bytes into the old generation
-void* koreAllocOld(size_t requested);
-// allocates enough space for a string token whose raw size is requested into the old generation.
-// rounds up to the nearest 8 bytes and always allocates at least 16 bytes
-void* koreAllocTokenOld(size_t requested);
+void *koreAllocOld(size_t requested);
+// allocates enough space for a string token whose raw size is requested into
+// the old generation. rounds up to the nearest 8 bytes and always allocates at
+// least 16 bytes
+void *koreAllocTokenOld(size_t requested);
 // allocates exactly requested bytes into the always garbage-collected arena.
-// objects that can potentially survive a collection (i.e. can be reached from the
-// root during collection) should never be allocated in this arena.
-void* koreAllocAlwaysGC(size_t requested);
+// objects that can potentially survive a collection (i.e. can be reached from
+// the root during collection) should never be allocated in this arena.
+void *koreAllocAlwaysGC(size_t requested);
 // swaps the two semispace of the young generation as part of garbage collection
-// if the swapOld flag is set, it also swaps the two semispaces of the old generation
+// if the swapOld flag is set, it also swaps the two semispaces of the old
+// generation
 void koreAllocSwap(bool swapOld);
 // resizes the last allocation into the young generation
-void* koreResizeLastAlloc(void* oldptr, size_t newrequest, size_t oldrequest);
+void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t oldrequest);
 // allocator hook for the GMP library
-void* koreAllocMP(size_t);
+void *koreAllocMP(size_t);
 // reallocator hook for the GMP library
-void* koreReallocMP(void*, size_t, size_t);
+void *koreReallocMP(void *, size_t, size_t);
 // deallocator hook for the GMP library
-void koreFree(void*, size_t);
+void koreFree(void *, size_t);
 
 // helper allocators for integers and floats
-// they allocate enough space into the corresponding generation and initialize the blockheader
-// with the correct length. The size argument is ignored but exists for uniformity with
-// the standard malloc signature. The caller has to set the appropriate gc bits.
-void* koreAllocInteger(size_t requested);
-void* koreAllocFloating(size_t requested);
-void* koreAllocIntegerOld(size_t requested);
-void* koreAllocFloatingOld(size_t requested);
+// they allocate enough space into the corresponding generation and initialize
+// the blockheader with the correct length. The size argument is ignored but
+// exists for uniformity with the standard malloc signature. The caller has to
+// set the appropriate gc bits.
+void *koreAllocInteger(size_t requested);
+void *koreAllocFloating(size_t requested);
+void *koreAllocIntegerOld(size_t requested);
+void *koreAllocFloatingOld(size_t requested);
 
 #ifdef ALLOC_DBG
 #define MEM_LOG(...) fprintf(stderr, __VA_ARGS__)
 #else
 #define MEM_LOG(...)
 #endif
-
 }
 
 #endif // ALLOC_H

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -1,6 +1,9 @@
 #ifndef ARENA_H
 #define ARENA_H
 
+#include <cstddef>
+#include <sys/types.h>
+
 extern "C" {
 
 // An arena can be used to allocate objects that can then be deallocated all at

--- a/include/runtime/arena.h
+++ b/include/runtime/arena.h
@@ -6,10 +6,10 @@ extern "C" {
 // An arena can be used to allocate objects that can then be deallocated all at
 // once.
 struct arena {
-  char* first_block;
-  char* block;
-  char* block_start;
-  char* block_end;
+  char *first_block;
+  char *block;
+  char *block_start;
+  char *block_end;
   char *first_collection_block;
   size_t num_blocks;
   size_t num_collection_blocks;
@@ -17,18 +17,18 @@ struct arena {
 };
 
 typedef struct {
-  char* next_block;
-  char* next_superblock;
+  char *next_block;
+  char *next_superblock;
   char semispace;
 } memory_block_header;
 
 // Macro to define a new arena with the given ID. Supports IDs ranging from 0 to
 // 127.
-#define REGISTER_ARENA(name, id) \
-  static struct arena name = { .allocation_semispace_id = id }
+#define REGISTER_ARENA(name, id)                                               \
+  static struct arena name = {.allocation_semispace_id = id}
 
-#define mem_block_start(ptr) \
-  ((char *)(((uintptr_t)(ptr) - 1) & ~(BLOCK_SIZE-1)))
+#define mem_block_start(ptr)                                                   \
+  ((char *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
 
 // Resets the given arena.
 void arenaReset(struct arena *);
@@ -44,14 +44,14 @@ char getArenaAllocationSemispaceID(const struct arena *);
 char getArenaCollectionSemispaceID(const struct arena *);
 
 // Returns the ID of the semispace where the given address was allocated.
-// The behavior is undefined if called with an address that has not been allocated
-// within an arena.
+// The behavior is undefined if called with an address that has not been
+// allocated within an arena.
 char getArenaSemispaceIDOfObject(void *);
 
 // Allocates the requested number of bytes as a contiguous region and returns a
 // pointer to the first allocated byte.
-// If called with requested size greater than the maximun single allocation size,
-// the space is allocated in a general (not garbage collected pool).
+// If called with requested size greater than the maximun single allocation
+// size, the space is allocated in a general (not garbage collected pool).
 void *arenaAlloc(struct arena *, size_t);
 
 // Resizes the last allocation as long as the resize does not require a new
@@ -65,8 +65,9 @@ void *arenaResizeLastAlloc(struct arena *, ssize_t);
 // It is used before garbage collection.
 void arenaSwapAndClear(struct arena *);
 
-// Clears the current allocation space by setting its start back to its first block.
-// It is used during garbage collection to effectively collect all of the arena.
+// Clears the current allocation space by setting its start back to its first
+// block. It is used during garbage collection to effectively collect all of the
+// arena.
 void arenaClear(struct arena *);
 
 // Returns the address of the first byte that belongs in the given arena.
@@ -89,15 +90,19 @@ char **arenaEndPtr(struct arena *);
 //               starting pointer, or 0 if this is equal to the 3rd argument.
 char *movePtr(char *, size_t, const char *);
 
-// Given two pointers to objects allocated in the same arena, return the number of bytes they are separated by within the virtual block of memory represented by the blocks of that arena. This difference will include blocks containing sentinel bytes. Undefined behavior will result if the pointers belong to different arenas.
+// Given two pointers to objects allocated in the same arena, return the number
+// of bytes they are separated by within the virtual block of memory represented
+// by the blocks of that arena. This difference will include blocks containing
+// sentinel bytes. Undefined behavior will result if the pointers belong to
+// different arenas.
 ssize_t ptrDiff(char *, char *);
 
-// return the total number of allocatable bytes currently in the arena in its active semispace.
+// return the total number of allocatable bytes currently in the arena in its
+// active semispace.
 size_t arenaSize(const struct arena *);
 
 // Deallocates all the memory allocated for registered arenas.
 void freeAllMemory(void);
-
 }
 
 #endif // ARENA_H

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -1,10 +1,10 @@
 #ifndef RUNTIME_COLLECT_H
 #define RUNTIME_COLLECT_H
 
-#include <type_traits>
-#include <iterator>
-#include <vector>
 #include "runtime/header.h"
+#include <iterator>
+#include <type_traits>
+#include <vector>
 
 struct block;
 using block_iterator = std::vector<block **>::iterator;
@@ -16,54 +16,54 @@ typedef std::pair<block_iterator, block_iterator> (*BlockEnumerator)(void);
 // Example usage:
 void registerGCRootsEnumerator(BlockEnumerator);
 
-using list_node = immer::detail::rbts::node<KElem, list::memory_policy, list::bits, list::bits_leaf>;
-using list_impl = immer::detail::rbts::rrbtree<KElem, list::memory_policy, list::bits, list::bits_leaf>;
+using list_node = immer::detail::rbts::node<
+    KElem, list::memory_policy, list::bits, list::bits_leaf>;
+using list_impl = immer::detail::rbts::rrbtree<
+    KElem, list::memory_policy, list::bits, list::bits_leaf>;
 using map_node = map::iterator::node_t;
 using map_impl = map::iterator::tree_t;
 using set_node = set::iterator::node_t;
 using set_impl = set::iterator::tree_t;
 
 extern "C" {
-  extern size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
-  bool during_gc(void);
-  extern bool collect_old;
-  size_t get_size(uint64_t, uint16_t);
-  void migrate_once(block **);
-  void migrate_list(void *l);
-  void migrate_map(void *m);
-  void migrate_set(void *s);
-  void migrate_collection_node(void **nodePtr);
-  void setKoreMemoryFunctionsForGMP(void);
-  void koreCollect(void**, uint8_t, layoutitem *);
+extern size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
+bool during_gc(void);
+extern bool collect_old;
+size_t get_size(uint64_t, uint16_t);
+void migrate_once(block **);
+void migrate_list(void *l);
+void migrate_map(void *m);
+void migrate_set(void *s);
+void migrate_collection_node(void **nodePtr);
+void setKoreMemoryFunctionsForGMP(void);
+void koreCollect(void **, uint8_t, layoutitem *);
 }
 
 #ifdef GC_DBG
-# define initialize_age() \
-  uint64_t age = (hdr & AGE_MASK) >> AGE_OFFSET; \
+#define initialize_age()                                                       \
+  uint64_t age = (hdr & AGE_MASK) >> AGE_OFFSET;                               \
   uint64_t oldAge = age;
-# define increment_age() \
-  if (age < ((1 << AGE_WIDTH) - 1)) age++;
-# define migrate_header(block) \
-  block->h.hdr |= shouldPromote ? NOT_YOUNG_OBJECT_BIT : 0; \
-  block->h.hdr &= ~AGE_MASK; \
+#define increment_age()                                                        \
+  if (age < ((1 << AGE_WIDTH) - 1))                                            \
+    age++;
+#define migrate_header(block)                                                  \
+  block->h.hdr |= shouldPromote ? NOT_YOUNG_OBJECT_BIT : 0;                    \
+  block->h.hdr &= ~AGE_MASK;                                                   \
   block->h.hdr |= age << AGE_OFFSET
 #else
-# define initialize_age() \
-  bool age = hdr & AGE_MASK;
-# define increment_age()
-# define migrate_header(block) \
+#define initialize_age() bool age = hdr & AGE_MASK;
+#define increment_age()
+#define migrate_header(block)                                                  \
   block->h.hdr |= shouldPromote ? NOT_YOUNG_OBJECT_BIT : AGE_MASK
 #endif
 
-#define initialize_migrate() \
-  bool isInYoungGen = is_in_young_gen_hdr(hdr); \
-  initialize_age() \
-  bool isInOldGen = is_in_old_gen_hdr(hdr); \
-  if (!(isInYoungGen || (isInOldGen && collect_old))) { \
-    return; \
-  } \
-  bool shouldPromote = isInYoungGen && age; \
-  increment_age() \
-  bool hasForwardingAddress = hdr & FWD_PTR_BIT
+#define initialize_migrate()                                                   \
+  bool isInYoungGen = is_in_young_gen_hdr(hdr);                                \
+  initialize_age() bool isInOldGen = is_in_old_gen_hdr(hdr);                   \
+  if (!(isInYoungGen || (isInOldGen && collect_old))) {                        \
+    return;                                                                    \
+  }                                                                            \
+  bool shouldPromote = isInYoungGen && age;                                    \
+  increment_age() bool hasForwardingAddress = hdr & FWD_PTR_BIT
 
 #endif // RUNTIME_COLLECT_H

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -1,8 +1,8 @@
 #ifndef RUNTIME_HEADER_H
 #define RUNTIME_HEADER_H
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 
 #include <gmp.h>
@@ -21,112 +21,107 @@
 // the actual length is equal to the block header with the gc bits masked out.
 
 #define len(s) len_hdr((s)->h.hdr)
-#define len_hdr(s) ((s) & LENGTH_MASK)
-#define set_len(s, l) ((s)->h.hdr = (l) | (l > BLOCK_SIZE - sizeof(char *) ? NOT_YOUNG_OBJECT_BIT : 0))
+#define len_hdr(s) ((s)&LENGTH_MASK)
+#define set_len(s, l)                                                          \
+  ((s)->h.hdr                                                                  \
+   = (l) | (l > BLOCK_SIZE - sizeof(char *) ? NOT_YOUNG_OBJECT_BIT : 0))
 #define size_hdr(s) ((((s) >> 32) & 0xff) * 8)
 #define layout(s) layout_hdr((s)->h.hdr)
 #define layout_hdr(s) ((s) >> LAYOUT_OFFSET)
 #define tag_hdr(s) (s & TAG_MASK)
-#define is_in_young_gen_hdr(s) (!((s) & NOT_YOUNG_OBJECT_BIT))
-#define is_in_old_gen_hdr(s) \
-        (((s) & NOT_YOUNG_OBJECT_BIT) && ((s) & AGE_MASK))
-#define reset_gc(s) ((s)->h.hdr = (s)->h.hdr & ~(NOT_YOUNG_OBJECT_BIT | AGE_MASK | FWD_PTR_BIT))
-#define struct_base(struct_type, member_name, member_addr) \
-        ((struct_type *)((char *)(member_addr) - offsetof(struct_type, member_name)))
+#define is_in_young_gen_hdr(s) (!((s)&NOT_YOUNG_OBJECT_BIT))
+#define is_in_old_gen_hdr(s) (((s)&NOT_YOUNG_OBJECT_BIT) && ((s)&AGE_MASK))
+#define reset_gc(s)                                                            \
+  ((s)->h.hdr = (s)->h.hdr & ~(NOT_YOUNG_OBJECT_BIT | AGE_MASK | FWD_PTR_BIT))
+#define struct_base(struct_type, member_name, member_addr)                     \
+  ((struct_type *)((char *)(member_addr)-offsetof(struct_type, member_name)))
 #define leaf_block(tag) ((block *)((((uint64_t)(tag)) << 32) | 1))
 #define variable_block(tag) ((block *)((((uint64_t)(tag)) << 32) | 3))
 #define is_leaf_block(block) (((uintptr_t)block) & 1)
 #define is_variable_block(block) ((((uintptr_t)block) & 3) == 3)
 
 extern "C" {
-  // llvm: blockheader = type { i64 } 
-  typedef struct blockheader {
-    uint64_t hdr;
-  } blockheader;
+// llvm: blockheader = type { i64 }
+typedef struct blockheader {
+  uint64_t hdr;
+} blockheader;
 
-  // A value b of type block* is either a constant or a block.
-  // if (((uintptr_t)b) & 3) == 3, then it is a bound variable and
-  // ((uintptr_t)b) >> 32 is the debruijn index. If ((uintptr_t)b) & 3 == 1)
-  // then it is a symbol with 0 arguments and ((uintptr_t)b) >> 32 is the tag
-  // of the symbol. Otherwise, if ((uintptr_t)b) & 1 == 0 then it is a pointer to
-  // a block.
-  // llvm: block = type { %blockheader, [0 x i64 *] }
-  typedef struct block {
-    blockheader h;
-    uint64_t *children[];
-  } block;
+// A value b of type block* is either a constant or a block.
+// if (((uintptr_t)b) & 3) == 3, then it is a bound variable and
+// ((uintptr_t)b) >> 32 is the debruijn index. If ((uintptr_t)b) & 3 == 1)
+// then it is a symbol with 0 arguments and ((uintptr_t)b) >> 32 is the tag
+// of the symbol. Otherwise, if ((uintptr_t)b) & 1 == 0 then it is a pointer to
+// a block.
+// llvm: block = type { %blockheader, [0 x i64 *] }
+typedef struct block {
+  blockheader h;
+  uint64_t *children[];
+} block;
 
-  
-  // llvm: string = type { %blockheader, [0 x i8] }
-  typedef struct string {
-    blockheader h;
-    char data[];
-  } string;
-  
-  // llvm: stringbuffer = type { i64, i64, %string* }
-  typedef struct stringbuffer {
-    blockheader h;
-    uint64_t strlen;
-    string *contents;
-  } stringbuffer;
+// llvm: string = type { %blockheader, [0 x i8] }
+typedef struct string {
+  blockheader h;
+  char data[];
+} string;
 
-  typedef struct mpz_hdr {
-    blockheader h;
-    mpz_t i;
-  } mpz_hdr;
+// llvm: stringbuffer = type { i64, i64, %string* }
+typedef struct stringbuffer {
+  blockheader h;
+  uint64_t strlen;
+  string *contents;
+} stringbuffer;
 
-  typedef struct floating {
-    uint64_t exp; // number of bits in exponent range
-    mpfr_t f;
-  } floating;
+typedef struct mpz_hdr {
+  blockheader h;
+  mpz_t i;
+} mpz_hdr;
 
-  typedef struct floating_hdr {
-    blockheader h;
-    floating f;
-  } floating_hdr;
+typedef struct floating {
+  uint64_t exp; // number of bits in exponent range
+  mpfr_t f;
+} floating;
 
-  typedef struct layoutitem {
-    uint64_t offset;
-    uint16_t cat;
-  } layoutitem;
+typedef struct floating_hdr {
+  blockheader h;
+  floating f;
+} floating_hdr;
 
-  typedef struct layout {
-    uint8_t nargs;
-    layoutitem *args;
-  } layout;
+typedef struct layoutitem {
+  uint64_t offset;
+  uint16_t cat;
+} layoutitem;
 
-  typedef struct {
-    FILE *file;
-    stringbuffer *buffer;
-  } writer;
+typedef struct layout {
+  uint8_t nargs;
+  layoutitem *args;
+} layout;
 
-  bool hook_KEQUAL_eq(block *, block *);
-  bool during_gc(void);
-  size_t hash_k(block *);
-  void k_hash(block *, void *);
-  bool hash_enter(void);
-  void hash_exit(void);
+typedef struct {
+  FILE *file;
+  stringbuffer *buffer;
+} writer;
+
+bool hook_KEQUAL_eq(block *, block *);
+bool during_gc(void);
+size_t hash_k(block *);
+void k_hash(block *, void *);
+bool hash_enter(void);
+void hash_exit(void);
 }
 
 class KElem {
 public:
-  KElem(block * elem) {
-    this->elem = elem;
-  }
+  KElem(block *elem) { this->elem = elem; }
 
-  bool operator==(const KElem& other) const {
+  bool operator==(const KElem &other) const {
     return hook_KEQUAL_eq(this->elem, other.elem);
   }
 
-  bool operator!=(const KElem& other) const {
-    return !(*this == other);
-  }
+  bool operator!=(const KElem &other) const { return !(*this == other); }
 
-  operator block*() const {
-    return elem;
-  }
+  operator block *() const { return elem; }
 
-  block * elem;
+  block *elem;
 };
 
 struct kore_alloc_heap {
@@ -150,20 +145,22 @@ struct kore_alloc_heap {
 };
 
 struct HashBlock {
-  size_t operator()(const KElem &block) const noexcept {
-    return hash_k(block);
-  }
+  size_t operator()(const KElem &block) const noexcept { return hash_k(block); }
 };
- 
+
 struct KEq {
-  bool operator() (block * const& lhs, block * const& rhs) const {
+  bool operator()(block *const &lhs, block *const &rhs) const {
     return hook_KEQUAL_eq(lhs, rhs);
   }
 };
 
-using list = immer::flex_vector<KElem, immer::memory_policy<immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy>>;
-using map = immer::map<KElem, KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
-using set = immer::set<KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
+using list = immer::flex_vector<
+    KElem, immer::memory_policy<
+               immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy>>;
+using map = immer::map<
+    KElem, KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
+using set
+    = immer::set<KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
 
 typedef struct mapiter {
   map::iterator curr;
@@ -193,70 +190,71 @@ typedef list *SortList;
 typedef map *SortMap;
 typedef set *SortSet;
 
-
 extern "C" {
 
-  block *parseConfiguration(const char *filename);
-  void printConfiguration(const char *filename, block *subject);
-  void printStatistics(const char *filename, uint64_t steps);
-  string *printConfigurationToString(block *subject);
-  void printConfigurationToFile(FILE *, block *subject);
-  void printConfigurationInternal(writer *file, block *subject, const char *sort, bool);
-  mpz_ptr move_int(mpz_t);
+block *parseConfiguration(const char *filename);
+void printConfiguration(const char *filename, block *subject);
+void printStatistics(const char *filename, uint64_t steps);
+string *printConfigurationToString(block *subject);
+void printConfigurationToFile(FILE *, block *subject);
+void printConfigurationInternal(
+    writer *file, block *subject, const char *sort, bool);
+mpz_ptr move_int(mpz_t);
 
-  // The following functions have to be generated at kompile time
-  // and linked with the interpreter.
-  uint32_t getTagForSymbolName(const char *symbolname);
-  struct blockheader getBlockHeaderForSymbol(uint32_t tag);
-  bool isSymbolAFunction(uint32_t tag);
-  bool isSymbolABinder(uint32_t tag);
-  void storeSymbolChildren(block *symbol, void *children[]);
-  void *evaluateFunctionSymbol(uint32_t tag, void *arguments[]);
-  void *getToken(const char *sortname, uint64_t len, const char *tokencontents);
-  layout *getLayoutData(uint16_t);
-  uint32_t getInjectionForSortOfTag(uint32_t tag);
+// The following functions have to be generated at kompile time
+// and linked with the interpreter.
+uint32_t getTagForSymbolName(const char *symbolname);
+struct blockheader getBlockHeaderForSymbol(uint32_t tag);
+bool isSymbolAFunction(uint32_t tag);
+bool isSymbolABinder(uint32_t tag);
+void storeSymbolChildren(block *symbol, void *children[]);
+void *evaluateFunctionSymbol(uint32_t tag, void *arguments[]);
+void *getToken(const char *sortname, uint64_t len, const char *tokencontents);
+layout *getLayoutData(uint16_t);
+uint32_t getInjectionForSortOfTag(uint32_t tag);
 
-  bool hook_STRING_eq(SortString, SortString);
+bool hook_STRING_eq(SortString, SortString);
 
-  const char *getSymbolNameForTag(uint32_t tag);
-  const char *topSort(void);
-  void printMap(writer *, map *, const char *, const char *, const char *);
-  void printSet(writer *, set *, const char *, const char *, const char *);
-  void printList(writer *, list *, const char *, const char *, const char *);
-  void visitChildren(block *subject, writer *file,
-      void visitConfig(writer *, block *, const char *, bool), 
-      void visitMap(writer *, map *, const char *, const char *, const char *), 
-      void visitList(writer *, list *, const char *, const char *, const char *), 
-      void visitSet(writer *, set *, const char *, const char *, const char *), 
-      void visitInt(writer *, mpz_t, const char *),
-      void visitFloat(writer *, floating *, const char *),
-      void visitBool(writer *, bool, const char *),
-      void visitStringBuffer(writer *, stringbuffer *, const char *),
-      void visitMInt(writer *, size_t *, size_t, const char *),
-      void visitSeparator(writer *));
+const char *getSymbolNameForTag(uint32_t tag);
+const char *topSort(void);
+void printMap(writer *, map *, const char *, const char *, const char *);
+void printSet(writer *, set *, const char *, const char *, const char *);
+void printList(writer *, list *, const char *, const char *, const char *);
+void visitChildren(
+    block *subject, writer *file,
+    void visitConfig(writer *, block *, const char *, bool),
+    void visitMap(writer *, map *, const char *, const char *, const char *),
+    void visitList(writer *, list *, const char *, const char *, const char *),
+    void visitSet(writer *, set *, const char *, const char *, const char *),
+    void visitInt(writer *, mpz_t, const char *),
+    void visitFloat(writer *, floating *, const char *),
+    void visitBool(writer *, bool, const char *),
+    void visitStringBuffer(writer *, stringbuffer *, const char *),
+    void visitMInt(writer *, size_t *, size_t, const char *),
+    void visitSeparator(writer *));
 
-  void sfprintf(writer *, const char *, ...);
+void sfprintf(writer *, const char *, ...);
 
-  stringbuffer *hook_BUFFER_empty(void);
-  stringbuffer *hook_BUFFER_concat(stringbuffer *buf, string *s);
-  stringbuffer *hook_BUFFER_concat_raw(stringbuffer *buf, char const *data, uint64_t n);
-  string *hook_BUFFER_toString(stringbuffer *buf);
+stringbuffer *hook_BUFFER_empty(void);
+stringbuffer *hook_BUFFER_concat(stringbuffer *buf, string *s);
+stringbuffer *
+hook_BUFFER_concat_raw(stringbuffer *buf, char const *data, uint64_t n);
+string *hook_BUFFER_toString(stringbuffer *buf);
 
-  size_t hook_SET_size_long(set *);
+size_t hook_SET_size_long(set *);
 
-  mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned);
+mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned);
 
-  block *debruijnize(block *);
-  block *incrementDebruijn(block *);
-  block *alphaRename(block *);
+block *debruijnize(block *);
+block *incrementDebruijn(block *);
+block *alphaRename(block *);
 
-  setiter set_iterator(set *);
-  block *set_iterator_next(setiter *);
-  mapiter map_iterator(map *);
-  block *map_iterator_next(mapiter *);
+setiter set_iterator(set *);
+block *set_iterator_next(setiter *);
+mapiter map_iterator(map *);
+block *map_iterator_next(mapiter *);
 
-  extern const uint32_t first_inj_tag, last_inj_tag;
-
+extern const uint32_t first_inj_tag, last_inj_tag;
 }
 
 std::string floatToString(const floating *);

--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -1,9 +1,9 @@
 #include "kllvm/ast/AST.h"
 
-#include <unordered_set>
-#include <unordered_map>
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+#include <unordered_map>
+#include <unordered_set>
 
 using namespace kllvm;
 
@@ -49,14 +49,14 @@ std::string kllvm::decodeKore(std::string kore) {
   bool literal = true;
   std::string result;
   size_t i = 0;
-  while(i < kore.length()) {
+  while (i < kore.length()) {
     if (kore[i] == '\'') {
       literal = !literal;
       i++;
     } else if (literal) {
       result.push_back(kore[i]);
       i++;
-    } else {  
+    } else {
       auto code = kore.substr(i, 4);
       result.push_back(codes[code]);
       i += 4;
@@ -86,7 +86,8 @@ bool KORECompositeSort::operator==(const KORESort &other) const {
       return false;
     }
     for (int i = 0; i < arguments.size(); ++i) {
-      if (*sort->arguments[i] != *arguments[i]) return false;
+      if (*sort->arguments[i] != *arguments[i])
+        return false;
     }
     return true;
   }
@@ -117,10 +118,13 @@ ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
   std::string name = getHook(definition);
   if (name == "MINT.MInt") {
     if (auto param = dynamic_cast<KORECompositeSort *>(arguments[0].get())) {
-      auto &att = definition->getSortDeclarations().at(param->getName())->getAttributes();
+      auto &att = definition->getSortDeclarations()
+                      .at(param->getName())
+                      ->getAttributes();
       auto &natAtt = att.at("nat");
       assert(natAtt->getArguments().size() == 1);
-      auto strPattern = dynamic_cast<KOREStringPattern *>(natAtt->getArguments()[0].get());
+      auto strPattern
+          = dynamic_cast<KOREStringPattern *>(natAtt->getArguments()[0].get());
       name = name + " " + strPattern->getContents();
     } else {
       print(std::cerr);
@@ -132,34 +136,46 @@ ValueType KORECompositeSort::getCategory(KOREDefinition *definition) {
 }
 
 std::string KORECompositeSort::getHook(KOREDefinition *definition) {
-  auto &att = definition->getSortDeclarations().at(this->getName())->getAttributes();
+  auto &att
+      = definition->getSortDeclarations().at(this->getName())->getAttributes();
   if (!att.count("hook")) {
     return "STRING.String";
   }
   auto &hookAtt = att.at("hook");
   assert(hookAtt->getArguments().size() == 1);
-  auto strPattern = dynamic_cast<KOREStringPattern *>(hookAtt->getArguments()[0].get());
+  auto strPattern
+      = dynamic_cast<KOREStringPattern *>(hookAtt->getArguments()[0].get());
   return strPattern->getContents();
 }
 
 ValueType KORECompositeSort::getCategory(std::string name) {
   SortCategory category;
   uint64_t bits = 0;
-  if (name == "MAP.Map") category = SortCategory::Map;
-  else if (name == "LIST.List") category = SortCategory::List;
-  else if (name == "SET.Set") category = SortCategory::Set;
-  else if (name == "ARRAY.Array") category = SortCategory::Symbol; // ARRAY is implemented in K
-  else if (name == "INT.Int") category = SortCategory::Int;
-  else if (name == "FLOAT.Float") category = SortCategory::Float;
-  else if (name == "BUFFER.StringBuffer") category = SortCategory::StringBuffer;
-  else if (name == "BOOL.Bool") category = SortCategory::Bool;
-  else if (name == "KVAR.KVar") category = SortCategory::Variable;
-  // we expect the "hook" of a MInt to be of the form "MINT.MInt N" for some bitwidth N
+  if (name == "MAP.Map")
+    category = SortCategory::Map;
+  else if (name == "LIST.List")
+    category = SortCategory::List;
+  else if (name == "SET.Set")
+    category = SortCategory::Set;
+  else if (name == "ARRAY.Array")
+    category = SortCategory::Symbol; // ARRAY is implemented in K
+  else if (name == "INT.Int")
+    category = SortCategory::Int;
+  else if (name == "FLOAT.Float")
+    category = SortCategory::Float;
+  else if (name == "BUFFER.StringBuffer")
+    category = SortCategory::StringBuffer;
+  else if (name == "BOOL.Bool")
+    category = SortCategory::Bool;
+  else if (name == "KVAR.KVar")
+    category = SortCategory::Variable;
+  // we expect the "hook" of a MInt to be of the form "MINT.MInt N" for some
+  // bitwidth N
   else if (name.substr(0, 10) == "MINT.MInt ") {
     category = SortCategory::MInt;
     bits = std::stoi(name.substr(10));
-  }
-  else category = SortCategory::Symbol;
+  } else
+    category = SortCategory::Symbol;
   return {category, bits};
 }
 
@@ -180,7 +196,8 @@ bool KORESymbol::operator==(const KORESymbol &other) const {
     return false;
   }
   for (int i = 0; i < arguments.size(); ++i) {
-    if (*arguments[i] != *other.arguments[i]) return false;
+    if (*arguments[i] != *other.arguments[i])
+      return false;
   }
   return true;
 }
@@ -190,38 +207,19 @@ std::string KORESymbol::layoutString(KOREDefinition *definition) const {
   for (auto arg : arguments) {
     auto sort = dynamic_cast<KORECompositeSort *>(arg.get());
     ValueType cat = sort->getCategory(definition);
-    switch(cat.cat) {
-    case SortCategory::Map:
-      result.push_back('1');
-      break;
-    case SortCategory::List:
-      result.push_back('2');
-      break;
-    case SortCategory::Set:
-      result.push_back('3');
-      break;
-    case SortCategory::Int:
-      result.push_back('4');
-      break;
-    case SortCategory::Float:
-      result.push_back('5');
-      break;
-    case SortCategory::StringBuffer:
-      result.push_back('6');
-      break;
-    case SortCategory::Bool:
-      result.push_back('7');
-      break;
-    case SortCategory::Variable:
-      result.push_back('8');
-      break;
+    switch (cat.cat) {
+    case SortCategory::Map: result.push_back('1'); break;
+    case SortCategory::List: result.push_back('2'); break;
+    case SortCategory::Set: result.push_back('3'); break;
+    case SortCategory::Int: result.push_back('4'); break;
+    case SortCategory::Float: result.push_back('5'); break;
+    case SortCategory::StringBuffer: result.push_back('6'); break;
+    case SortCategory::Bool: result.push_back('7'); break;
+    case SortCategory::Variable: result.push_back('8'); break;
     case SortCategory::MInt:
       result.append("_" + std::to_string(cat.bits) + "_");
-    case SortCategory::Symbol:
-      result.push_back('0');
-      break;
-    case SortCategory::Uncomputed:
-      abort();
+    case SortCategory::Symbol: result.push_back('0'); break;
+    case SortCategory::Uncomputed: abort();
     }
   }
   return result;
@@ -255,9 +253,9 @@ bool KORESymbol::isPolymorphic() const {
 }
 
 static std::unordered_set<std::string> BUILTINS{
-  "\\and", "\\not", "\\or", "\\implies", "\\iff", "\\forall", "\\exists",
-  "\\ceil", "\\floor", "\\equals", "\\in", "\\top", "\\bottom", "\\dv",
-  "\\rewrites", "\\next", "\\mu", "\\nu"};
+    "\\and",    "\\not",  "\\or",       "\\implies", "\\iff", "\\forall",
+    "\\exists", "\\ceil", "\\floor",    "\\equals",  "\\in",  "\\top",
+    "\\bottom", "\\dv",   "\\rewrites", "\\next",    "\\mu",  "\\nu"};
 
 bool KORESymbol::isBuiltin() const {
   return BUILTINS.count(name);
@@ -291,7 +289,8 @@ void KORECompositePattern::addArgument(sptr<KOREPattern> Argument) {
   arguments.push_back(Argument);
 }
 
-void KORECompositePattern::markSymbols(std::map<std::string, std::vector<KORESymbol *>> &map) {
+void KORECompositePattern::markSymbols(
+    std::map<std::string, std::vector<KORESymbol *>> &map) {
   if (!constructor->isBuiltin()) {
     if (!map.count(constructor->getName())) {
       map.emplace(constructor->getName(), std::vector<KORESymbol *>{});
@@ -303,7 +302,8 @@ void KORECompositePattern::markSymbols(std::map<std::string, std::vector<KORESym
   }
 }
 
-void KORECompositePattern::markVariables(std::map<std::string, KOREVariablePattern *> &map) {
+void KORECompositePattern::markVariables(
+    std::map<std::string, KOREVariablePattern *> &map) {
   for (auto &arg : arguments) {
     arg->markVariables(map);
   }
@@ -318,7 +318,8 @@ sptr<KOREPattern> KORECompositePattern::substitute(const substitution &subst) {
   if (name == "\\forall" || name == "\\exists") {
     ptr->addArgument(arguments[0]);
     auto newSubst = subst;
-    newSubst.erase(dynamic_cast<KOREVariablePattern *>(arguments[0].get())->getName());
+    newSubst.erase(
+        dynamic_cast<KOREVariablePattern *>(arguments[0].get())->getName());
     ptr->addArgument(arguments[1]->substitute(newSubst));
     return ptr;
   }
@@ -373,7 +374,8 @@ static void append(std::ostream &out, std::string str) {
   out << str;
 }
 
-static void color(std::ostream &out, std::string color, PrettyPrintData const& data) {
+static void
+color(std::ostream &out, std::string color, PrettyPrintData const &data) {
   if (data.hasColor) {
     static bool once = true;
     static std::map<std::string, std::string> colors;
@@ -589,25 +591,13 @@ std::string enquote(std::string str) {
   result.push_back('"');
   for (size_t i = 0; i < str.length(); ++i) {
     char c = str[i];
-    switch(c) {
-    case '\\':
-      result.append("\\\\");
-      break;
-    case '"':
-      result.append("\\\"");
-      break;
-    case '\n':
-      result.append("\\n");
-      break;
-    case '\t':
-      result.append("\\t");
-      break;
-    case '\r':
-      result.append("\\r");
-      break;
-    case '\f':
-      result.append("\\f");
-      break;
+    switch (c) {
+    case '\\': result.append("\\\\"); break;
+    case '"': result.append("\\\""); break;
+    case '\n': result.append("\\n"); break;
+    case '\t': result.append("\\t"); break;
+    case '\r': result.append("\\r"); break;
+    case '\f': result.append("\\f"); break;
     default:
       if ((unsigned char)c >= 32 && (unsigned char)c < 127) {
         result.push_back(c);
@@ -643,16 +633,19 @@ void KORECompositeSort::prettyPrint(std::ostream &out) const {
   }
 }
 
-void KOREVariablePattern::prettyPrint(std::ostream &out, PrettyPrintData const& data) const {
+void KOREVariablePattern::prettyPrint(
+    std::ostream &out, PrettyPrintData const &data) const {
   append(out, decodeKore(getName().substr(3)));
   append(out, ':');
   sort->prettyPrint(out);
 }
 
-void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const& data) const {
+void KORECompositePattern::prettyPrint(
+    std::ostream &out, PrettyPrintData const &data) const {
   std::string name = getConstructor()->getName();
   if (name == "\\dv") {
-    KORECompositeSort *s = dynamic_cast<KORECompositeSort *>(getConstructor()->getFormalArguments()[0].get()); 
+    KORECompositeSort *s = dynamic_cast<KORECompositeSort *>(
+        getConstructor()->getFormalArguments()[0].get());
     bool hasHook = data.hook.count(s->getName());
     auto str = dynamic_cast<KOREStringPattern *>(arguments[0].get());
     if (hasHook) {
@@ -680,75 +673,75 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
         if (i == format.length() - 1) {
           abort();
         }
-        char c2 = format[i+1];
+        char c2 = format[i + 1];
         ++i;
-        switch(c2) {
-          case 'n':
-            newline(out);
-            break;
-          case 'i':
-            indent++;
-            localIndent++;
-            break;
-          case 'd':
-            indent--;
-            localIndent--;
-            break;
-          case 'c':
-            if (data.colors.count(name)) {
-              if (localColor >= data.colors.at(name).size() ) {
-                abort();
-              }
-              color(out, data.colors.at(name)[localColor++], data);
-            }
-            break;
-          case 'r':
-            if (data.hasColor) {
-              append(out, RESET_COLOR);
-            }
-            break;
-          case '0':
-          case '1':
-          case '2':
-          case '3':
-          case '4':
-          case '5':
-          case '6':
-          case '7':
-          case '8':
-          case '9': {
-            std::string buf;
-            for(; i < format.length() && format[i] >= '0' && format[i] <= '9'; i++) {
-              buf.push_back(format[i]);
-            }
-            i--;
-            int idx = std::stoi(buf);
-            if (idx == 0 || idx > arguments.size()) {
+        switch (c2) {
+        case 'n': newline(out); break;
+        case 'i':
+          indent++;
+          localIndent++;
+          break;
+        case 'd':
+          indent--;
+          localIndent--;
+          break;
+        case 'c':
+          if (data.colors.count(name)) {
+            if (localColor >= data.colors.at(name).size()) {
               abort();
             }
-            KOREPattern *inner = arguments[idx-1].get();
-            bool assoc = false;
-            if (auto app = dynamic_cast<KORECompositePattern *>(inner)) {
-              if (app->getConstructor()->getName() == constructor->getName() && data.assoc.count(name)) {
-                assoc = true;
-              }
-              if (assoc) {
-                for (int j = 0; j < localIndent; j++) {
-                  indent--;
-                }
-              }
-              inner->prettyPrint(out, data);
-              if (assoc) {
-                for (int j = 0; j < localIndent; j++) {
-                  indent++;
-                }
-              }
-            } else {
-              inner->prettyPrint(out, data);
+            color(out, data.colors.at(name)[localColor++], data);
+          }
+          break;
+        case 'r':
+          if (data.hasColor) {
+            append(out, RESET_COLOR);
+          }
+          break;
+        case '0':
+        case '1':
+        case '2':
+        case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
+        case '8':
+        case '9': {
+          std::string buf;
+          for (; i < format.length() && format[i] >= '0' && format[i] <= '9';
+               i++) {
+            buf.push_back(format[i]);
+          }
+          i--;
+          int idx = std::stoi(buf);
+          if (idx == 0 || idx > arguments.size()) {
+            abort();
+          }
+          KOREPattern *inner = arguments[idx - 1].get();
+          bool assoc = false;
+          if (auto app = dynamic_cast<KORECompositePattern *>(inner)) {
+            if (app->getConstructor()->getName() == constructor->getName()
+                && data.assoc.count(name)) {
+              assoc = true;
             }
-            break;
-          } default:
-            append(out, c2);
+            if (assoc) {
+              for (int j = 0; j < localIndent; j++) {
+                indent--;
+              }
+            }
+            inner->prettyPrint(out, data);
+            if (assoc) {
+              for (int j = 0; j < localIndent; j++) {
+                indent++;
+              }
+            }
+          } else {
+            inner->prettyPrint(out, data);
+          }
+          break;
+        }
+        default: append(out, c2);
         }
       } else {
         append(out, c);
@@ -760,9 +753,7 @@ void KORECompositePattern::prettyPrint(std::ostream &out, PrettyPrintData const&
 }
 
 struct CompareFirst {
-  bool isDigit(char c) {
-    return c >= '0' && c <= '9';
-  }
+  bool isDigit(char c) { return c >= '0' && c <= '9'; }
 
   std::string getChunk(std::string s, size_t slength, size_t marker) {
     std::string chunk;
@@ -827,7 +818,9 @@ struct CompareFirst {
   }
 };
 
-static void flatten(KORECompositePattern *pat, std::string name, std::vector<sptr<KOREPattern>> &result) {
+static void flatten(
+    KORECompositePattern *pat, std::string name,
+    std::vector<sptr<KOREPattern>> &result) {
   for (auto &arg : pat->getArguments()) {
     if (auto pat2 = dynamic_cast<KORECompositePattern *>(arg.get())) {
       if (pat2->getConstructor()->getName() == name) {
@@ -841,7 +834,8 @@ static void flatten(KORECompositePattern *pat, std::string name, std::vector<spt
   }
 }
 
-sptr<KOREPattern> KORECompositePattern::sortCollections(PrettyPrintData const& data) {
+sptr<KOREPattern>
+KORECompositePattern::sortCollections(PrettyPrintData const &data) {
   if (arguments.empty()) {
     return shared_from_this();
   }
@@ -870,14 +864,16 @@ sptr<KOREPattern> KORECompositePattern::sortCollections(PrettyPrintData const& d
     }
     sptr<KOREPattern> result = items[0];
     for (int i = 1; i < items.size(); ++i) {
-      sptr<KORECompositePattern> tmp = KORECompositePattern::Create(constructor.get());
+      sptr<KORECompositePattern> tmp
+          = KORECompositePattern::Create(constructor.get());
       tmp->addArgument(result);
       tmp->addArgument(items[i]);
       result = tmp;
     }
     return result;
   }
-  sptr<KORECompositePattern> result = KORECompositePattern::Create(constructor.get());
+  sptr<KORECompositePattern> result
+      = KORECompositePattern::Create(constructor.get());
   for (auto &arg : arguments) {
     result->addArgument(arg->sortCollections(data));
   }
@@ -885,7 +881,7 @@ sptr<KOREPattern> KORECompositePattern::sortCollections(PrettyPrintData const& d
 }
 
 std::set<std::string> KOREPattern::gatherSingletonVars(void) {
-  auto counts = gatherVarCounts(); 
+  auto counts = gatherVarCounts();
   std::set<std::string> result;
   for (auto entry : counts) {
     if (entry.second == 1) {
@@ -906,7 +902,8 @@ std::map<std::string, int> KORECompositePattern::gatherVarCounts(void) {
   return result;
 }
 
-sptr<KOREPattern> KORECompositePattern::filterSubstitution(PrettyPrintData const& data, std::set<std::string> const& vars) {
+sptr<KOREPattern> KORECompositePattern::filterSubstitution(
+    PrettyPrintData const &data, std::set<std::string> const &vars) {
   if (constructor->getName() == "\\equals") {
     if (auto var = dynamic_cast<KOREVariablePattern *>(arguments[0].get())) {
       std::ostringstream ss;
@@ -918,9 +915,14 @@ sptr<KOREPattern> KORECompositePattern::filterSubstitution(PrettyPrintData const
       indent = oldIndent;
       atNewLine = oldAtNewLine;
       std::string name = ss.str();
-      if (vars.count(var->getName()) && (name[0] == '_' || (name.size() > 1 && (name[0] == '@' || name[0] == '!' || name[0] == '?') && name[1] == '_'))) {
+      if (vars.count(var->getName())
+          && (name[0] == '_'
+              || (name.size() > 1
+                  && (name[0] == '@' || name[0] == '!' || name[0] == '?')
+                  && name[1] == '_'))) {
         sptr<KORECompositePattern> unit = KORECompositePattern::Create("\\top");
-        unit->getConstructor()->addFormalArgument(constructor->getFormalArguments()[1]);
+        unit->getConstructor()->addFormalArgument(
+            constructor->getFormalArguments()[1]);
         return unit;
       } else {
         return shared_from_this();
@@ -928,8 +930,10 @@ sptr<KOREPattern> KORECompositePattern::filterSubstitution(PrettyPrintData const
     } else {
       return shared_from_this();
     }
-  } else if (constructor->getName() == "\\and" || constructor->getName() == "\\or") {
-    sptr<KORECompositePattern> result = KORECompositePattern::Create(constructor.get());
+  } else if (
+      constructor->getName() == "\\and" || constructor->getName() == "\\or") {
+    sptr<KORECompositePattern> result
+        = KORECompositePattern::Create(constructor.get());
     for (auto &arg : arguments) {
       if (constructor->getName() == "\\or") {
         std::set<std::string> vars = arg->gatherSingletonVars();
@@ -939,12 +943,14 @@ sptr<KOREPattern> KORECompositePattern::filterSubstitution(PrettyPrintData const
       }
     }
     if (constructor->getName() == "\\and") {
-     if (auto composite = dynamic_cast<KORECompositePattern *>(result->getArguments()[0].get())) {
+      if (auto composite = dynamic_cast<KORECompositePattern *>(
+              result->getArguments()[0].get())) {
         if (composite->getConstructor()->getName() == "\\top") {
           return result->getArguments()[1];
         }
       }
-      if (auto composite = dynamic_cast<KORECompositePattern *>(result->getArguments()[1].get())) {
+      if (auto composite = dynamic_cast<KORECompositePattern *>(
+              result->getArguments()[1].get())) {
         if (composite->getConstructor()->getName() == "\\top") {
           return result->getArguments()[0];
         }
@@ -955,28 +961,40 @@ sptr<KOREPattern> KORECompositePattern::filterSubstitution(PrettyPrintData const
   return shared_from_this();
 }
 
-sptr<KOREPattern> KORECompositePattern::expandMacros(SubsortMap const& subsorts, SymbolMap const& overloads, std::vector<ptr<KOREDeclaration>> const& macros, bool reverse, std::set<size_t> &appliedRules) {
-  sptr<KORECompositePattern> applied = KORECompositePattern::Create(constructor.get());
+sptr<KOREPattern> KORECompositePattern::expandMacros(
+    SubsortMap const &subsorts, SymbolMap const &overloads,
+    std::vector<ptr<KOREDeclaration>> const &macros, bool reverse,
+    std::set<size_t> &appliedRules) {
+  sptr<KORECompositePattern> applied
+      = KORECompositePattern::Create(constructor.get());
   for (auto &arg : arguments) {
-    applied->addArgument(arg->expandMacros(subsorts, overloads, macros, reverse));
+    applied->addArgument(
+        arg->expandMacros(subsorts, overloads, macros, reverse));
   }
 
   size_t i = 0;
   for (auto &decl : macros) {
-    if ((decl->getAttributes().count("macro") || decl->getAttributes().count("macro-rec")) && reverse) {
+    if ((decl->getAttributes().count("macro")
+         || decl->getAttributes().count("macro-rec"))
+        && reverse) {
       i++;
       continue;
     }
     auto axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get());
-    auto equals = dynamic_cast<KORECompositePattern *>(axiom->getPattern().get());
+    auto equals
+        = dynamic_cast<KORECompositePattern *>(axiom->getPattern().get());
     auto lhs = equals->arguments[reverse ? 1 : 0];
     auto rhs = equals->arguments[reverse ? 0 : 1];
     substitution subst;
     bool matches = lhs->matches(subst, subsorts, overloads, applied);
-    if (matches && (decl->getAttributes().count("macro-rec") || decl->getAttributes().count("alias-rec") || !appliedRules.count(i))) {
+    if (matches
+        && (decl->getAttributes().count("macro-rec")
+            || decl->getAttributes().count("alias-rec")
+            || !appliedRules.count(i))) {
       std::set<size_t> oldAppliedRules = appliedRules;
       appliedRules.insert(i);
-      auto result = rhs->substitute(subst)->expandMacros(subsorts, overloads, macros, reverse, appliedRules);
+      auto result = rhs->substitute(subst)->expandMacros(
+          subsorts, overloads, macros, reverse, appliedRules);
       appliedRules = oldAppliedRules;
       return result;
     }
@@ -985,7 +1003,9 @@ sptr<KOREPattern> KORECompositePattern::expandMacros(SubsortMap const& subsorts,
   return applied;
 }
 
-bool KOREVariablePattern::matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) {
+bool KOREVariablePattern::matches(
+    substitution &subst, SubsortMap const &subsorts, SymbolMap const &overloads,
+    sptr<KOREPattern> subject) {
   if (subst[name->getName()]) {
     std::ostringstream Out1, Out2;
     subst[name->getName()]->print(Out1);
@@ -997,14 +1017,18 @@ bool KOREVariablePattern::matches(substitution &subst, SubsortMap const& subsort
   }
 }
 
-bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) {
+bool KORECompositePattern::matches(
+    substitution &subst, SubsortMap const &subsorts, SymbolMap const &overloads,
+    sptr<KOREPattern> subject) {
   auto subj = dynamic_cast<KORECompositePattern *>(subject.get());
   if (!subj) {
     return false;
   }
   if (*subj->getConstructor() != *getConstructor()) {
-    if (subj->getConstructor()->getName() == "inj" && getConstructor()->getName() == "inj") {
-      if (*subj->getConstructor()->getFormalArguments()[1] != *getConstructor()->getFormalArguments()[1]) {
+    if (subj->getConstructor()->getName() == "inj"
+        && getConstructor()->getName() == "inj") {
+      if (*subj->getConstructor()->getFormalArguments()[1]
+          != *getConstructor()->getFormalArguments()[1]) {
         return false;
       }
       sptr<KORESort> a = subj->getConstructor()->getFormalArguments()[0];
@@ -1016,7 +1040,8 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
         ba->getConstructor()->addArgument(b);
         ba->addArgument(arguments[0]);
         return ba->matches(subst, subsorts, overloads, subj->getArguments()[0]);
-      } else if (subsorts.count(a.get()) && subsorts.at(a.get()).count(b.get())) {
+      } else if (
+          subsorts.count(a.get()) && subsorts.at(a.get()).count(b.get())) {
         sptr<KORECompositePattern> ab = KORECompositePattern::Create("inj");
         ab->getConstructor()->addFormalArgument(a);
         ab->getConstructor()->addFormalArgument(b);
@@ -1026,17 +1051,25 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
       } else {
         return false;
       }
-    } else if (subj->getConstructor()->getName() == "inj") { 
+    } else if (subj->getConstructor()->getName() == "inj") {
       sptr<KOREPattern> child = subj->getArguments()[0];
       if (auto composite = dynamic_cast<KORECompositePattern *>(child.get())) {
-        if (overloads.count(composite->getConstructor()) && overloads.at(composite->getConstructor()).count(getConstructor())) {
-          sptr<KORECompositePattern> greater = KORECompositePattern::Create(getConstructor());
+        if (overloads.count(composite->getConstructor())
+            && overloads.at(composite->getConstructor())
+                   .count(getConstructor())) {
+          sptr<KORECompositePattern> greater
+              = KORECompositePattern::Create(getConstructor());
           for (int i = 0; i < arguments.size(); i++) {
-            if (*getConstructor()->getArguments()[i] != *composite->getConstructor()->getArguments()[i]) {
-              sptr<KORECompositePattern> inj = KORECompositePattern::Create("inj");
-              inj->getConstructor()->addFormalArgument(composite->getConstructor()->getArguments()[i]);
-              inj->getConstructor()->addFormalArgument(getConstructor()->getArguments()[i]);
-              inj->getConstructor()->addArgument(composite->getConstructor()->getArguments()[i]);
+            if (*getConstructor()->getArguments()[i]
+                != *composite->getConstructor()->getArguments()[i]) {
+              sptr<KORECompositePattern> inj
+                  = KORECompositePattern::Create("inj");
+              inj->getConstructor()->addFormalArgument(
+                  composite->getConstructor()->getArguments()[i]);
+              inj->getConstructor()->addFormalArgument(
+                  getConstructor()->getArguments()[i]);
+              inj->getConstructor()->addArgument(
+                  composite->getConstructor()->getArguments()[i]);
               inj->addArgument(composite->getArguments()[i]);
               greater->addArgument(inj);
             } else {
@@ -1059,12 +1092,16 @@ bool KORECompositePattern::matches(substitution &subst, SubsortMap const& subsor
   }
   bool match = true;
   for (int i = 0; i < subj->arguments.size(); i++) {
-    match = match && arguments[i]->matches(subst, subsorts, overloads, subj->arguments[i]);
+    match = match
+            && arguments[i]->matches(
+                subst, subsorts, overloads, subj->arguments[i]);
   }
   return match;
 }
 
-bool KOREStringPattern::matches(substitution &subst, SubsortMap const& subsorts, SymbolMap const& overloads, sptr<KOREPattern> subject) {
+bool KOREStringPattern::matches(
+    substitution &subst, SubsortMap const &subsorts, SymbolMap const &overloads,
+    sptr<KOREPattern> subject) {
   auto subj = dynamic_cast<KOREStringPattern *>(subject.get());
   if (!subj) {
     return false;
@@ -1077,18 +1114,18 @@ void KOREDeclaration::addAttribute(ptr<KORECompositePattern> Attribute) {
   attributes.insert({name, std::move(Attribute)});
 }
 
-void
-KOREDeclaration::addObjectSortVariable(sptr<KORESortVariable> SortVariable) {
+void KOREDeclaration::addObjectSortVariable(
+    sptr<KORESortVariable> SortVariable) {
   objectSortVariables.push_back(SortVariable);
 }
 
-std::string KOREDeclaration::getStringAttribute(std::string name) const { 
+std::string KOREDeclaration::getStringAttribute(std::string name) const {
   KORECompositePattern *attr = attributes.at(name).get();
   assert(attr->getArguments().size() == 1);
-  auto strPattern = dynamic_cast<KOREStringPattern *>(attr->getArguments()[0].get());
+  auto strPattern
+      = dynamic_cast<KOREStringPattern *>(attr->getArguments()[0].get());
   return strPattern->getContents();
 }
- 
 
 void KOREAxiomDeclaration::addPattern(ptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
@@ -1104,21 +1141,31 @@ static const std::string CONSTRUCTOR = "constructor";
 static const std::string CEIL = "ceil";
 
 bool KOREAxiomDeclaration::isRequired() {
-  return !attributes.count(ASSOC) && !attributes.count(COMM) && !attributes.count(IDEM) && !attributes.count(UNIT) && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR) && !attributes.count(SUBSORT) && !attributes.count(CEIL);
+  return !attributes.count(ASSOC) && !attributes.count(COMM)
+         && !attributes.count(IDEM) && !attributes.count(UNIT)
+         && !attributes.count(FUNCTIONAL) && !attributes.count(CONSTRUCTOR)
+         && !attributes.count(SUBSORT) && !attributes.count(CEIL);
 }
 
 bool KOREAxiomDeclaration::isTopAxiom() {
   if (auto top = dynamic_cast<KORECompositePattern *>(pattern.get())) {
-    if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0].get())) {
-        if (bottomPattern->getConstructor()->getName() == "\\bottom" && bottomPattern->getArguments().empty()) {
+    if (top->getConstructor()->getName() == "\\implies"
+        && top->getArguments().size() == 2) {
+      if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[0].get())) {
+        if (bottomPattern->getConstructor()->getName() == "\\bottom"
+            && bottomPattern->getArguments().empty()) {
           return true;
         }
       }
       return false;
-    } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\rewrites"
+        && top->getArguments().size() == 2) {
       return true;
-    } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\and"
+        && top->getArguments().size() == 2) {
       return true;
     }
   }
@@ -1127,61 +1174,97 @@ bool KOREAxiomDeclaration::isTopAxiom() {
 
 KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
   if (auto top = dynamic_cast<KORECompositePattern *>(pattern.get())) {
-    if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1].get())) {
-        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0].get())) {
-            if (bottomPattern->getConstructor()->getName() == "\\bottom" && bottomPattern->getArguments().empty()) {
-              if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
-                if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
-                  if (auto rewrites = dynamic_cast<KORECompositePattern *>(andPattern2->getArguments()[1].get())) {
-                    if (rewrites->getConstructor()->getName() == "\\rewrites" && rewrites->getArguments().size() == 2) {
+    if (top->getConstructor()->getName() == "\\implies"
+        && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[1].get())) {
+        if (andPattern->getConstructor()->getName() == "\\and"
+            && andPattern->getArguments().size() == 2) {
+          if (auto bottomPattern = dynamic_cast<KORECompositePattern *>(
+                  top->getArguments()[0].get())) {
+            if (bottomPattern->getConstructor()->getName() == "\\bottom"
+                && bottomPattern->getArguments().empty()) {
+              if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(
+                      andPattern->getArguments()[1].get())) {
+                if (andPattern2->getConstructor()->getName() == "\\and"
+                    && andPattern2->getArguments().size() == 2) {
+                  if (auto rewrites = dynamic_cast<KORECompositePattern *>(
+                          andPattern2->getArguments()[1].get())) {
+                    if (rewrites->getConstructor()->getName() == "\\rewrites"
+                        && rewrites->getArguments().size() == 2) {
                       return rewrites->getArguments()[1].get();
                     }
                   }
-                } else if (andPattern2->getConstructor()->getName() == "\\rewrites" && andPattern2->getArguments().size() == 2) {
-                  if (auto andPattern3 = dynamic_cast<KORECompositePattern *>(andPattern2->getArguments()[1].get())) {
-                    if (andPattern3->getConstructor()->getName() == "\\and" && andPattern3->getArguments().size() == 2) {
+                } else if (
+                    andPattern2->getConstructor()->getName() == "\\rewrites"
+                    && andPattern2->getArguments().size() == 2) {
+                  if (auto andPattern3 = dynamic_cast<KORECompositePattern *>(
+                          andPattern2->getArguments()[1].get())) {
+                    if (andPattern3->getConstructor()->getName() == "\\and"
+                        && andPattern3->getArguments().size() == 2) {
                       return andPattern3->getArguments()[1].get();
                     }
                   }
                 }
               }
-            } else if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0].get())) {
-              if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+            } else if (
+                auto equals = dynamic_cast<KORECompositePattern *>(
+                    andPattern->getArguments()[0].get())) {
+              if (equals->getConstructor()->getName() == "\\equals"
+                  && equals->getArguments().size() == 2) {
                 return equals->getArguments()[1].get();
               }
             }
           }
-        } else if (andPattern->getConstructor()->getName() == "\\rewrites" && andPattern->getArguments().size() == 2) {
-          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
-            if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
+        } else if (
+            andPattern->getConstructor()->getName() == "\\rewrites"
+            && andPattern->getArguments().size() == 2) {
+          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(
+                  andPattern->getArguments()[1].get())) {
+            if (andPattern2->getConstructor()->getName() == "\\and"
+                && andPattern2->getArguments().size() == 2) {
               return andPattern2->getArguments()[1].get();
             }
           }
-        } else if (andPattern->getConstructor()->getName() == "\\equals" && andPattern->getArguments().size() == 2) {
-          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
-            if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
+        } else if (
+            andPattern->getConstructor()->getName() == "\\equals"
+            && andPattern->getArguments().size() == 2) {
+          if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(
+                  andPattern->getArguments()[1].get())) {
+            if (andPattern2->getConstructor()->getName() == "\\and"
+                && andPattern2->getArguments().size() == 2) {
               return andPattern2->getArguments()[0].get();
             }
           }
         }
       }
-    } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1].get())) {
-        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto rewrites = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
-            if (rewrites->getConstructor()->getName() == "\\rewrites" && rewrites->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\and"
+        && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[1].get())) {
+        if (andPattern->getConstructor()->getName() == "\\and"
+            && andPattern->getArguments().size() == 2) {
+          if (auto rewrites = dynamic_cast<KORECompositePattern *>(
+                  andPattern->getArguments()[1].get())) {
+            if (rewrites->getConstructor()->getName() == "\\rewrites"
+                && rewrites->getArguments().size() == 2) {
               return rewrites->getArguments()[1].get();
             }
           }
         }
       }
-    } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\equals"
+        && top->getArguments().size() == 2) {
       return top->getArguments()[1].get();
-    } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[1].get())) {
-        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\rewrites"
+        && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[1].get())) {
+        if (andPattern->getConstructor()->getName() == "\\and"
+            && andPattern->getArguments().size() == 2) {
           return andPattern->getArguments()[1].get();
         }
       }
@@ -1193,38 +1276,63 @@ KOREPattern *KOREAxiomDeclaration::getRightHandSide() const {
 
 KOREPattern *KOREAxiomDeclaration::getRequires() const {
   if (auto top = dynamic_cast<KORECompositePattern *>(pattern.get())) {
-    if (top->getConstructor()->getName() == "\\implies" && top->getArguments().size() == 2) {
-      if (auto outer = dynamic_cast<KORECompositePattern *>(top->getArguments()[0].get())) {
-        if (outer->getConstructor()->getName() == "\\and" && outer->getArguments().size() == 2) {
-          if (auto _not = dynamic_cast<KORECompositePattern *>(outer->getArguments()[0].get())) {
-            if (_not->getConstructor()->getName() == "\\not" && _not->getArguments().size() == 1) {
-              outer = dynamic_cast<KORECompositePattern *>(outer->getArguments()[1].get());
+    if (top->getConstructor()->getName() == "\\implies"
+        && top->getArguments().size() == 2) {
+      if (auto outer = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[0].get())) {
+        if (outer->getConstructor()->getName() == "\\and"
+            && outer->getArguments().size() == 2) {
+          if (auto _not = dynamic_cast<KORECompositePattern *>(
+                  outer->getArguments()[0].get())) {
+            if (_not->getConstructor()->getName() == "\\not"
+                && _not->getArguments().size() == 1) {
+              outer = dynamic_cast<KORECompositePattern *>(
+                  outer->getArguments()[1].get());
               assert(outer);
             }
           }
         }
-        if (outer->getConstructor()->getName() == "\\equals" && outer->getArguments().size() == 2) {
+        if (outer->getConstructor()->getName() == "\\equals"
+            && outer->getArguments().size() == 2) {
           return outer->getArguments()[0].get();
-        } else if (outer->getConstructor()->getName() == "\\top" && outer->getArguments().empty()) {
+        } else if (
+            outer->getConstructor()->getName() == "\\top"
+            && outer->getArguments().empty()) {
           return nullptr;
-        } else if (outer->getConstructor()->getName() == "\\bottom" && outer->getArguments().empty()) {
+        } else if (
+            outer->getConstructor()->getName() == "\\bottom"
+            && outer->getArguments().empty()) {
           // strategy axiom hack
-          if (auto trueTop = dynamic_cast<KORECompositePattern *>(top->getArguments()[1].get())) {
-            if (trueTop->getConstructor()->getName() == "\\and" && trueTop->getArguments().size() == 2) {
-              if (auto equals = dynamic_cast<KORECompositePattern *>(trueTop->getArguments()[0].get())) {
-                if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+          if (auto trueTop = dynamic_cast<KORECompositePattern *>(
+                  top->getArguments()[1].get())) {
+            if (trueTop->getConstructor()->getName() == "\\and"
+                && trueTop->getArguments().size() == 2) {
+              if (auto equals = dynamic_cast<KORECompositePattern *>(
+                      trueTop->getArguments()[0].get())) {
+                if (equals->getConstructor()->getName() == "\\equals"
+                    && equals->getArguments().size() == 2) {
                   return equals->getArguments()[0].get();
-                } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+                } else if (
+                    equals->getConstructor()->getName() == "\\top"
+                    && equals->getArguments().empty()) {
                   return nullptr;
                 }
               }
-            } else if (trueTop->getConstructor()->getName() == "\\rewrites" && trueTop->getArguments().size() == 2) {
-              if (auto andPattern = dynamic_cast<KORECompositePattern *>(trueTop->getArguments()[0].get())) {
-                if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-                  if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0].get())) {
-                    if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+            } else if (
+                trueTop->getConstructor()->getName() == "\\rewrites"
+                && trueTop->getArguments().size() == 2) {
+              if (auto andPattern = dynamic_cast<KORECompositePattern *>(
+                      trueTop->getArguments()[0].get())) {
+                if (andPattern->getConstructor()->getName() == "\\and"
+                    && andPattern->getArguments().size() == 2) {
+                  if (auto equals = dynamic_cast<KORECompositePattern *>(
+                          andPattern->getArguments()[0].get())) {
+                    if (equals->getConstructor()->getName() == "\\equals"
+                        && equals->getArguments().size() == 2) {
                       return equals->getArguments()[0].get();
-                    } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+                    } else if (
+                        equals->getConstructor()->getName() == "\\top"
+                        && equals->getArguments().empty()) {
                       return nullptr;
                     }
                   }
@@ -1232,47 +1340,77 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
               }
             }
           }
-        } else if (outer->getConstructor()->getName() == "\\and" && outer->getArguments().size() == 2) {
-          if (auto inner = dynamic_cast<KORECompositePattern *>(outer->getArguments()[0].get())) {
-            if (inner->getConstructor()->getName() == "\\top" && inner->getArguments().empty()) {
+        } else if (
+            outer->getConstructor()->getName() == "\\and"
+            && outer->getArguments().size() == 2) {
+          if (auto inner = dynamic_cast<KORECompositePattern *>(
+                  outer->getArguments()[0].get())) {
+            if (inner->getConstructor()->getName() == "\\top"
+                && inner->getArguments().empty()) {
               return nullptr;
-            } else if (inner->getConstructor()->getName() == "\\equals" && inner->getArguments().size() == 2) {
+            } else if (
+                inner->getConstructor()->getName() == "\\equals"
+                && inner->getArguments().size() == 2) {
               return inner->getArguments()[0].get();
             }
           }
         }
       }
-    } else if (top->getConstructor()->getName() == "\\and" && top->getArguments().size() == 2) {
-      if (auto equals = dynamic_cast<KORECompositePattern *>(top->getArguments()[0].get())) {
-        if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\and"
+        && top->getArguments().size() == 2) {
+      if (auto equals = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[0].get())) {
+        if (equals->getConstructor()->getName() == "\\equals"
+            && equals->getArguments().size() == 2) {
           return equals->getArguments()[0].get();
-        } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+        } else if (
+            equals->getConstructor()->getName() == "\\top"
+            && equals->getArguments().empty()) {
           return nullptr;
         }
       }
-    } else if (top->getConstructor()->getName() == "\\equals" && top->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\equals"
+        && top->getArguments().size() == 2) {
       return nullptr;
-    } else if (top->getConstructor()->getName() == "\\rewrites" && top->getArguments().size() == 2) {
-      if (auto andPattern = dynamic_cast<KORECompositePattern *>(top->getArguments()[0].get())) {
-        if (andPattern->getConstructor()->getName() == "\\and" && andPattern->getArguments().size() == 2) {
-          if (auto equals = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[0].get())) {
-            if (equals->getConstructor()->getName() == "\\equals" && equals->getArguments().size() == 2) {
+    } else if (
+        top->getConstructor()->getName() == "\\rewrites"
+        && top->getArguments().size() == 2) {
+      if (auto andPattern = dynamic_cast<KORECompositePattern *>(
+              top->getArguments()[0].get())) {
+        if (andPattern->getConstructor()->getName() == "\\and"
+            && andPattern->getArguments().size() == 2) {
+          if (auto equals = dynamic_cast<KORECompositePattern *>(
+                  andPattern->getArguments()[0].get())) {
+            if (equals->getConstructor()->getName() == "\\equals"
+                && equals->getArguments().size() == 2) {
               return equals->getArguments()[0].get();
-            } else if (equals->getConstructor()->getName() == "\\top" && equals->getArguments().empty()) {
+            } else if (
+                equals->getConstructor()->getName() == "\\top"
+                && equals->getArguments().empty()) {
               return nullptr;
-            } else if (equals->getConstructor()->getName() == "\\not" && equals->getArguments().size() == 1) {
-              if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(andPattern->getArguments()[1].get())) {
-                if (andPattern2->getConstructor()->getName() == "\\and" && andPattern2->getArguments().size() == 2) {
-                  if (auto equals2 = dynamic_cast<KORECompositePattern *>(andPattern2->getArguments()[0].get())) {
-                    if (equals2->getConstructor()->getName() == "\\equals" && equals2->getArguments().size() == 2) {
+            } else if (
+                equals->getConstructor()->getName() == "\\not"
+                && equals->getArguments().size() == 1) {
+              if (auto andPattern2 = dynamic_cast<KORECompositePattern *>(
+                      andPattern->getArguments()[1].get())) {
+                if (andPattern2->getConstructor()->getName() == "\\and"
+                    && andPattern2->getArguments().size() == 2) {
+                  if (auto equals2 = dynamic_cast<KORECompositePattern *>(
+                          andPattern2->getArguments()[0].get())) {
+                    if (equals2->getConstructor()->getName() == "\\equals"
+                        && equals2->getArguments().size() == 2) {
                       return equals2->getArguments()[0].get();
-                    } else if (equals2->getConstructor()->getName() == "\\top" && equals2->getArguments().empty()) {
+                    } else if (
+                        equals2->getConstructor()->getName() == "\\top"
+                        && equals2->getArguments().empty()) {
                       return nullptr;
-		    }
-		  }
-		}
-	      }
-	    }
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -1282,9 +1420,7 @@ KOREPattern *KOREAxiomDeclaration::getRequires() const {
   abort();
 }
 
-
-void
-KOREAliasDeclaration::addVariables(ptr<KORECompositePattern> Variables) {
+void KOREAliasDeclaration::addVariables(ptr<KORECompositePattern> Variables) {
   boundVariables = std::move(Variables);
 }
 
@@ -1292,7 +1428,8 @@ void KOREAliasDeclaration::addPattern(ptr<KOREPattern> Pattern) {
   pattern = std::move(Pattern);
 }
 
-KOREPattern::substitution KOREAliasDeclaration::getSubstitution(KORECompositePattern *subject) {
+KOREPattern::substitution
+KOREAliasDeclaration::getSubstitution(KORECompositePattern *subject) {
   int i = 0;
   KOREPattern::substitution result;
   for (auto &arg : boundVariables->getArguments()) {
@@ -1320,12 +1457,16 @@ void KOREModule::addDeclaration(ptr<KOREDeclaration> Declaration) {
 
 void KOREDefinition::addModule(ptr<KOREModule> Module) {
   for (auto &decl : Module->getDeclarations()) {
-    if (auto sortDecl = dynamic_cast<KORECompositeSortDeclaration *>(decl.get())) {
+    if (auto sortDecl
+        = dynamic_cast<KORECompositeSortDeclaration *>(decl.get())) {
       sortDeclarations.insert({sortDecl->getName(), sortDecl});
       auto sort = KORECompositeSort::Create(sortDecl->getName());
-    } else if (auto symbolDecl = dynamic_cast<KORESymbolDeclaration *>(decl.get())) {
-      symbolDeclarations.insert({symbolDecl->getSymbol()->getName(), symbolDecl});
-    } else if (auto aliasDecl = dynamic_cast<KOREAliasDeclaration *>(decl.get())) {
+    } else if (
+        auto symbolDecl = dynamic_cast<KORESymbolDeclaration *>(decl.get())) {
+      symbolDeclarations.insert(
+          {symbolDecl->getSymbol()->getName(), symbolDecl});
+    } else if (
+        auto aliasDecl = dynamic_cast<KOREAliasDeclaration *>(decl.get())) {
       aliasDeclarations.insert({aliasDecl->getSymbol()->getName(), aliasDecl});
     } else if (auto axiom = dynamic_cast<KOREAxiomDeclaration *>(decl.get())) {
       axioms.push_back(axiom);
@@ -1346,12 +1487,14 @@ void KOREDefinition::preprocess() {
   }
   auto symbols = std::map<std::string, std::vector<KORESymbol *>>{};
   unsigned nextOrdinal = 0;
-  for (auto iter = symbolDeclarations.begin(); iter != symbolDeclarations.end(); ++iter) {
+  for (auto iter = symbolDeclarations.begin(); iter != symbolDeclarations.end();
+       ++iter) {
     auto decl = *iter;
     if (decl.second->getAttributes().count("freshGenerator")) {
       auto sort = decl.second->getSymbol()->getSort();
       if (sort->isConcrete()) {
-        freshFunctions[dynamic_cast<KORECompositeSort *>(sort.get())->getName()] = decl.second->getSymbol();
+        freshFunctions[dynamic_cast<KORECompositeSort *>(sort.get())->getName()]
+            = decl.second->getSymbol();
       }
     }
   }
@@ -1369,12 +1512,13 @@ void KOREDefinition::preprocess() {
   for (auto moditer = modules.begin(); moditer != modules.end(); ++moditer) {
     auto &declarations = (*moditer)->getDeclarations();
     for (auto iter = declarations.begin(); iter != declarations.end(); ++iter) {
-      KORESymbolDeclaration * decl = dynamic_cast<KORESymbolDeclaration *>(iter->get());
+      KORESymbolDeclaration *decl
+          = dynamic_cast<KORESymbolDeclaration *>(iter->get());
       if (decl == nullptr) {
         continue;
       }
       if (decl->isHooked() && decl->getObjectSortVariables().empty()) {
-        KORESymbol * symbol = decl->getSymbol();
+        KORESymbol *symbol = decl->getSymbol();
         symbols.emplace(symbol->getName(), std::vector<KORESymbol *>{symbol});
       }
     }
@@ -1391,7 +1535,8 @@ void KOREDefinition::preprocess() {
   uint16_t nextLayout = 1;
   auto instantiations = std::unordered_map<KORESymbol, uint32_t, HashSymbol>{};
   auto layouts = std::unordered_map<std::string, uint16_t>{};
-  auto variables = std::unordered_map<std::string, std::pair<uint32_t, uint32_t>>{};
+  auto variables
+      = std::unordered_map<std::string, std::pair<uint32_t, uint32_t>>{};
   for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
     auto entry = *iter;
     uint32_t firstTag = nextSymbol;
@@ -1413,9 +1558,10 @@ void KOREDefinition::preprocess() {
         allObjectSymbols[Out.str()] = symbol;
       }
     }
-    uint32_t lastTag = nextSymbol-1;
+    uint32_t lastTag = nextSymbol - 1;
     if (!entry.second.empty()) {
-      variables.emplace(entry.first, std::pair<uint32_t, uint32_t>{firstTag, lastTag});
+      variables.emplace(
+          entry.first, std::pair<uint32_t, uint32_t>{firstTag, lastTag});
     }
   }
   for (auto iter = symbols.begin(); iter != symbols.end(); ++iter) {
@@ -1425,11 +1571,15 @@ void KOREDefinition::preprocess() {
       KORESymbol *symbol = *iter;
       for (auto &sort : symbol->getArguments()) {
         if (sort->isConcrete()) {
-          hookedSorts[dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(this)] = std::dynamic_pointer_cast<KORECompositeSort>(sort);
+          hookedSorts[dynamic_cast<KORECompositeSort *>(sort.get())
+                          ->getCategory(this)]
+              = std::dynamic_pointer_cast<KORECompositeSort>(sort);
         }
       }
       if (symbol->getSort()->isConcrete()) {
-        hookedSorts[dynamic_cast<KORECompositeSort *>(symbol->getSort().get())->getCategory(this)] = std::dynamic_pointer_cast<KORECompositeSort>(symbol->getSort());
+        hookedSorts[dynamic_cast<KORECompositeSort *>(symbol->getSort().get())
+                        ->getCategory(this)]
+            = std::dynamic_pointer_cast<KORECompositeSort>(symbol->getSort());
       }
       if (!symbol->isConcrete()) {
         if (symbol->isPolymorphic()) {
@@ -1486,8 +1636,7 @@ void KOREVariable::print(std::ostream &Out, unsigned indent) const {
   Out << Indent << name;
 }
 
-void
-KOREVariablePattern::print(std::ostream &Out, unsigned indent) const {
+void KOREVariablePattern::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent;
   name->print(Out);
@@ -1495,8 +1644,7 @@ KOREVariablePattern::print(std::ostream &Out, unsigned indent) const {
   sort->print(Out);
 }
 
-void
-KORECompositePattern::print(std::ostream &Out, unsigned indent) const {
+void KORECompositePattern::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent;
   constructor->print(Out);
@@ -1534,8 +1682,9 @@ void KOREStringPattern::print(std::ostream &Out, unsigned indent) const {
 }
 
 static void printAttributeList(
-  std::ostream &Out, const std::map<std::string, ptr<KORECompositePattern>> &attributes,
-  unsigned indent = 0) {
+    std::ostream &Out,
+    const std::map<std::string, ptr<KORECompositePattern>> &attributes,
+    unsigned indent = 0) {
 
   std::string Indent(indent, ' ');
   Out << Indent << "[";
@@ -1562,7 +1711,7 @@ void KOREDeclaration::printSortVariables(std::ostream &Out) const {
 }
 
 void KORECompositeSortDeclaration::print(
-  std::ostream &Out, unsigned indent) const {
+    std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << (_isHooked ? "hooked-sort " : "sort ") << sortName;
   printSortVariables(Out);
@@ -1570,8 +1719,7 @@ void KORECompositeSortDeclaration::print(
   printAttributeList(Out, attributes);
 }
 
-void
-KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
+void KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << (_isHooked ? "hooked-symbol " : "symbol ")
       << symbol->getName();
@@ -1590,8 +1738,7 @@ KORESymbolDeclaration::print(std::ostream &Out, unsigned indent) const {
   printAttributeList(Out, attributes);
 }
 
-void
-KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
+void KOREAliasDeclaration::print(std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << "alias " << symbol->getName();
   printSortVariables(Out);
@@ -1622,8 +1769,8 @@ void KOREAxiomDeclaration::print(std::ostream &Out, unsigned indent) const {
   printAttributeList(Out, attributes);
 }
 
-void
-KOREModuleImportDeclaration::print(std::ostream &Out, unsigned indent) const {
+void KOREModuleImportDeclaration::print(
+    std::ostream &Out, unsigned indent) const {
   std::string Indent(indent, ' ');
   Out << Indent << "import " << moduleName;
   Out << " ";
@@ -1655,7 +1802,9 @@ void KOREDefinition::print(std::ostream &Out, unsigned indent) const {
   }
 }
 
-void kllvm::readMultimap(std::string name, KORESymbolDeclaration *decl, std::map<std::string, std::set<std::string>> &output, std::string attName) {
+void kllvm::readMultimap(
+    std::string name, KORESymbolDeclaration *decl,
+    std::map<std::string, std::set<std::string>> &output, std::string attName) {
   if (decl->getAttributes().count(attName)) {
     KORECompositePattern *att = decl->getAttributes().at(attName).get();
     for (auto &pat : att->getArguments()) {
@@ -1669,13 +1818,16 @@ void kllvm::readMultimap(std::string name, KORESymbolDeclaration *decl, std::map
 // of all its subpatterns. This can sometimes exhaust all the stack space.
 // This function deallocates a pattern iteratively, without recursion.
 void kllvm::deallocateSPtrKorePattern(sptr<KOREPattern> pattern) {
-    std::vector<sptr<KOREPattern>> vec;
-    vec.push_back(std::move(pattern));
-    while(!vec.empty()) {
-        sptr<KOREPattern> curr = std::move(vec.back());
-        vec.pop_back();
-        if (auto composite = std::dynamic_pointer_cast<KORECompositePattern>(curr)) {
-            vec.insert(vec.end(), std::make_move_iterator(composite->arguments.begin()), std::make_move_iterator(composite->arguments.end()));
-        }
+  std::vector<sptr<KOREPattern>> vec;
+  vec.push_back(std::move(pattern));
+  while (!vec.empty()) {
+    sptr<KOREPattern> curr = std::move(vec.back());
+    vec.pop_back();
+    if (auto composite
+        = std::dynamic_pointer_cast<KORECompositePattern>(curr)) {
+      vec.insert(
+          vec.end(), std::make_move_iterator(composite->arguments.begin()),
+          std::make_move_iterator(composite->arguments.end()));
     }
+  }
 }

--- a/lib/codegen/Debug.cpp
+++ b/lib/codegen/Debug.cpp
@@ -17,69 +17,77 @@ void initDebugInfo(llvm::Module *module, std::string filename) {
   Dbg = new llvm::DIBuilder(*module);
   DbgFile = Dbg->createFile(filename, ".");
 
-  module->addModuleFlag(llvm::Module::Warning, "Debug Info Version", (uint32_t)llvm::DEBUG_METADATA_VERSION);
+  module->addModuleFlag(
+      llvm::Module::Warning, "Debug Info Version",
+      (uint32_t)llvm::DEBUG_METADATA_VERSION);
   module->addModuleFlag(llvm::Module::Warning, "Dwarf Version", 4);
   DbgCU = Dbg->createCompileUnit(
-    llvm::dwarf::DW_LANG_C, 
-    DbgFile,
-    "llvm-kompile-codegen",
-    0, "", 0);
+      llvm::dwarf::DW_LANG_C, DbgFile, "llvm-kompile-codegen", 0, "", 0);
 }
 
 void finalizeDebugInfo(void) {
   Dbg->finalize();
 }
 
-void initDebugFunction(std::string name, std::string linkageName, llvm::DISubroutineType *type, KOREDefinition *definition, llvm::Function *func) {
-  if(!Dbg) return;
+void initDebugFunction(
+    std::string name, std::string linkageName, llvm::DISubroutineType *type,
+    KOREDefinition *definition, llvm::Function *func) {
+  if (!Dbg)
+    return;
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
   llvm::DIScope *FContext = Unit;
 #if LLVM_VERSION_MAJOR >= 8
   DbgSP = Dbg->createFunction(
-    FContext,
-    name,
-    name,
-    Unit, DbgLine, type, DbgLine, llvm::DINode::DIFlags::FlagZero, llvm::DISubprogram::SPFlagDefinition);
+      FContext, name, name, Unit, DbgLine, type, DbgLine,
+      llvm::DINode::DIFlags::FlagZero, llvm::DISubprogram::SPFlagDefinition);
 #else
   DbgSP = Dbg->createFunction(
-    FContext,
-    name,
-    name,
-    Unit, DbgLine, type, false, true, DbgLine);
+      FContext, name, name, Unit, DbgLine, type, false, true, DbgLine);
 #endif
   func->setSubprogram(DbgSP);
 }
 
-void initDebugParam(llvm::Function *func, unsigned argNo, std::string name, ValueType type, std::string typeName) {
-  if(!Dbg) return;
-  llvm::DILocalVariable *DbgVar = Dbg->createParameterVariable(DbgSP, name, argNo+1, DbgFile, DbgLine, getDebugType(type, typeName), true);
+void initDebugParam(
+    llvm::Function *func, unsigned argNo, std::string name, ValueType type,
+    std::string typeName) {
+  if (!Dbg)
+    return;
+  llvm::DILocalVariable *DbgVar = Dbg->createParameterVariable(
+      DbgSP, name, argNo + 1, DbgFile, DbgLine, getDebugType(type, typeName),
+      true);
   Dbg->insertDbgValueIntrinsic(
-    func->arg_begin()+argNo,
-    DbgVar,
-    Dbg->createExpression(),
-    llvm::DILocation::get(func->getContext(), DbgLine, DbgColumn, DbgSP),
-    &func->getEntryBlock());
+      func->arg_begin() + argNo, DbgVar, Dbg->createExpression(),
+      llvm::DILocation::get(func->getContext(), DbgLine, DbgColumn, DbgSP),
+      &func->getEntryBlock());
 }
 
-void initDebugGlobal(std::string name, llvm::DIType *type, llvm::GlobalVariable *var) {
-	if (!Dbg) return;
-	resetDebugLoc();
-	auto DbgExp = Dbg->createGlobalVariableExpression(DbgCU, name, name, DbgFile, DbgLine, type, false);
-	var->addDebugInfo(DbgExp);
+void initDebugGlobal(
+    std::string name, llvm::DIType *type, llvm::GlobalVariable *var) {
+  if (!Dbg)
+    return;
+  resetDebugLoc();
+  auto DbgExp = Dbg->createGlobalVariableExpression(
+      DbgCU, name, name, DbgFile, DbgLine, type, false);
+  var->addDebugInfo(DbgExp);
 }
 
-static std::string SOURCE_ATT = "org'Stop'kframework'Stop'attributes'Stop'Source";
-static std::string LOCATION_ATT = "org'Stop'kframework'Stop'attributes'Stop'Location";
+static std::string SOURCE_ATT
+    = "org'Stop'kframework'Stop'attributes'Stop'Source";
+static std::string LOCATION_ATT
+    = "org'Stop'kframework'Stop'attributes'Stop'Location";
 
-void initDebugAxiom(std::map<std::string, ptr<KORECompositePattern>> const& att) {
-  if (!Dbg) return;
+void initDebugAxiom(
+    std::map<std::string, ptr<KORECompositePattern>> const &att) {
+  if (!Dbg)
+    return;
   if (!att.count(SOURCE_ATT)) {
     resetDebugLoc();
     return;
   }
   KORECompositePattern *sourceAtt = att.at(SOURCE_ATT).get();
   assert(sourceAtt->getArguments().size() == 1);
-  auto strPattern = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0].get());
+  auto strPattern
+      = dynamic_cast<KOREStringPattern *>(sourceAtt->getArguments()[0].get());
   std::string source = strPattern->getContents();
   if (!att.count(LOCATION_ATT)) {
     resetDebugLoc();
@@ -87,26 +95,32 @@ void initDebugAxiom(std::map<std::string, ptr<KORECompositePattern>> const& att)
   }
   KORECompositePattern *locationAtt = att.at(LOCATION_ATT).get();
   assert(locationAtt->getArguments().size() == 1);
-  auto strPattern2 = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0].get());
+  auto strPattern2
+      = dynamic_cast<KOREStringPattern *>(locationAtt->getArguments()[0].get());
   std::string location = strPattern2->getContents();
   source = source.substr(7, source.length() - 8);
   size_t first_comma = location.find_first_of(',');
   DbgLine = std::stoi(location.substr(9, first_comma - 9));
-  DbgColumn = std::stoi(location.substr(first_comma + 1, location.find_first_of(',', first_comma + 1) - first_comma - 1));
+  DbgColumn = std::stoi(location.substr(
+      first_comma + 1,
+      location.find_first_of(',', first_comma + 1) - first_comma - 1));
   DbgFile = Dbg->createFile(source, DbgFile->getDirectory());
 }
 
 void resetDebugLoc(void) {
-  if (!Dbg) return;
+  if (!Dbg)
+    return;
   DbgLine = 0;
   DbgColumn = 0;
   DbgFile = DbgCU->getFile();
 }
 
 llvm::DIType *getForwardDecl(std::string name) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   auto Unit = Dbg->createFile(DbgFile->getFilename(), DbgFile->getDirectory());
-  return Dbg->createForwardDecl(llvm::dwarf::DW_TAG_structure_type, name, DbgCU, Unit, 0);
+  return Dbg->createForwardDecl(
+      llvm::dwarf::DW_TAG_structure_type, name, DbgCU, Unit, 0);
 }
 
 static std::string MAP_STRUCT = "map";
@@ -117,15 +131,16 @@ static std::string FLOAT_STRUCT = "floating";
 static std::string BUFFER_STRUCT = "stringbuffer";
 static std::string BLOCK_STRUCT = "block";
 
-
 llvm::DIType *getDebugType(ValueType type, std::string typeName) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   static std::map<std::string, llvm::DIType *> types;
-  llvm::DIType *map, *list, *set, *integer, *floating, *buffer, *boolean, *mint, *symbol;
+  llvm::DIType *map, *list, *set, *integer, *floating, *buffer, *boolean, *mint,
+      *symbol;
   if (types[typeName]) {
     return types[typeName];
   }
-  switch(type.cat) {
+  switch (type.cat) {
   case SortCategory::Map:
     map = getPointerDebugType(getForwardDecl(MAP_STRUCT), typeName);
     types[typeName] = map;
@@ -155,7 +170,8 @@ llvm::DIType *getDebugType(ValueType type, std::string typeName) {
     types[typeName] = boolean;
     return boolean;
   case SortCategory::MInt:
-    mint = Dbg->createBasicType(typeName, type.bits, llvm::dwarf::DW_ATE_unsigned);
+    mint = Dbg->createBasicType(
+        typeName, type.bits, llvm::dwarf::DW_ATE_unsigned);
     types[typeName] = mint;
     return mint;
   case SortCategory::Symbol:
@@ -163,24 +179,25 @@ llvm::DIType *getDebugType(ValueType type, std::string typeName) {
     symbol = getPointerDebugType(getForwardDecl(BLOCK_STRUCT), typeName);
     types[typeName] = symbol;
     return symbol;
-  case SortCategory::Uncomputed:
-    abort();
-
+  case SortCategory::Uncomputed: abort();
   }
 }
 
 llvm::DIType *getIntDebugType(void) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   return Dbg->createBasicType("uint32_t", 32, llvm::dwarf::DW_ATE_unsigned);
 }
 
 llvm::DIType *getLongDebugType(void) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   return Dbg->createBasicType("uint64_t", 64, llvm::dwarf::DW_ATE_unsigned);
 }
 
 llvm::DIType *getBoolDebugType(void) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   return Dbg->createBasicType("bool", 8, llvm::dwarf::DW_ATE_boolean);
 }
 
@@ -189,41 +206,52 @@ llvm::DIType *getVoidDebugType(void) {
 }
 
 llvm::DIType *getCharPtrDebugType(void) {
-  if (!Dbg) return nullptr;
-  return Dbg->createPointerType(Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char), sizeof(size_t) * 8);
+  if (!Dbg)
+    return nullptr;
+  return Dbg->createPointerType(
+      Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char),
+      sizeof(size_t) * 8);
 }
 
 llvm::DIType *getCharDebugType(void) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   return Dbg->createBasicType("char", 8, llvm::dwarf::DW_ATE_signed_char);
 }
 
 llvm::DIType *getPointerDebugType(llvm::DIType *ty, std::string typeName) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   auto ptrType = Dbg->createPointerType(ty, sizeof(size_t) * 8);
   return Dbg->createTypedef(ptrType, typeName, DbgFile, 0, DbgCU);
 }
 
 llvm::DIType *getArrayDebugType(llvm::DIType *ty, size_t len, size_t align) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   std::vector<llvm::Metadata *> subscripts;
   auto arr = Dbg->getOrCreateArray(subscripts);
   return Dbg->createArrayType(len, align, ty, arr);
 }
 
 llvm::DIType *getShortDebugType(void) {
-  if (!Dbg) return nullptr;
+  if (!Dbg)
+    return nullptr;
   return Dbg->createBasicType("uint16_t", 16, llvm::dwarf::DW_ATE_unsigned);
 }
 
-llvm::DISubroutineType *getDebugFunctionType(llvm::Metadata *returnType, std::vector<llvm::Metadata *> argTypes) {
-  if (!Dbg) return nullptr;
+llvm::DISubroutineType *getDebugFunctionType(
+    llvm::Metadata *returnType, std::vector<llvm::Metadata *> argTypes) {
+  if (!Dbg)
+    return nullptr;
   argTypes.insert(argTypes.begin(), returnType);
   return Dbg->createSubroutineType(Dbg->getOrCreateTypeArray(argTypes));
 }
 
 void setDebugLoc(llvm::Instruction *instr) {
-  if (!Dbg) return;
-  instr->setDebugLoc(llvm::DebugLoc(llvm::DILocation::get(instr->getContext(), DbgLine, DbgColumn, DbgSP)));
+  if (!Dbg)
+    return;
+  instr->setDebugLoc(llvm::DebugLoc(
+      llvm::DILocation::get(instr->getContext(), DbgLine, DbgColumn, DbgSP)));
 }
-}
+} // namespace kllvm

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -5,7 +5,7 @@
 
 #include "llvm/IR/CFG.h"
 #include "llvm/IR/Constants.h"
-#include "llvm/IR/Instructions.h" 
+#include "llvm/IR/Instructions.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <iostream>
@@ -18,15 +18,23 @@ static std::string LAYOUTITEM_STRUCT = "layoutitem";
 
 FailNode FailNode::instance;
 
-static unsigned max_name_length = 1024 - std::to_string(std::numeric_limits<unsigned long long>::max()).length();
+static unsigned max_name_length
+    = 1024
+      - std::to_string(std::numeric_limits<unsigned long long>::max()).length();
 
 void Decision::operator()(DecisionNode *entry) {
   if (entry == FailNode::get()) {
     if (FailPattern) {
-      llvm::Value *val = load(std::make_pair("_1", getValueType({SortCategory::Symbol, 0}, Module)));
-      FailSubject->addIncoming(new llvm::BitCastInst(val, llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock), CurrentBlock);
-      FailPattern->addIncoming(stringLiteral("\\bottom{SortGeneratedTopCell{}}()"), CurrentBlock);
-      FailSort->addIncoming(stringLiteral("SortGeneratedTopCell{}"), CurrentBlock);
+      llvm::Value *val = load(std::make_pair(
+          "_1", getValueType({SortCategory::Symbol, 0}, Module)));
+      FailSubject->addIncoming(
+          new llvm::BitCastInst(
+              val, llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock),
+          CurrentBlock);
+      FailPattern->addIncoming(
+          stringLiteral("\\bottom{SortGeneratedTopCell{}}()"), CurrentBlock);
+      FailSort->addIncoming(
+          stringLiteral("SortGeneratedTopCell{}"), CurrentBlock);
     }
     llvm::BranchInst::Create(this->FailureBlock, this->CurrentBlock);
   } else {
@@ -38,7 +46,8 @@ llvm::Value *Decision::ptrTerm(llvm::Value *val) {
   if (val->getType()->isIntegerTy()) {
     val = allocateTerm(val->getType(), CurrentBlock, "koreAllocAlwaysGC");
   }
-  return new llvm::BitCastInst(val, llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock);
+  return new llvm::BitCastInst(
+      val, llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock);
 }
 
 bool DecisionNode::beginNode(Decision *d, std::string name) {
@@ -46,23 +55,29 @@ bool DecisionNode::beginNode(Decision *d, std::string name) {
     llvm::BranchInst::Create(cachedCode, d->CurrentBlock);
     return true;
   }
-  auto Block = llvm::BasicBlock::Create(d->Ctx,
-      name.substr(0, max_name_length),
-      d->CurrentBlock->getParent());
+  auto Block = llvm::BasicBlock::Create(
+      d->Ctx, name.substr(0, max_name_length), d->CurrentBlock->getParent());
   cachedCode = Block;
   llvm::BranchInst::Create(Block, d->CurrentBlock);
   d->CurrentBlock = Block;
   return false;
 }
 
-static std::pair<std::string, std::string> getFailPattern(DecisionCase const& _case, bool isInt) {
+static std::pair<std::string, std::string>
+getFailPattern(DecisionCase const &_case, bool isInt) {
   if (isInt) {
     size_t bitwidth = _case.getLiteral().getBitWidth();
     if (bitwidth == 1) {
-      return std::make_pair("SortBool{}", "\\dv{SortBool{}}(\"" + (_case.getLiteral() == 0 ? std::string("false") : std::string("true")) + "\")");
+      return std::make_pair(
+          "SortBool{}", "\\dv{SortBool{}}(\""
+                            + (_case.getLiteral() == 0 ? std::string("false")
+                                                       : std::string("true"))
+                            + "\")");
     } else {
       std::string sort = "SortMInt{Sort" + std::to_string(bitwidth) + "{}}";
-      return std::make_pair(sort, "\\dv{" + sort + "}(\"" + _case.getLiteral().toString(10, false) + "p" + std::to_string(bitwidth) + "\")");
+      return std::make_pair(
+          sort, "\\dv{" + sort + "}(\"" + _case.getLiteral().toString(10, false)
+                    + "p" + std::to_string(bitwidth) + "\")");
     }
   } else {
     std::ostringstream symbol;
@@ -84,7 +99,10 @@ static std::pair<std::string, std::string> getFailPattern(DecisionCase const& _c
   }
 }
 
-static std::pair<std::string, std::string> getFailPattern(std::vector<std::pair<llvm::BasicBlock *, const DecisionCase *>> const& caseData, bool isInt, llvm::BasicBlock *FailBlock) {
+static std::pair<std::string, std::string> getFailPattern(
+    std::vector<std::pair<llvm::BasicBlock *, const DecisionCase *>> const
+        &caseData,
+    bool isInt, llvm::BasicBlock *FailBlock) {
   std::string reason;
   std::string sort;
   for (auto &entry : caseData) {
@@ -122,7 +140,8 @@ void SwitchNode::codegen(Decision *d) {
     if (child == FailNode::get()) {
       CaseBlock = d->FailureBlock;
     } else {
-      CaseBlock = llvm::BasicBlock::Create(d->Ctx, 
+      CaseBlock = llvm::BasicBlock::Create(
+          d->Ctx,
           name.substr(0, max_name_length) + "_case_" + std::to_string(idx++),
           d->CurrentBlock->getParent());
     }
@@ -135,8 +154,14 @@ void SwitchNode::codegen(Decision *d) {
     }
   }
   if (isCheckNull) {
-    auto cast = new llvm::PtrToIntInst(val, llvm::Type::getInt64Ty(d->Ctx), "", d->CurrentBlock);
-    auto cmp = new llvm::ICmpInst(*d->CurrentBlock, llvm::CmpInst::ICMP_NE, cast, llvm::ConstantExpr::getPtrToInt(llvm::ConstantPointerNull::get(llvm::dyn_cast<llvm::PointerType>(val->getType())), llvm::Type::getInt64Ty(d->Ctx)));
+    auto cast = new llvm::PtrToIntInst(
+        val, llvm::Type::getInt64Ty(d->Ctx), "", d->CurrentBlock);
+    auto cmp = new llvm::ICmpInst(
+        *d->CurrentBlock, llvm::CmpInst::ICMP_NE, cast,
+        llvm::ConstantExpr::getPtrToInt(
+            llvm::ConstantPointerNull::get(
+                llvm::dyn_cast<llvm::PointerType>(val->getType())),
+            llvm::Type::getInt64Ty(d->Ctx)));
     val = cmp;
     isInt = true;
   }
@@ -147,18 +172,26 @@ void SwitchNode::codegen(Decision *d) {
     failPattern = d->stringLiteral(failReason.second);
   }
   if (isInt) {
-    auto _switch = llvm::SwitchInst::Create(val, _default, cases.size(), d->CurrentBlock);
+    auto _switch = llvm::SwitchInst::Create(
+        val, _default, cases.size(), d->CurrentBlock);
     for (auto &_case : caseData) {
-      _switch->addCase(llvm::ConstantInt::get(d->Ctx, _case.second->getLiteral()), _case.first);
+      _switch->addCase(
+          llvm::ConstantInt::get(d->Ctx, _case.second->getLiteral()),
+          _case.first);
     }
-  } else { 
+  } else {
     if (caseData.size() == 0) {
       llvm::BranchInst::Create(_default, d->CurrentBlock);
     } else {
       llvm::Value *tagVal = d->getTag(val);
-      auto _switch = llvm::SwitchInst::Create(tagVal, _default, caseData.size(), d->CurrentBlock);
+      auto _switch = llvm::SwitchInst::Create(
+          tagVal, _default, caseData.size(), d->CurrentBlock);
       for (auto &_case : caseData) {
-        _switch->addCase(llvm::ConstantInt::get(llvm::Type::getInt32Ty(d->Ctx), _case.second->getConstructor()->getTag()), _case.first); 
+        _switch->addCase(
+            llvm::ConstantInt::get(
+                llvm::Type::getInt32Ty(d->Ctx),
+                _case.second->getConstructor()->getTag()),
+            _case.first);
       }
     }
   }
@@ -178,31 +211,51 @@ void SwitchNode::codegen(Decision *d) {
     d->CurrentBlock = entry.first;
     if (!isInt) {
       int offset = 0;
-      llvm::StructType *BlockType = getBlockType(d->Module, d->Definition, _case.getConstructor());
-      llvm::BitCastInst *Cast = new llvm::BitCastInst(val, llvm::PointerType::getUnqual(BlockType), "", d->CurrentBlock);
-      KORESymbolDeclaration *symbolDecl = d->Definition->getSymbolDeclarations().at(_case.getConstructor()->getName());
+      llvm::StructType *BlockType
+          = getBlockType(d->Module, d->Definition, _case.getConstructor());
+      llvm::BitCastInst *Cast = new llvm::BitCastInst(
+          val, llvm::PointerType::getUnqual(BlockType), "", d->CurrentBlock);
+      KORESymbolDeclaration *symbolDecl
+          = d->Definition->getSymbolDeclarations().at(
+              _case.getConstructor()->getName());
       llvm::Instruction *Renamed;
       for (auto binding : _case.getBindings()) {
-        llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Cast, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(d->Ctx), offset+2)}, "", d->CurrentBlock);
+        llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(
+            BlockType, Cast,
+            {llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0),
+             llvm::ConstantInt::get(
+                 llvm::Type::getInt32Ty(d->Ctx), offset + 2)},
+            "", d->CurrentBlock);
         llvm::Value *Child;
-        switch (dynamic_cast<KORECompositeSort *>(_case.getConstructor()->getArguments()[offset].get())->getCategory(d->Definition).cat) {
+        switch (dynamic_cast<KORECompositeSort *>(
+                    _case.getConstructor()->getArguments()[offset].get())
+                    ->getCategory(d->Definition)
+                    .cat) {
         case SortCategory::Map:
         case SortCategory::List:
-        case SortCategory::Set:
-          Child = ChildPtr;
-          break;
+        case SortCategory::Set: Child = ChildPtr; break;
         default:
-          Child = new llvm::LoadInst(ChildPtr->getType()->getPointerElementType(), ChildPtr, binding.first.substr(0, max_name_length), d->CurrentBlock);
+          Child = new llvm::LoadInst(
+              ChildPtr->getType()->getPointerElementType(), ChildPtr,
+              binding.first.substr(0, max_name_length), d->CurrentBlock);
           break;
         }
-        auto BlockPtr = llvm::PointerType::getUnqual(getTypeByName(d->Module, BLOCK_STRUCT));
+        auto BlockPtr = llvm::PointerType::getUnqual(
+            getTypeByName(d->Module, BLOCK_STRUCT));
         if (symbolDecl->getAttributes().count("binder")) {
           if (offset == 0) {
-            Renamed = llvm::CallInst::Create(getOrInsertFunction(d->Module, "alphaRename", BlockPtr, BlockPtr), Child, "renamedVar", d->CurrentBlock);
+            Renamed = llvm::CallInst::Create(
+                getOrInsertFunction(
+                    d->Module, "alphaRename", BlockPtr, BlockPtr),
+                Child, "renamedVar", d->CurrentBlock);
             setDebugLoc(Renamed);
             d->store(binding, Renamed);
           } else if (offset == _case.getBindings().size() - 1) {
-            llvm::Instruction *Replaced = llvm::CallInst::Create(getOrInsertFunction(d->Module, "replaceBinderIndex", BlockPtr, BlockPtr, BlockPtr), {Child, Renamed}, "withUnboundIndex", d->CurrentBlock);
+            llvm::Instruction *Replaced = llvm::CallInst::Create(
+                getOrInsertFunction(
+                    d->Module, "replaceBinderIndex", BlockPtr, BlockPtr,
+                    BlockPtr),
+                {Child, Renamed}, "withUnboundIndex", d->CurrentBlock);
             setDebugLoc(Replaced);
             d->store(binding, Replaced);
           } else {
@@ -215,14 +268,23 @@ void SwitchNode::codegen(Decision *d) {
       }
     } else {
       if (currChoiceBlock && _case.getLiteral() == 1) {
-        auto PrevDepth = new llvm::LoadInst(d->ChoiceDepth->getType()->getPointerElementType(), d->ChoiceDepth, "", d->CurrentBlock);
-        auto CurrDepth = llvm::BinaryOperator::Create(llvm::Instruction::Add, PrevDepth, llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 1), "", d->CurrentBlock);
+        auto PrevDepth = new llvm::LoadInst(
+            d->ChoiceDepth->getType()->getPointerElementType(), d->ChoiceDepth,
+            "", d->CurrentBlock);
+        auto CurrDepth = llvm::BinaryOperator::Create(
+            llvm::Instruction::Add, PrevDepth,
+            llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 1), "",
+            d->CurrentBlock);
         new llvm::StoreInst(CurrDepth, d->ChoiceDepth, d->CurrentBlock);
 
         auto ty = d->ChoiceBuffer->getType()->getElementType();
         auto zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), 0);
-        auto currentElt = llvm::GetElementPtrInst::CreateInBounds(ty, d->ChoiceBuffer, {zero, CurrDepth}, "", d->CurrentBlock);
-        new llvm::StoreInst(llvm::BlockAddress::get(d->CurrentBlock->getParent(), currChoiceBlock), currentElt, d->CurrentBlock);
+        auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
+            ty, d->ChoiceBuffer, {zero, CurrDepth}, "", d->CurrentBlock);
+        new llvm::StoreInst(
+            llvm::BlockAddress::get(
+                d->CurrentBlock->getParent(), currChoiceBlock),
+            currentElt, d->CurrentBlock);
         d->FailJump->addDestination(currChoiceBlock);
       }
     }
@@ -251,7 +313,8 @@ void MakePatternNode::codegen(Decision *d) {
   for (auto use : uses) {
     finalSubst[use.first] = d->load(use);
   }
-  CreateTerm creator(finalSubst, d->Definition, d->CurrentBlock, d->Module, false);
+  CreateTerm creator(
+      finalSubst, d->Definition, d->CurrentBlock, d->Module, false);
   llvm::Value *val = creator(pattern).first;
   d->CurrentBlock = creator.getCurrentBlock();
   d->store(std::make_pair(name, type), val);
@@ -268,21 +331,25 @@ void FunctionNode::codegen(Decision *d) {
   for (auto arg : bindings) {
     llvm::Value *val;
     if (arg.first.find_first_not_of("-0123456789") == std::string::npos) {
-      val = llvm::ConstantInt::get(llvm::Type::getInt64Ty(d->Ctx), std::stoi(arg.first));
+      val = llvm::ConstantInt::get(
+          llvm::Type::getInt64Ty(d->Ctx), std::stoi(arg.first));
     } else {
       val = d->load(arg);
     }
     args.push_back(val);
     finalSubst[arg.first] = val;
   }
-  CreateTerm creator(finalSubst, d->Definition, d->CurrentBlock, d->Module, false);
-  auto Call = creator.createFunctionCall(function, cat, args, function.substr(0, 5) == "hook_", false);
+  CreateTerm creator(
+      finalSubst, d->Definition, d->CurrentBlock, d->Module, false);
+  auto Call = creator.createFunctionCall(
+      function, cat, args, function.substr(0, 5) == "hook_", false);
   Call->setName(name.substr(0, max_name_length));
   d->store(std::make_pair(name, type), Call);
   if (d->FailPattern) {
     std::string debugName = function;
     if (function.substr(0, 5) == "hook_") {
-      debugName = function.substr(5, function.find_first_of('_', 5) - 5) + "." + function.substr(function.find_first_of('_', 5) + 1);
+      debugName = function.substr(5, function.find_first_of('_', 5) - 5) + "."
+                  + function.substr(function.find_first_of('_', 5) + 1);
     } else if (function.substr(0, 15) == "side_condition_") {
       size_t ordinal = std::stoll(function.substr(15));
       KOREAxiomDeclaration *axiom = d->Definition->getAxiomByOrdinal(ordinal);
@@ -297,9 +364,19 @@ void FunctionNode::codegen(Decision *d) {
     for (auto arg : args) {
       functionArgs.push_back(d->ptrTerm(arg));
     }
-    functionArgs.push_back(llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(d->Ctx)));
+    functionArgs.push_back(
+        llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(d->Ctx)));
 
-    auto call = llvm::CallInst::Create(getOrInsertFunction(d->Module, "addMatchFunction", llvm::FunctionType::get(llvm::Type::getVoidTy(d->Ctx), {llvm::Type::getInt8PtrTy(d->Ctx), llvm::Type::getInt8PtrTy(d->Ctx), llvm::Type::getInt8PtrTy(d->Ctx)}, true)), functionArgs, "", d->CurrentBlock);
+    auto call = llvm::CallInst::Create(
+        getOrInsertFunction(
+            d->Module, "addMatchFunction",
+            llvm::FunctionType::get(
+                llvm::Type::getVoidTy(d->Ctx),
+                {llvm::Type::getInt8PtrTy(d->Ctx),
+                 llvm::Type::getInt8PtrTy(d->Ctx),
+                 llvm::Type::getInt8PtrTy(d->Ctx)},
+                true)),
+        functionArgs, "", d->CurrentBlock);
     setDebugLoc(call);
   }
   child->codegen(d);
@@ -316,19 +393,23 @@ void MakeIteratorNode::codegen(Decision *d) {
   args.push_back(arg);
   types.push_back(arg->getType());
   llvm::Type *sretType = getTypeByName(d->Module, "iter");
-  llvm::Value *AllocSret = allocateTerm(sretType, d->CurrentBlock, "koreAllocAlwaysGC");
+  llvm::Value *AllocSret
+      = allocateTerm(sretType, d->CurrentBlock, "koreAllocAlwaysGC");
   AllocSret->setName(name.substr(0, max_name_length));
   args.insert(args.begin(), AllocSret);
   types.insert(types.begin(), AllocSret->getType());
 
-  llvm::FunctionType *funcType = llvm::FunctionType::get(llvm::Type::getVoidTy(d->Module->getContext()), types, false);
+  llvm::FunctionType *funcType = llvm::FunctionType::get(
+      llvm::Type::getVoidTy(d->Module->getContext()), types, false);
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
   auto call = llvm::CallInst::Create(func, args, "", d->CurrentBlock);
   setDebugLoc(call);
 #if __clang_major__ >= 12
-  llvm::Attribute sretAttr = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet, sretType);
+  llvm::Attribute sretAttr
+      = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet, sretType);
 #else
-  llvm::Attribute sretAttr = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet);
+  llvm::Attribute sretAttr
+      = llvm::Attribute::get(d->Ctx, llvm::Attribute::StructRet);
 #endif
   func->arg_begin()->addAttr(sretAttr);
   call->addParamAttr(0, sretAttr);
@@ -344,9 +425,12 @@ void IterNextNode::codegen(Decision *d) {
   d->ChoiceBlock = d->CurrentBlock;
   llvm::Value *arg = d->load(std::make_pair(iterator, iteratorType));
 
-  llvm::FunctionType *funcType = llvm::FunctionType::get(getValueType({SortCategory::Symbol, 0}, d->Module), {arg->getType()}, false);
+  llvm::FunctionType *funcType = llvm::FunctionType::get(
+      getValueType({SortCategory::Symbol, 0}, d->Module), {arg->getType()},
+      false);
   llvm::Function *func = getOrInsertFunction(d->Module, hookName, funcType);
-  auto Call = llvm::CallInst::Create(func, {arg}, binding.substr(0, max_name_length), d->CurrentBlock);
+  auto Call = llvm::CallInst::Create(
+      func, {arg}, binding.substr(0, max_name_length), d->CurrentBlock);
   setDebugLoc(Call);
   d->store(std::make_pair(binding, bindingType), Call);
   child->codegen(d);
@@ -359,7 +443,10 @@ void LeafNode::codegen(Decision *d) {
     return;
   }
   if (d->FailPattern) {
-    auto call = llvm::CallInst::Create(getOrInsertFunction(d->Module, "addMatchSuccess", llvm::Type::getVoidTy(d->Ctx)), {}, "", d->CurrentBlock);
+    auto call = llvm::CallInst::Create(
+        getOrInsertFunction(
+            d->Module, "addMatchSuccess", llvm::Type::getVoidTy(d->Ctx)),
+        {}, "", d->CurrentBlock);
     setDebugLoc(call);
     llvm::ReturnInst::Create(d->Ctx, d->CurrentBlock);
     setCompleted();
@@ -373,13 +460,28 @@ void LeafNode::codegen(Decision *d) {
     types.push_back(val->getType());
   }
   auto type = getParamType(d->Cat, d->Module);
-  auto Call = llvm::CallInst::Create(getOrInsertFunction(d->Module, name, llvm::FunctionType::get(type, types, false)), args, "", d->CurrentBlock);
+  auto Call = llvm::CallInst::Create(
+      getOrInsertFunction(
+          d->Module, name, llvm::FunctionType::get(type, types, false)),
+      args, "", d->CurrentBlock);
   setDebugLoc(Call);
   Call->setCallingConv(llvm::CallingConv::Fast);
   if (child == nullptr) {
     llvm::ReturnInst::Create(d->Ctx, Call, d->CurrentBlock);
-  } else {  
-    auto Call2 = llvm::CallInst::Create(getOrInsertFunction(d->Module, "addSearchResult", llvm::FunctionType::get(llvm::Type::getVoidTy(d->Ctx), {type, llvm::PointerType::getUnqual(llvm::PointerType::getUnqual(type)), llvm::Type::getInt64PtrTy(d->Ctx), llvm::Type::getInt64PtrTy(d->Ctx)}, false)), {Call, d->ResultBuffer, d->ResultCount, d->ResultCapacity}, "", d->CurrentBlock);
+  } else {
+    auto Call2 = llvm::CallInst::Create(
+        getOrInsertFunction(
+            d->Module, "addSearchResult",
+            llvm::FunctionType::get(
+                llvm::Type::getVoidTy(d->Ctx),
+                {type,
+                 llvm::PointerType::getUnqual(
+                     llvm::PointerType::getUnqual(type)),
+                 llvm::Type::getInt64PtrTy(d->Ctx),
+                 llvm::Type::getInt64PtrTy(d->Ctx)},
+                false)),
+        {Call, d->ResultBuffer, d->ResultCount, d->ResultCapacity}, "",
+        d->CurrentBlock);
     setDebugLoc(Call2);
     if (child != FailNode::get()) {
       child->codegen(d);
@@ -391,13 +493,19 @@ void LeafNode::codegen(Decision *d) {
 }
 
 llvm::Value *Decision::getTag(llvm::Value *val) {
-  auto res = llvm::CallInst::Create(getOrInsertFunction(Module, "getTag", llvm::Type::getInt32Ty(Ctx), getValueType({SortCategory::Symbol, 0}, Module)), val, "tag", CurrentBlock);
+  auto res = llvm::CallInst::Create(
+      getOrInsertFunction(
+          Module, "getTag", llvm::Type::getInt32Ty(Ctx),
+          getValueType({SortCategory::Symbol, 0}, Module)),
+      val, "tag", CurrentBlock);
   setDebugLoc(res);
   return res;
 }
 
 llvm::AllocaInst *Decision::decl(var_type name) {
-  auto sym = new llvm::AllocaInst(name.second, 0, "", this->CurrentBlock->getParent()->getEntryBlock().getFirstNonPHI());
+  auto sym = new llvm::AllocaInst(
+      name.second, 0, "",
+      this->CurrentBlock->getParent()->getEntryBlock().getFirstNonPHI());
   this->symbols[name] = sym;
   return sym;
 }
@@ -407,7 +515,9 @@ llvm::Value *Decision::load(var_type name) {
   if (!sym) {
     sym = this->decl(name);
   }
-  return new llvm::LoadInst(sym->getType()->getPointerElementType(), sym, name.first.substr(0, max_name_length), this->CurrentBlock);
+  return new llvm::LoadInst(
+      sym->getType()->getPointerElementType(), sym,
+      name.first.substr(0, max_name_length), this->CurrentBlock);
 }
 
 void Decision::store(var_type name, llvm::Value *val) {
@@ -421,42 +531,66 @@ void Decision::store(var_type name, llvm::Value *val) {
 llvm::Constant *Decision::stringLiteral(std::string str) {
   auto Str = llvm::ConstantDataArray::getString(Ctx, str, true);
   auto global = Module->getOrInsertGlobal("str_lit_" + str, Str->getType());
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  llvm::GlobalVariable *globalVar
+      = llvm::dyn_cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
-  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), globalVar, indices);
+  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+      Str->getType(), globalVar, indices);
   return Ptr;
 }
 
-static void initChoiceBuffer(DecisionNode *dt, llvm::Module *module, llvm::BasicBlock *block, llvm::BasicBlock *stuck, llvm::BasicBlock *fail, llvm::AllocaInst **choiceBufferOut, llvm::AllocaInst **choiceDepthOut, llvm::IndirectBrInst **jumpOut) {
+static void initChoiceBuffer(
+    DecisionNode *dt, llvm::Module *module, llvm::BasicBlock *block,
+    llvm::BasicBlock *stuck, llvm::BasicBlock *fail,
+    llvm::AllocaInst **choiceBufferOut, llvm::AllocaInst **choiceDepthOut,
+    llvm::IndirectBrInst **jumpOut) {
   std::unordered_set<LeafNode *> leaves;
   dt->preprocess(leaves);
-  auto ty = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
-  llvm::AllocaInst *choiceBuffer = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
-  llvm::AllocaInst *choiceDepth = new llvm::AllocaInst(llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
-  auto zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0);
+  auto ty = llvm::ArrayType::get(
+      llvm::Type::getInt8PtrTy(module->getContext()), dt->getChoiceDepth() + 1);
+  llvm::AllocaInst *choiceBuffer
+      = new llvm::AllocaInst(ty, 0, "choiceBuffer", block);
+  llvm::AllocaInst *choiceDepth = new llvm::AllocaInst(
+      llvm::Type::getInt64Ty(module->getContext()), 0, "choiceDepth", block);
+  auto zero
+      = llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0);
   new llvm::StoreInst(zero, choiceDepth, block);
-  auto firstElt = llvm::GetElementPtrInst::CreateInBounds(ty, choiceBuffer, {zero, zero}, "", block);
-  new llvm::StoreInst(llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
+  auto firstElt = llvm::GetElementPtrInst::CreateInBounds(
+      ty, choiceBuffer, {zero, zero}, "", block);
+  new llvm::StoreInst(
+      llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
 
-  llvm::LoadInst *currDepth = new llvm::LoadInst(choiceDepth->getType()->getPointerElementType(), choiceDepth, "", fail);
-  auto currentElt = llvm::GetElementPtrInst::CreateInBounds(ty, choiceBuffer, {zero, currDepth}, "", fail);
-  llvm::LoadInst *failAddress = new llvm::LoadInst(currentElt->getType()->getPointerElementType(), currentElt, "", fail);
-  auto newDepth = llvm::BinaryOperator::Create(llvm::Instruction::Sub, currDepth, llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1), "", fail);
+  llvm::LoadInst *currDepth = new llvm::LoadInst(
+      choiceDepth->getType()->getPointerElementType(), choiceDepth, "", fail);
+  auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
+      ty, choiceBuffer, {zero, currDepth}, "", fail);
+  llvm::LoadInst *failAddress = new llvm::LoadInst(
+      currentElt->getType()->getPointerElementType(), currentElt, "", fail);
+  auto newDepth = llvm::BinaryOperator::Create(
+      llvm::Instruction::Sub, currDepth,
+      llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1),
+      "", fail);
   new llvm::StoreInst(newDepth, choiceDepth, fail);
-  llvm::IndirectBrInst *jump = llvm::IndirectBrInst::Create(failAddress, 1, fail);
+  llvm::IndirectBrInst *jump
+      = llvm::IndirectBrInst::Create(failAddress, 1, fail);
   jump->addDestination(stuck);
   *choiceBufferOut = choiceBuffer;
   *choiceDepthOut = choiceDepth;
   *jumpOut = jump;
 }
 
-
-void makeEvalOrAnywhereFunction(KORESymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt, void (*addStuck)(llvm::BasicBlock*, llvm::Module*, KORESymbol *, Decision&, KOREDefinition *)) {
-  auto returnSort = dynamic_cast<KORECompositeSort *>(function->getSort().get())->getCategory(definition);
+void makeEvalOrAnywhereFunction(
+    KORESymbol *function, KOREDefinition *definition, llvm::Module *module,
+    DecisionNode *dt,
+    void (*addStuck)(
+        llvm::BasicBlock *, llvm::Module *, KORESymbol *, Decision &,
+        KOREDefinition *)) {
+  auto returnSort = dynamic_cast<KORECompositeSort *>(function->getSort().get())
+                        ->getCategory(definition);
   auto returnType = getParamType(returnSort, module);
   std::ostringstream Out;
   function->getSort()->print(Out);
@@ -465,7 +599,8 @@ void makeEvalOrAnywhereFunction(KORESymbol *function, KOREDefinition *definition
   std::vector<llvm::Metadata *> debugArgs;
   std::vector<ValueType> cats;
   for (auto &sort : function->getArguments()) {
-    auto cat = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(definition);
+    auto cat = dynamic_cast<KORECompositeSort *>(sort.get())
+                   ->getCategory(definition);
     std::ostringstream Out;
     sort->print(Out);
     debugArgs.push_back(getDebugType(cat, Out.str()));
@@ -482,27 +617,38 @@ void makeEvalOrAnywhereFunction(KORESymbol *function, KOREDefinition *definition
       break;
     }
   }
-  llvm::FunctionType *funcType = llvm::FunctionType::get(returnType, args, false);
+  llvm::FunctionType *funcType
+      = llvm::FunctionType::get(returnType, args, false);
   std::ostringstream Out2;
   function->print(Out2, 0, false);
   std::string name = "eval_" + Out2.str();
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
-  KORESymbolDeclaration *symbolDecl = definition->getSymbolDeclarations().at(function->getName());
+  KORESymbolDeclaration *symbolDecl
+      = definition->getSymbolDeclarations().at(function->getName());
   initDebugAxiom(symbolDecl->getAttributes());
-  initDebugFunction(function->getName(), name, getDebugFunctionType(debugReturnType, debugArgs), definition, matchFunc);
+  initDebugFunction(
+      function->getName(), name,
+      getDebugFunctionType(debugReturnType, debugArgs), definition, matchFunc);
   matchFunc->setCallingConv(llvm::CallingConv::Fast);
-  llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
-  llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
-  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::BasicBlock *block
+      = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
+  llvm::BasicBlock *stuck
+      = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  llvm::BasicBlock *fail
+      = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
   llvm::AllocaInst *choiceBuffer, *choiceDepth;
   llvm::IndirectBrInst *jump;
-  initChoiceBuffer(dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
+  initChoiceBuffer(
+      dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
   int i = 0;
-  Decision codegen(definition, block, fail, jump, choiceBuffer, choiceDepth, module, returnSort, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
-  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end(); ++val, ++i) {
-    val->setName("_" + std::to_string(i+1));
+  Decision codegen(
+      definition, block, fail, jump, choiceBuffer, choiceDepth, module,
+      returnSort, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end();
+       ++val, ++i) {
+    val->setName("_" + std::to_string(i + 1));
     codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
     std::ostringstream Out;
     function->getArguments()[i]->print(Out);
@@ -513,89 +659,135 @@ void makeEvalOrAnywhereFunction(KORESymbol *function, KOREDefinition *definition
   codegen(dt);
 }
 
-void abortWhenStuck(llvm::BasicBlock *CurrentBlock, llvm::Module *Module, KORESymbol *symbol, Decision &codegen, KOREDefinition *d) {
+void abortWhenStuck(
+    llvm::BasicBlock *CurrentBlock, llvm::Module *Module, KORESymbol *symbol,
+    Decision &codegen, KOREDefinition *d) {
   auto &Ctx = Module->getContext();
   std::ostringstream Out;
   symbol->print(Out);
   symbol = d->getAllSymbols().at(Out.str());
   auto BlockType = getBlockType(Module, d, symbol);
   llvm::Value *Ptr;
-  auto BlockPtr = llvm::PointerType::getUnqual(getTypeByName(Module, BLOCK_STRUCT));
+  auto BlockPtr
+      = llvm::PointerType::getUnqual(getTypeByName(Module, BLOCK_STRUCT));
   if (symbol->getArguments().empty()) {
-    Ptr = llvm::ConstantExpr::getIntToPtr(llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), ((uint64_t)symbol->getTag() << 32 | 1)), getValueType({SortCategory::Symbol, 0}, Module));
+    Ptr = llvm::ConstantExpr::getIntToPtr(
+        llvm::ConstantInt::get(
+            llvm::Type::getInt64Ty(Ctx),
+            ((uint64_t)symbol->getTag() << 32 | 1)),
+        getValueType({SortCategory::Symbol, 0}, Module));
   } else {
     llvm::Value *BlockHeader = getBlockHeader(Module, d, symbol, BlockType);
     llvm::Value *Block = allocateTerm(BlockType, CurrentBlock);
-    llvm::Value *BlockHeaderPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Block, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0)}, symbol->getName(), CurrentBlock);
+    llvm::Value *BlockHeaderPtr = llvm::GetElementPtrInst::CreateInBounds(
+        BlockType, Block,
+        {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0),
+         llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0)},
+        symbol->getName(), CurrentBlock);
     new llvm::StoreInst(BlockHeader, BlockHeaderPtr, CurrentBlock);
     for (int idx = 0; idx < symbol->getArguments().size(); idx++) {
-      auto cat = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[idx].get())->getCategory(d);
+      auto cat
+          = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[idx].get())
+                ->getCategory(d);
       auto type = getParamType(cat, Module);
-      llvm::Value *ChildValue = codegen.load(std::make_pair("_" + std::to_string(idx+1), type));
-      llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, Block, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx + 2)}, "", CurrentBlock);
+      llvm::Value *ChildValue
+          = codegen.load(std::make_pair("_" + std::to_string(idx + 1), type));
+      llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(
+          BlockType, Block,
+          {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0),
+           llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx + 2)},
+          "", CurrentBlock);
       if (ChildValue->getType() == ChildPtr->getType()) {
-        ChildValue = new llvm::LoadInst(ChildValue->getType()->getPointerElementType(), ChildValue, "", CurrentBlock);
+        ChildValue = new llvm::LoadInst(
+            ChildValue->getType()->getPointerElementType(), ChildValue, "",
+            CurrentBlock);
       }
       new llvm::StoreInst(ChildValue, ChildPtr, CurrentBlock);
     }
     Ptr = new llvm::BitCastInst(Block, BlockPtr, "", CurrentBlock);
   }
-  llvm::CallInst::Create(getOrInsertFunction(Module, "finish_rewriting", llvm::Type::getVoidTy(Ctx), BlockPtr, llvm::Type::getInt1Ty(Ctx)), {Ptr, llvm::ConstantInt::getTrue(Ctx)}, "", CurrentBlock);
+  llvm::CallInst::Create(
+      getOrInsertFunction(
+          Module, "finish_rewriting", llvm::Type::getVoidTy(Ctx), BlockPtr,
+          llvm::Type::getInt1Ty(Ctx)),
+      {Ptr, llvm::ConstantInt::getTrue(Ctx)}, "", CurrentBlock);
   new llvm::UnreachableInst(Ctx, CurrentBlock);
 }
 
-void makeEvalFunction(KORESymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt) {
+void makeEvalFunction(
+    KORESymbol *function, KOREDefinition *definition, llvm::Module *module,
+    DecisionNode *dt) {
   makeEvalOrAnywhereFunction(function, definition, module, dt, abortWhenStuck);
 }
 
-void addOwise(llvm::BasicBlock *stuck, llvm::Module *module, KORESymbol *symbol, Decision &codegen, KOREDefinition *d) {
+void addOwise(
+    llvm::BasicBlock *stuck, llvm::Module *module, KORESymbol *symbol,
+    Decision &codegen, KOREDefinition *d) {
   llvm::StringMap<llvm::Value *> finalSubst;
   ptr<KORECompositePattern> pat = KORECompositePattern::Create(symbol);
   for (int i = 0; i < symbol->getArguments().size(); i++) {
-    auto cat = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[i].get())->getCategory(d);
+    auto cat
+        = dynamic_cast<KORECompositeSort *>(symbol->getArguments()[i].get())
+              ->getCategory(d);
     auto type = getParamType(cat, module);
 
-    std::string name = "_" + std::to_string(i+1);
+    std::string name = "_" + std::to_string(i + 1);
     finalSubst[name] = codegen.load(std::make_pair(name, type));
- 
+
     auto var = KOREVariablePattern::Create(name, symbol->getArguments()[i]);
     pat->addArgument(std::move(var));
   }
   CreateTerm creator = CreateTerm(finalSubst, d, stuck, module, true);
   llvm::Value *retval = creator(pat.get()).first;
-  auto returnSort = dynamic_cast<KORECompositeSort *>(symbol->getSort().get())->getCategory(d);
+  auto returnSort = dynamic_cast<KORECompositeSort *>(symbol->getSort().get())
+                        ->getCategory(d);
   auto returnType = getValueType(returnSort, module);
-  switch(returnSort.cat) {
+  switch (returnSort.cat) {
   case SortCategory::Map:
   case SortCategory::List:
   case SortCategory::Set:
     if (retval->getType() == returnType) {
-      auto tempAlloc = allocateTerm(retval->getType(), creator.getCurrentBlock(), "koreAllocAlwaysGC");
+      auto tempAlloc = allocateTerm(
+          retval->getType(), creator.getCurrentBlock(), "koreAllocAlwaysGC");
       new llvm::StoreInst(retval, tempAlloc, creator.getCurrentBlock());
       retval = tempAlloc;
     }
     break;
-  default:
-    break;
+  default: break;
   }
-  llvm::ReturnInst::Create(module->getContext(), retval, creator.getCurrentBlock());
+  llvm::ReturnInst::Create(
+      module->getContext(), retval, creator.getCurrentBlock());
 }
 
-void makeAnywhereFunction(KORESymbol *function, KOREDefinition *definition, llvm::Module *module, DecisionNode *dt) {
+void makeAnywhereFunction(
+    KORESymbol *function, KOREDefinition *definition, llvm::Module *module,
+    DecisionNode *dt) {
   makeEvalOrAnywhereFunction(function, definition, module, dt, addOwise);
 }
 
-std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(unsigned ordinal, llvm::Module *module, KOREDefinition *definition, llvm::BasicBlock *block, llvm::BasicBlock *stuck, std::vector<llvm::Value *> args, std::vector<ValueType> types) {
-  auto finished = getOrInsertFunction(module, "finished_rewriting", llvm::FunctionType::get(llvm::Type::getInt1Ty(module->getContext()), {}, false));
+std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
+    unsigned ordinal, llvm::Module *module, KOREDefinition *definition,
+    llvm::BasicBlock *block, llvm::BasicBlock *stuck,
+    std::vector<llvm::Value *> args, std::vector<ValueType> types) {
+  auto finished = getOrInsertFunction(
+      module, "finished_rewriting",
+      llvm::FunctionType::get(
+          llvm::Type::getInt1Ty(module->getContext()), {}, false));
   auto isFinished = llvm::CallInst::Create(finished, {}, "", block);
-  auto checkCollect = llvm::BasicBlock::Create(module->getContext(), "checkCollect", block->getParent());
+  auto checkCollect = llvm::BasicBlock::Create(
+      module->getContext(), "checkCollect", block->getParent());
   llvm::BranchInst::Create(stuck, checkCollect, isFinished, block);
 
-  auto collection = getOrInsertFunction(module, "is_collection", llvm::FunctionType::get(llvm::Type::getInt1Ty(module->getContext()), {}, false));
+  auto collection = getOrInsertFunction(
+      module, "is_collection",
+      llvm::FunctionType::get(
+          llvm::Type::getInt1Ty(module->getContext()), {}, false));
   auto isCollection = llvm::CallInst::Create(collection, {}, "", checkCollect);
   setDebugLoc(isCollection);
-  auto collect = llvm::BasicBlock::Create(module->getContext(), "isCollect", block->getParent());
-  auto merge = llvm::BasicBlock::Create(module->getContext(), "step", block->getParent());
+  auto collect = llvm::BasicBlock::Create(
+      module->getContext(), "isCollect", block->getParent());
+  auto merge = llvm::BasicBlock::Create(
+      module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(collect, merge, isCollection, checkCollect);
 
   unsigned nroots = 0;
@@ -603,74 +795,105 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(uns
   std::vector<llvm::Type *> ptrTypes;
   std::vector<llvm::Value *> roots;
   for (auto type : types) {
-    switch(type.cat) {
-      case SortCategory::Map:
-      case SortCategory::List:
-      case SortCategory::Set:
-        nroots++;
-        ptrTypes.push_back(llvm::PointerType::getUnqual(getValueType(type, module)));
-        roots.push_back(args[i]);
-        break;
-      case SortCategory::Int:
-      case SortCategory::Float:
-      case SortCategory::StringBuffer:
-      case SortCategory::Symbol:
-      case SortCategory::Variable:
-        nroots++;
-        ptrTypes.push_back(getValueType(type, module));
-        roots.push_back(args[i]);
-        break;
-      case SortCategory::Bool:
-      case SortCategory::MInt:
-        break;
-      case SortCategory::Uncomputed:
-        abort();
+    switch (type.cat) {
+    case SortCategory::Map:
+    case SortCategory::List:
+    case SortCategory::Set:
+      nroots++;
+      ptrTypes.push_back(
+          llvm::PointerType::getUnqual(getValueType(type, module)));
+      roots.push_back(args[i]);
+      break;
+    case SortCategory::Int:
+    case SortCategory::Float:
+    case SortCategory::StringBuffer:
+    case SortCategory::Symbol:
+    case SortCategory::Variable:
+      nroots++;
+      ptrTypes.push_back(getValueType(type, module));
+      roots.push_back(args[i]);
+      break;
+    case SortCategory::Bool:
+    case SortCategory::MInt: break;
+    case SortCategory::Uncomputed: abort();
     }
     i++;
   }
-  auto arr = module->getOrInsertGlobal("gc_roots", llvm::ArrayType::get(llvm::Type::getInt8PtrTy(module->getContext()), 256));
+  auto arr = module->getOrInsertGlobal(
+      "gc_roots", llvm::ArrayType::get(
+                      llvm::Type::getInt8PtrTy(module->getContext()), 256));
   std::vector<llvm::Value *> rootPtrs;
   for (unsigned i = 0; i < nroots; i++) {
-    auto ptr = llvm::GetElementPtrInst::CreateInBounds(llvm::dyn_cast<llvm::PointerType>(arr->getType())->getElementType(), arr, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0), llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), i)}, "", collect);
-    auto casted = new llvm::BitCastInst(ptr, llvm::PointerType::getUnqual(ptrTypes[i]), "", collect);
+    auto ptr = llvm::GetElementPtrInst::CreateInBounds(
+        llvm::dyn_cast<llvm::PointerType>(arr->getType())->getElementType(),
+        arr,
+        {llvm::ConstantInt::get(
+             llvm::Type::getInt64Ty(module->getContext()), 0),
+         llvm::ConstantInt::get(
+             llvm::Type::getInt64Ty(module->getContext()), i)},
+        "", collect);
+    auto casted = new llvm::BitCastInst(
+        ptr, llvm::PointerType::getUnqual(ptrTypes[i]), "", collect);
     new llvm::StoreInst(roots[i], casted, collect);
     rootPtrs.push_back(casted);
   }
   std::vector<llvm::Constant *> elements;
   i = 0;
   for (auto cat : types) {
-    switch(cat.cat) {
-      case SortCategory::Map:
-      case SortCategory::List:
-      case SortCategory::Set:
-      case SortCategory::StringBuffer:
-      case SortCategory::Symbol:
-      case SortCategory::Variable:
-      case SortCategory::Int:
-      case SortCategory::Float:
-        elements.push_back(llvm::ConstantStruct::get(getTypeByName(module, LAYOUTITEM_STRUCT), llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), i++ * 8), llvm::ConstantInt::get(llvm::Type::getInt16Ty(module->getContext()), (int)cat.cat + cat.bits)));
-        break;
-      case SortCategory::Bool:
-      case SortCategory::MInt:
-        break;
-      case SortCategory::Uncomputed:
-        abort();
+    switch (cat.cat) {
+    case SortCategory::Map:
+    case SortCategory::List:
+    case SortCategory::Set:
+    case SortCategory::StringBuffer:
+    case SortCategory::Symbol:
+    case SortCategory::Variable:
+    case SortCategory::Int:
+    case SortCategory::Float:
+      elements.push_back(llvm::ConstantStruct::get(
+          getTypeByName(module, LAYOUTITEM_STRUCT),
+          llvm::ConstantInt::get(
+              llvm::Type::getInt64Ty(module->getContext()), i++ * 8),
+          llvm::ConstantInt::get(
+              llvm::Type::getInt16Ty(module->getContext()),
+              (int)cat.cat + cat.bits)));
+      break;
+    case SortCategory::Bool:
+    case SortCategory::MInt: break;
+    case SortCategory::Uncomputed: abort();
     }
   }
-  auto layoutArr = llvm::ConstantArray::get(llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), elements.size()), elements);
-  auto layout = module->getOrInsertGlobal("layout_item_rule_" + std::to_string(ordinal), layoutArr->getType());
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(layout);
+  auto layoutArr = llvm::ConstantArray::get(
+      llvm::ArrayType::get(
+          getTypeByName(module, LAYOUTITEM_STRUCT), elements.size()),
+      elements);
+  auto layout = module->getOrInsertGlobal(
+      "layout_item_rule_" + std::to_string(ordinal), layoutArr->getType());
+  llvm::GlobalVariable *globalVar
+      = llvm::dyn_cast<llvm::GlobalVariable>(layout);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(layoutArr);
   }
-  auto ptrTy = llvm::PointerType::getUnqual(llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), 0));
-  auto koreCollect = getOrInsertFunction(module, "koreCollect", llvm::FunctionType::get(llvm::Type::getVoidTy(module->getContext()), {arr->getType(), llvm::Type::getInt8Ty(module->getContext()), ptrTy}, false));
-  auto call = llvm::CallInst::Create(koreCollect, {arr, llvm::ConstantInt::get(llvm::Type::getInt8Ty(module->getContext()), nroots), llvm::ConstantExpr::getBitCast(layout, ptrTy)}, "", collect);
+  auto ptrTy = llvm::PointerType::getUnqual(
+      llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), 0));
+  auto koreCollect = getOrInsertFunction(
+      module, "koreCollect",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(module->getContext()),
+          {arr->getType(), llvm::Type::getInt8Ty(module->getContext()), ptrTy},
+          false));
+  auto call = llvm::CallInst::Create(
+      koreCollect,
+      {arr,
+       llvm::ConstantInt::get(
+           llvm::Type::getInt8Ty(module->getContext()), nroots),
+       llvm::ConstantExpr::getBitCast(layout, ptrTy)},
+      "", collect);
   setDebugLoc(call);
   i = 0;
   std::vector<llvm::Value *> phis;
   for (auto ptr : rootPtrs) {
-    auto loaded = new llvm::LoadInst(ptr->getType()->getPointerElementType(), ptr, "", collect);
+    auto loaded = new llvm::LoadInst(
+        ptr->getType()->getPointerElementType(), ptr, "", collect);
     auto phi = llvm::PHINode::Create(loaded->getType(), 2, "phi", merge);
     phi->addIncoming(loaded, collect);
     phi->addIncoming(roots[i++], checkCollect);
@@ -681,34 +904,36 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(uns
   unsigned rootIdx = 0;
   std::vector<llvm::Value *> results;
   for (auto type : types) {
-    switch(type.cat) {
-      case SortCategory::Map:
-      case SortCategory::List:
-      case SortCategory::Set:
-      case SortCategory::StringBuffer:
-      case SortCategory::Symbol:
-      case SortCategory::Variable:
-      case SortCategory::Int:
-      case SortCategory::Float:
-        results.push_back(phis[rootIdx++]);
-        break;
-      default:
-        results.push_back(args[i]);
+    switch (type.cat) {
+    case SortCategory::Map:
+    case SortCategory::List:
+    case SortCategory::Set:
+    case SortCategory::StringBuffer:
+    case SortCategory::Symbol:
+    case SortCategory::Variable:
+    case SortCategory::Int:
+    case SortCategory::Float: results.push_back(phis[rootIdx++]); break;
+    default: results.push_back(args[i]);
     }
     i++;
   }
   return std::make_pair(results, merge);
 }
 
-void makeStepFunction(KOREDefinition *definition, llvm::Module *module, DecisionNode *dt, bool search) {
+void makeStepFunction(
+    KOREDefinition *definition, llvm::Module *module, DecisionNode *dt,
+    bool search) {
   auto blockType = getValueType({SortCategory::Symbol, 0}, module);
   auto bufType = llvm::PointerType::getUnqual(blockType);
-  auto debugType = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
+  auto debugType
+      = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   llvm::FunctionType *funcType;
   std::string name;
   if (search) {
     name = "stepAll";
-    funcType = llvm::FunctionType::get(bufType, {blockType, llvm::Type::getInt64PtrTy(module->getContext())}, false);
+    funcType = llvm::FunctionType::get(
+        bufType, {blockType, llvm::Type::getInt64PtrTy(module->getContext())},
+        false);
   } else {
     name = "step";
     funcType = llvm::FunctionType::get(blockType, {blockType}, false);
@@ -716,45 +941,74 @@ void makeStepFunction(KOREDefinition *definition, llvm::Module *module, Decision
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   resetDebugLoc();
   if (search) {
-    initDebugFunction(name, name, getDebugFunctionType(getPointerDebugType(debugType, "block **"), {debugType, getPointerDebugType(getLongDebugType(), "uint64_t *")}), definition, matchFunc);
+    initDebugFunction(
+        name, name,
+        getDebugFunctionType(
+            getPointerDebugType(debugType, "block **"),
+            {debugType, getPointerDebugType(getLongDebugType(), "uint64_t *")}),
+        definition, matchFunc);
   } else {
-    initDebugFunction(name, name, getDebugFunctionType(debugType, {debugType}), definition, matchFunc);
+    initDebugFunction(
+        name, name, getDebugFunctionType(debugType, {debugType}), definition,
+        matchFunc);
   }
   matchFunc->setCallingConv(llvm::CallingConv::Fast);
   auto val = matchFunc->arg_begin();
-  llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
-  llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
-  llvm::BasicBlock *pre_stuck = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
-  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::BasicBlock *block
+      = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
+  llvm::BasicBlock *stuck
+      = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  llvm::BasicBlock *pre_stuck
+      = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
+  llvm::BasicBlock *fail
+      = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
   llvm::AllocaInst *choiceBuffer, *choiceDepth;
   llvm::IndirectBrInst *jump;
 
-  llvm::Value *resultBuffer = nullptr, *resultCount = nullptr, *resultCapacity = nullptr;
+  llvm::Value *resultBuffer = nullptr, *resultCount = nullptr,
+              *resultCapacity = nullptr;
   if (search) {
     resultBuffer = new llvm::AllocaInst(bufType, 0, "resultBuffer", block);
     resultCount = matchFunc->arg_begin() + 1;
-    resultCapacity = new llvm::AllocaInst(llvm::Type::getInt64Ty(module->getContext()), 0, "resultCapacity", block);
-    llvm::Value *initialBuffer = allocateTerm(blockType, block, "koreAllocAlwaysGC");
+    resultCapacity = new llvm::AllocaInst(
+        llvm::Type::getInt64Ty(module->getContext()), 0, "resultCapacity",
+        block);
+    llvm::Value *initialBuffer
+        = allocateTerm(blockType, block, "koreAllocAlwaysGC");
     new llvm::StoreInst(initialBuffer, resultBuffer, block);
-    new llvm::StoreInst(llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0), resultCount, block);
-    new llvm::StoreInst(llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1), resultCapacity, block);
+    new llvm::StoreInst(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 0),
+        resultCount, block);
+    new llvm::StoreInst(
+        llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1),
+        resultCapacity, block);
   }
- 
-  initChoiceBuffer(dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
-  initDebugParam(matchFunc, 0, "subject", {SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
+  initChoiceBuffer(
+      dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
+
+  initDebugParam(
+      matchFunc, 0, "subject", {SortCategory::Symbol, 0},
+      "SortGeneratedTopCell{}");
   llvm::BranchInst::Create(stuck, pre_stuck);
-  auto result = stepFunctionHeader(0, module, definition, block, stuck, {val}, {{SortCategory::Symbol, 0}});
+  auto result = stepFunctionHeader(
+      0, module, definition, block, stuck, {val}, {{SortCategory::Symbol, 0}});
   auto collectedVal = result.first[0];
   collectedVal->setName("_1");
-  Decision codegen(definition, result.second, fail, jump, choiceBuffer, choiceDepth, module, {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, resultBuffer, resultCount, resultCapacity);
-  codegen.store(std::make_pair(collectedVal->getName().str(), collectedVal->getType()), collectedVal);
+  Decision codegen(
+      definition, result.second, fail, jump, choiceBuffer, choiceDepth, module,
+      {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, resultBuffer,
+      resultCount, resultCapacity);
+  codegen.store(
+      std::make_pair(collectedVal->getName().str(), collectedVal->getType()),
+      collectedVal);
   if (search) {
     auto result = new llvm::LoadInst(bufType, resultBuffer, "", stuck);
     llvm::ReturnInst::Create(module->getContext(), result, stuck);
-  }  else {
-    auto phi = llvm::PHINode::Create(collectedVal->getType(), 2, "phi_1", stuck);
+  } else {
+    auto phi
+        = llvm::PHINode::Create(collectedVal->getType(), 2, "phi_1", stuck);
     phi->addIncoming(val, block);
     phi->addIncoming(collectedVal, pre_stuck);
     llvm::ReturnInst::Create(module->getContext(), phi, stuck);
@@ -763,55 +1017,84 @@ void makeStepFunction(KOREDefinition *definition, llvm::Module *module, Decision
   codegen(dt);
 }
 
-void makeMatchReasonFunction(KOREDefinition *definition, llvm::Module *module, KOREAxiomDeclaration *axiom, DecisionNode *dt) {
+void makeMatchReasonFunction(
+    KOREDefinition *definition, llvm::Module *module,
+    KOREAxiomDeclaration *axiom, DecisionNode *dt) {
   auto blockType = getValueType({SortCategory::Symbol, 0}, module);
-  llvm::FunctionType *funcType = llvm::FunctionType::get(llvm::Type::getVoidTy(module->getContext()), {blockType}, false);
+  llvm::FunctionType *funcType = llvm::FunctionType::get(
+      llvm::Type::getVoidTy(module->getContext()), {blockType}, false);
   std::string name = "match_" + std::to_string(axiom->getOrdinal());
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   std::string debugName = name;
   if (axiom->getAttributes().count("label")) {
     debugName = axiom->getStringAttribute("label") + ".match";
   }
-  auto debugType = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
+  auto debugType
+      = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
   resetDebugLoc();
-  initDebugFunction(debugName, debugName, getDebugFunctionType(getVoidDebugType(), {debugType}), definition, matchFunc);
+  initDebugFunction(
+      debugName, debugName,
+      getDebugFunctionType(getVoidDebugType(), {debugType}), definition,
+      matchFunc);
   matchFunc->setCallingConv(llvm::CallingConv::Fast);
   auto val = matchFunc->arg_begin();
-  llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
-  llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
-  llvm::BasicBlock *pre_stuck = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
-  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
-  llvm::PHINode *FailSubject = llvm::PHINode::Create(llvm::Type::getInt8PtrTy(module->getContext()), 0, "subject", fail);
-  llvm::PHINode *FailPattern = llvm::PHINode::Create(llvm::Type::getInt8PtrTy(module->getContext()), 0, "pattern", fail);
-  llvm::PHINode *FailSort = llvm::PHINode::Create(llvm::Type::getInt8PtrTy(module->getContext()), 0, "sort", fail);
-  auto call = llvm::CallInst::Create(getOrInsertFunction(module, "addMatchFailReason", llvm::FunctionType::get(llvm::Type::getVoidTy(module->getContext()), {FailSubject->getType(), FailPattern->getType(), FailSort->getType()}, false)), {FailSubject, FailPattern, FailSort}, "", fail);
+  llvm::BasicBlock *block
+      = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
+  llvm::BasicBlock *stuck
+      = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  llvm::BasicBlock *pre_stuck
+      = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
+  llvm::BasicBlock *fail
+      = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::PHINode *FailSubject = llvm::PHINode::Create(
+      llvm::Type::getInt8PtrTy(module->getContext()), 0, "subject", fail);
+  llvm::PHINode *FailPattern = llvm::PHINode::Create(
+      llvm::Type::getInt8PtrTy(module->getContext()), 0, "pattern", fail);
+  llvm::PHINode *FailSort = llvm::PHINode::Create(
+      llvm::Type::getInt8PtrTy(module->getContext()), 0, "sort", fail);
+  auto call = llvm::CallInst::Create(
+      getOrInsertFunction(
+          module, "addMatchFailReason",
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(module->getContext()),
+              {FailSubject->getType(), FailPattern->getType(),
+               FailSort->getType()},
+              false)),
+      {FailSubject, FailPattern, FailSort}, "", fail);
   setDebugLoc(call);
 
   llvm::AllocaInst *choiceBuffer, *choiceDepth;
   llvm::IndirectBrInst *jump;
-  initChoiceBuffer(dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
+  initChoiceBuffer(
+      dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
-  initDebugParam(matchFunc, 0, "subject", {SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
+  initDebugParam(
+      matchFunc, 0, "subject", {SortCategory::Symbol, 0},
+      "SortGeneratedTopCell{}");
   llvm::BranchInst::Create(stuck, pre_stuck);
   val->setName("_1");
-  Decision codegen(definition, block, fail, jump, choiceBuffer, choiceDepth, module, {SortCategory::Symbol, 0}, FailSubject, FailPattern, FailSort, nullptr, nullptr, nullptr);
+  Decision codegen(
+      definition, block, fail, jump, choiceBuffer, choiceDepth, module,
+      {SortCategory::Symbol, 0}, FailSubject, FailPattern, FailSort, nullptr,
+      nullptr, nullptr);
   codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
   llvm::ReturnInst::Create(module->getContext(), stuck);
 
   codegen(dt);
 }
 
-
-
 // TODO: actually collect the return value of this function. Right now it
 // assumes that it will never be collected and constructs a unique_ptr pointing
 // to the return value of the recursive call. This is not really safe if the
-// object actually gets collected because it's possible for the return value of the
-// recursive call to actually be owned by the axiom that it is a part of. However,
-// since we then immediately call release on the pointer and never free it, it should be
-// safe, it will just leak memory. But we don't really care that much about memory leaks
-// in the compiler right now, so it's probably fine.
-KOREPattern *makePartialTerm(KOREPattern *term, std::set<std::string> occurrences, std::string occurrence) {
+// object actually gets collected because it's possible for the return value of
+// the recursive call to actually be owned by the axiom that it is a part of.
+// However, since we then immediately call release on the pointer and never free
+// it, it should be safe, it will just leak memory. But we don't really care
+// that much about memory leaks in the compiler right now, so it's probably
+// fine.
+KOREPattern *makePartialTerm(
+    KOREPattern *term, std::set<std::string> occurrences,
+    std::string occurrence) {
   if (occurrences.count(occurrence)) {
     return KOREVariablePattern::Create(occurrence, term->getSort()).release();
   }
@@ -819,21 +1102,27 @@ KOREPattern *makePartialTerm(KOREPattern *term, std::set<std::string> occurrence
     if (pat->getConstructor()->getName() == "\\dv") {
       return term;
     }
-    ptr<KORECompositePattern> result = KORECompositePattern::Create(pat->getConstructor());
+    ptr<KORECompositePattern> result
+        = KORECompositePattern::Create(pat->getConstructor());
     for (unsigned i = 0; i < pat->getArguments().size(); i++) {
-      result->addArgument(ptr<KOREPattern>(makePartialTerm(dynamic_cast<KOREPattern *>(pat->getArguments()[i].get()), occurrences, "_" + std::to_string(i) + occurrence)));
+      result->addArgument(ptr<KOREPattern>(makePartialTerm(
+          dynamic_cast<KOREPattern *>(pat->getArguments()[i].get()),
+          occurrences, "_" + std::to_string(i) + occurrence)));
     }
     return result.release();
   }
   abort();
 }
 
-void makeStepFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, llvm::Module *module, PartialStep res) {
+void makeStepFunction(
+    KOREAxiomDeclaration *axiom, KOREDefinition *definition,
+    llvm::Module *module, PartialStep res) {
   auto blockType = getValueType({SortCategory::Symbol, 0}, module);
   std::vector<llvm::Type *> argTypes;
   std::vector<llvm::Metadata *> debugTypes;
   for (auto res : res.residuals) {
-    auto argSort = dynamic_cast<KORECompositeSort *>(res.pattern->getSort().get());
+    auto argSort
+        = dynamic_cast<KORECompositeSort *>(res.pattern->getSort().get());
     auto cat = argSort->getCategory(definition);
     std::ostringstream Out;
     argSort->print(Out);
@@ -842,51 +1131,67 @@ void makeStepFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, l
     case SortCategory::Map:
     case SortCategory::List:
     case SortCategory::Set:
-      argTypes.push_back(llvm::PointerType::getUnqual(getValueType(cat, module)));
+      argTypes.push_back(
+          llvm::PointerType::getUnqual(getValueType(cat, module)));
       break;
-    default:
-      argTypes.push_back(getValueType(cat, module));
-      break;
+    default: argTypes.push_back(getValueType(cat, module)); break;
     }
   }
-  auto blockDebugType = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
-  llvm::FunctionType *funcType = llvm::FunctionType::get(blockType, argTypes, false);
+  auto blockDebugType
+      = getDebugType({SortCategory::Symbol, 0}, "SortGeneratedTopCell{}");
+  llvm::FunctionType *funcType
+      = llvm::FunctionType::get(blockType, argTypes, false);
   std::string name = "step_" + std::to_string(axiom->getOrdinal());
   llvm::Function *matchFunc = getOrInsertFunction(module, name, funcType);
   resetDebugLoc();
-  initDebugFunction(name, name, getDebugFunctionType(blockDebugType, debugTypes), definition, matchFunc);
+  initDebugFunction(
+      name, name, getDebugFunctionType(blockDebugType, debugTypes), definition,
+      matchFunc);
   matchFunc->setCallingConv(llvm::CallingConv::Fast);
 
   llvm::StringMap<llvm::Value *> stuckSubst;
-  llvm::BasicBlock *block = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
-  llvm::BasicBlock *stuck = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
-  llvm::BasicBlock *pre_stuck = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
-  llvm::BasicBlock *fail = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
+  llvm::BasicBlock *block
+      = llvm::BasicBlock::Create(module->getContext(), "entry", matchFunc);
+  llvm::BasicBlock *stuck
+      = llvm::BasicBlock::Create(module->getContext(), "stuck", matchFunc);
+  llvm::BasicBlock *pre_stuck
+      = llvm::BasicBlock::Create(module->getContext(), "pre_stuck", matchFunc);
+  llvm::BasicBlock *fail
+      = llvm::BasicBlock::Create(module->getContext(), "fail", matchFunc);
 
   llvm::AllocaInst *choiceBuffer, *choiceDepth;
   llvm::IndirectBrInst *jump;
-  initChoiceBuffer(res.dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth, &jump);
+  initChoiceBuffer(
+      res.dt, module, block, pre_stuck, fail, &choiceBuffer, &choiceDepth,
+      &jump);
 
   llvm::BranchInst::Create(stuck, pre_stuck);
   std::vector<llvm::PHINode *> phis;
   int i = 0;
   std::vector<llvm::Value *> args;
   std::vector<ValueType> types;
-  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end(); ++val, ++i) {
+  for (auto val = matchFunc->arg_begin(); val != matchFunc->arg_end();
+       ++val, ++i) {
     args.push_back(val);
-    auto phi = llvm::PHINode::Create(val->getType(), 2, "phi" + res.residuals[i].occurrence, stuck);
+    auto phi = llvm::PHINode::Create(
+        val->getType(), 2, "phi" + res.residuals[i].occurrence, stuck);
     phi->addIncoming(val, block);
     phis.push_back(phi);
     auto sort = res.residuals[i].pattern->getSort();
-    auto cat = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(definition);
+    auto cat = dynamic_cast<KORECompositeSort *>(sort.get())
+                   ->getCategory(definition);
     types.push_back(cat);
     std::ostringstream Out;
     sort->print(Out);
-    initDebugParam(matchFunc, i, "_" + std::to_string(i+1), cat, Out.str());
+    initDebugParam(matchFunc, i, "_" + std::to_string(i + 1), cat, Out.str());
   }
-  auto header = stepFunctionHeader(axiom->getOrdinal(), module, definition, block, stuck, args, types);
+  auto header = stepFunctionHeader(
+      axiom->getOrdinal(), module, definition, block, stuck, args, types);
   i = 0;
-  Decision codegen(definition, header.second, fail, jump, choiceBuffer, choiceDepth, module, {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+  Decision codegen(
+      definition, header.second, fail, jump, choiceBuffer, choiceDepth, module,
+      {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, nullptr, nullptr,
+      nullptr);
   for (auto val : header.first) {
     val->setName(res.residuals[i].occurrence.substr(0, max_name_length));
     codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
@@ -897,11 +1202,14 @@ void makeStepFunction(KOREAxiomDeclaration *axiom, KOREDefinition *definition, l
   for (auto residual : res.residuals) {
     occurrences.insert(residual.occurrence);
   }
-  KOREPattern *partialTerm = makePartialTerm(dynamic_cast<KOREPattern *>(axiom->getRightHandSide()), occurrences, "_1");
+  KOREPattern *partialTerm = makePartialTerm(
+      dynamic_cast<KOREPattern *>(axiom->getRightHandSide()), occurrences,
+      "_1");
   CreateTerm creator(stuckSubst, definition, stuck, module, false);
   llvm::Value *retval = creator(partialTerm).first;
-  llvm::ReturnInst::Create(module->getContext(), retval, creator.getCurrentBlock());
+  llvm::ReturnInst::Create(
+      module->getContext(), retval, creator.getCurrentBlock());
 
   codegen(res.dt);
 }
-}
+} // namespace kllvm

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -1,7 +1,7 @@
 #include "kllvm/codegen/EmitConfigParser.h"
 #include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Util.h"
 #include "kllvm/codegen/Debug.h"
+#include "kllvm/codegen/Util.h"
 
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/Instructions.h"
@@ -10,7 +10,8 @@
 
 namespace kllvm {
 
-static llvm::Constant *getSymbolNamePtr(KORESymbol *symbol, llvm::BasicBlock *SetBlockName, llvm::Module *module) {
+static llvm::Constant *getSymbolNamePtr(
+    KORESymbol *symbol, llvm::BasicBlock *SetBlockName, llvm::Module *module) {
   llvm::LLVMContext &Ctx = module->getContext();
   std::ostringstream Out;
   symbol->print(Out);
@@ -18,40 +19,46 @@ static llvm::Constant *getSymbolNamePtr(KORESymbol *symbol, llvm::BasicBlock *Se
     SetBlockName->setName(Out.str());
   }
   auto Str = llvm::ConstantDataArray::getString(Ctx, Out.str(), true);
-  auto global = module->getOrInsertGlobal("sym_name_" + Out.str(), Str->getType());
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  auto global
+      = module->getOrInsertGlobal("sym_name_" + Out.str(), Str->getType());
+  llvm::GlobalVariable *globalVar
+      = llvm::dyn_cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Str);
   }
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
-  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), globalVar, indices);
+  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+      Str->getType(), globalVar, indices);
   return Ptr;
 }
 
 static llvm::Function *getStrcmp(llvm::Module *module) {
-llvm::LLVMContext &Ctx = module->getContext();
-  auto type = llvm::FunctionType::get(llvm::Type::getInt32Ty(Ctx),
+  llvm::LLVMContext &Ctx = module->getContext();
+  auto type = llvm::FunctionType::get(
+      llvm::Type::getInt32Ty(Ctx),
       {llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx)}, false);
   return getOrInsertFunction(module, "strcmp", type);
 }
 
 static llvm::Function *getPuts(llvm::Module *module) {
-llvm::LLVMContext &Ctx = module->getContext();
-  auto type = llvm::FunctionType::get(llvm::Type::getInt32Ty(Ctx),
-      {llvm::Type::getInt8PtrTy(Ctx)}, false);
+  llvm::LLVMContext &Ctx = module->getContext();
+  auto type = llvm::FunctionType::get(
+      llvm::Type::getInt32Ty(Ctx), {llvm::Type::getInt8PtrTy(Ctx)}, false);
   return getOrInsertFunction(module, "puts", type);
 }
 
-
-static void emitGetTagForSymbolName(KOREDefinition *definition, llvm::Module *module) {
+static void
+emitGetTagForSymbolName(KOREDefinition *definition, llvm::Module *module) {
   llvm::LLVMContext &Ctx = module->getContext();
-  auto type = llvm::FunctionType::get(llvm::Type::getInt32Ty(Ctx), {llvm::Type::getInt8PtrTy(Ctx)}, false);
-  auto func = getOrInsertFunction(module, "getTagForSymbolNameInternal",
-      type);
+  auto type = llvm::FunctionType::get(
+      llvm::Type::getInt32Ty(Ctx), {llvm::Type::getInt8PtrTy(Ctx)}, false);
+  auto func = getOrInsertFunction(module, "getTagForSymbolNameInternal", type);
   auto CurrentBlock = llvm::BasicBlock::Create(Ctx, "");
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
-  auto Phi = llvm::PHINode::Create(llvm::Type::getInt32Ty(Ctx), definition->getSymbols().size(), "phi", MergeBlock);
+  auto Phi = llvm::PHINode::Create(
+      llvm::Type::getInt32Ty(Ctx), definition->getSymbols().size(), "phi",
+      MergeBlock);
   auto &syms = definition->getAllSymbols();
   llvm::Function *Strcmp = getStrcmp(module);
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
@@ -60,12 +67,15 @@ static void emitGetTagForSymbolName(KOREDefinition *definition, llvm::Module *mo
     auto symbol = entry.second;
     CurrentBlock->insertInto(func);
     auto Ptr = getSymbolNamePtr(symbol, CurrentBlock, module);
-    auto compare = llvm::CallInst::Create(Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
-    auto icmp = new llvm::ICmpInst(*CurrentBlock, llvm::CmpInst::ICMP_EQ, 
-       compare, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0));
+    auto compare = llvm::CallInst::Create(
+        Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
+    auto icmp = new llvm::ICmpInst(
+        *CurrentBlock, llvm::CmpInst::ICMP_EQ, compare,
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0));
     auto FalseBlock = llvm::BasicBlock::Create(Ctx, "");
     llvm::BranchInst::Create(MergeBlock, FalseBlock, icmp, CurrentBlock);
-    Phi->addIncoming(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CurrentBlock);
+    Phi->addIncoming(
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CurrentBlock);
     CurrentBlock = FalseBlock;
   }
   llvm::ReturnInst::Create(Ctx, Phi, MergeBlock);
@@ -85,24 +95,35 @@ static std::string BUFFER_STRUCT = "stringbuffer";
 static std::string LAYOUT_STRUCT = "layout";
 static std::string LAYOUTITEM_STRUCT = "layoutitem";
 
-static void emitDataTableForSymbol(std::string name, llvm::Type *ty, llvm::DIType *dity, KOREDefinition *definition, llvm::Module *module,
-    llvm::Constant * getter(KOREDefinition *, llvm::Module *,
-        KORESymbol *)) {
+static void emitDataTableForSymbol(
+    std::string name, llvm::Type *ty, llvm::DIType *dity,
+    KOREDefinition *definition, llvm::Module *module,
+    llvm::Constant *getter(KOREDefinition *, llvm::Module *, KORESymbol *)) {
   llvm::LLVMContext &Ctx = module->getContext();
   std::vector<llvm::Type *> argTypes;
   argTypes.push_back(llvm::Type::getInt32Ty(Ctx));
-  auto func = getOrInsertFunction(module, name, llvm::FunctionType::get(ty, argTypes, false));
-  initDebugFunction(name, name, getDebugFunctionType(dity, {getIntDebugType()}), definition, func);
+  auto func = getOrInsertFunction(
+      module, name, llvm::FunctionType::get(ty, argTypes, false));
+  initDebugFunction(
+      name, name, getDebugFunctionType(dity, {getIntDebugType()}), definition,
+      func);
   auto EntryBlock = llvm::BasicBlock::Create(Ctx, "entry", func);
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
   auto stuck = llvm::BasicBlock::Create(Ctx, "stuck");
   auto &syms = definition->getSymbols();
-  auto icmp = new llvm::ICmpInst(*EntryBlock, llvm::CmpInst::ICMP_ULE, func->arg_begin(), llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), syms.rbegin()->first));
+  auto icmp = new llvm::ICmpInst(
+      *EntryBlock, llvm::CmpInst::ICMP_ULE, func->arg_begin(),
+      llvm::ConstantInt::get(
+          llvm::Type::getInt32Ty(Ctx), syms.rbegin()->first));
   llvm::BranchInst::Create(MergeBlock, stuck, icmp, EntryBlock);
   auto tableType = llvm::ArrayType::get(ty, syms.size());
   auto table = module->getOrInsertGlobal("table_" + name, tableType);
   llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(table);
-  initDebugGlobal("table_" + name, getArrayDebugType(dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)), globalVar);
+  initDebugGlobal(
+      "table_" + name,
+      getArrayDebugType(
+          dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)),
+      globalVar);
   std::vector<llvm::Constant *> values;
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
     auto entry = *iter;
@@ -113,52 +134,64 @@ static void emitDataTableForSymbol(std::string name, llvm::Type *ty, llvm::DITyp
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(llvm::ConstantArray::get(tableType, values));
   }
-  auto offset = new llvm::ZExtInst(func->arg_begin(), llvm::Type::getInt64Ty(Ctx), "", MergeBlock);
+  auto offset = new llvm::ZExtInst(
+      func->arg_begin(), llvm::Type::getInt64Ty(Ctx), "", MergeBlock);
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto retval = llvm::GetElementPtrInst::Create(
-    tableType, globalVar, {zero, offset}, "", MergeBlock);
+      tableType, globalVar, {zero, offset}, "", MergeBlock);
   MergeBlock->insertInto(func);
-  auto load = new llvm::LoadInst(retval->getType()->getPointerElementType(), retval, "", MergeBlock);
+  auto load = new llvm::LoadInst(
+      retval->getType()->getPointerElementType(), retval, "", MergeBlock);
   llvm::ReturnInst::Create(Ctx, load, MergeBlock);
   addAbort(stuck, module);
   stuck->insertInto(func);
 }
 
-
-static void emitDataForSymbol(std::string name, llvm::Type *ty, llvm::DIType *dity, KOREDefinition *definition, llvm::Module *module, bool isEval,
-    std::pair<llvm::Value *, llvm::BasicBlock *> getter(KOREDefinition *, llvm::Module *,
-        KORESymbol *, llvm::Instruction *)) {
+static void emitDataForSymbol(
+    std::string name, llvm::Type *ty, llvm::DIType *dity,
+    KOREDefinition *definition, llvm::Module *module, bool isEval,
+    std::pair<llvm::Value *, llvm::BasicBlock *> getter(
+        KOREDefinition *, llvm::Module *, KORESymbol *, llvm::Instruction *)) {
   llvm::LLVMContext &Ctx = module->getContext();
   std::vector<llvm::Type *> argTypes;
   argTypes.push_back(llvm::Type::getInt32Ty(Ctx));
   if (isEval) {
-    auto ty = llvm::PointerType::getUnqual(llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0));
+    auto ty = llvm::PointerType::getUnqual(
+        llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0));
     argTypes.push_back(ty);
   }
-  auto func = getOrInsertFunction(module, name, llvm::FunctionType::get(ty, argTypes, false));
+  auto func = getOrInsertFunction(
+      module, name, llvm::FunctionType::get(ty, argTypes, false));
   if (!isEval) {
-    initDebugFunction(name, name, getDebugFunctionType(dity, {getIntDebugType()}), definition, func);
+    initDebugFunction(
+        name, name, getDebugFunctionType(dity, {getIntDebugType()}), definition,
+        func);
   }
   auto EntryBlock = llvm::BasicBlock::Create(Ctx, "entry", func);
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
   auto stuck = llvm::BasicBlock::Create(Ctx, "stuck");
   auto &syms = definition->getSymbols();
-  auto Switch = llvm::SwitchInst::Create(func->arg_begin(), stuck, syms.size(), EntryBlock);
-  auto Phi = llvm::PHINode::Create(ty, definition->getSymbols().size(), "phi", MergeBlock);
+  auto Switch = llvm::SwitchInst::Create(
+      func->arg_begin(), stuck, syms.size(), EntryBlock);
+  auto Phi = llvm::PHINode::Create(
+      ty, definition->getSymbols().size(), "phi", MergeBlock);
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
     auto entry = *iter;
     uint32_t tag = entry.first;
     auto symbol = entry.second;
     auto decl = definition->getSymbolDeclarations().at(symbol->getName());
-    bool isFunc = decl->getAttributes().count("function") || decl->getAttributes().count("anywhere");
+    bool isFunc = decl->getAttributes().count("function")
+                  || decl->getAttributes().count("anywhere");
     if (isEval && !isFunc) {
       continue;
     }
-    auto CaseBlock = llvm::BasicBlock::Create(Ctx, "tag" + std::to_string(tag), func);
+    auto CaseBlock
+        = llvm::BasicBlock::Create(Ctx, "tag" + std::to_string(tag), func);
     auto Branch = llvm::BranchInst::Create(MergeBlock, CaseBlock);
     auto pair = getter(definition, module, symbol, Branch);
     Phi->addIncoming(pair.first, pair.second);
-    Switch->addCase(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CaseBlock);
+    Switch->addCase(
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CaseBlock);
   }
   llvm::ReturnInst::Create(Ctx, Phi, MergeBlock);
   MergeBlock->insertInto(func);
@@ -166,82 +199,102 @@ static void emitDataForSymbol(std::string name, llvm::Type *ty, llvm::DIType *di
   stuck->insertInto(func);
 }
 
-static std::pair<llvm::Value *, llvm::BasicBlock *> getHeader(KOREDefinition *definition, llvm::Module *module,
-    KORESymbol *symbol, llvm::Instruction *inst) {
+static std::pair<llvm::Value *, llvm::BasicBlock *> getHeader(
+    KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol,
+    llvm::Instruction *inst) {
   auto BlockType = getBlockType(module, definition, symbol);
-  return std::make_pair(getBlockHeader(module, definition, symbol, BlockType), inst->getParent());
+  return std::make_pair(
+      getBlockHeader(module, definition, symbol, BlockType), inst->getParent());
 }
 
-static void emitGetBlockHeaderForSymbol(KOREDefinition *def, llvm::Module *mod) {
-  emitDataForSymbol("getBlockHeaderForSymbol", getTypeByName(mod, BLOCKHEADER_STRUCT), getForwardDecl(BLOCKHEADER_STRUCT),
-      def, mod, false, getHeader);
+static void
+emitGetBlockHeaderForSymbol(KOREDefinition *def, llvm::Module *mod) {
+  emitDataForSymbol(
+      "getBlockHeaderForSymbol", getTypeByName(mod, BLOCKHEADER_STRUCT),
+      getForwardDecl(BLOCKHEADER_STRUCT), def, mod, false, getHeader);
 }
 
-static std::pair<llvm::Value *, llvm::BasicBlock *> getFunction(KOREDefinition *def, llvm::Module *mod,
-    KORESymbol *symbol, llvm::Instruction *inst) {
+static std::pair<llvm::Value *, llvm::BasicBlock *> getFunction(
+    KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol,
+    llvm::Instruction *inst) {
   auto decl = def->getSymbolDeclarations().at(symbol->getName());
-  bool res = decl->getAttributes().count("function") || decl->getAttributes().count("anywhere");
-  return std::make_pair(llvm::ConstantInt::get(llvm::Type::getInt1Ty(mod->getContext()), res),
+  bool res = decl->getAttributes().count("function")
+             || decl->getAttributes().count("anywhere");
+  return std::make_pair(
+      llvm::ConstantInt::get(llvm::Type::getInt1Ty(mod->getContext()), res),
       inst->getParent());
 }
 
 static void emitIsSymbolAFunction(KOREDefinition *def, llvm::Module *mod) {
-  emitDataForSymbol("isSymbolAFunction", llvm::Type::getInt1Ty(mod->getContext()), getBoolDebugType(),
-      def, mod, false, getFunction);
+  emitDataForSymbol(
+      "isSymbolAFunction", llvm::Type::getInt1Ty(mod->getContext()),
+      getBoolDebugType(), def, mod, false, getFunction);
 }
 
-static llvm::Constant * getBinder(KOREDefinition *def, llvm::Module *mod,
-    KORESymbol *symbol) {
+static llvm::Constant *
+getBinder(KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol) {
   auto decl = def->getSymbolDeclarations().at(symbol->getName());
   bool res = decl->getAttributes().count("binder");
   return llvm::ConstantInt::get(llvm::Type::getInt1Ty(mod->getContext()), res);
 }
 
 static void emitIsSymbolABinder(KOREDefinition *def, llvm::Module *mod) {
-  emitDataTableForSymbol("isSymbolABinder", llvm::Type::getInt1Ty(mod->getContext()), getBoolDebugType(),
-      def, mod, getBinder);
+  emitDataTableForSymbol(
+      "isSymbolABinder", llvm::Type::getInt1Ty(mod->getContext()),
+      getBoolDebugType(), def, mod, getBinder);
 }
 
-
-static std::pair<llvm::Value *, llvm::BasicBlock *> getInjection(KOREDefinition *def, llvm::Module *mod,
-    KORESymbol *symbol, llvm::Instruction *inst) {
-  llvm::Constant *tag = llvm::ConstantInt::get(llvm::Type::getInt32Ty(mod->getContext()), 0);
+static std::pair<llvm::Value *, llvm::BasicBlock *> getInjection(
+    KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol,
+    llvm::Instruction *inst) {
+  llvm::Constant *tag
+      = llvm::ConstantInt::get(llvm::Type::getInt32Ty(mod->getContext()), 0);
   for (auto sym : def->getSymbols()) {
-    if (sym.second->getName() == "inj" && *sym.second->getArguments()[0] == *symbol->getSort()) {
-      tag = llvm::ConstantInt::get(llvm::Type::getInt32Ty(mod->getContext()), sym.first);
+    if (sym.second->getName() == "inj"
+        && *sym.second->getArguments()[0] == *symbol->getSort()) {
+      tag = llvm::ConstantInt::get(
+          llvm::Type::getInt32Ty(mod->getContext()), sym.first);
       break;
     }
   }
   return std::make_pair(tag, inst->getParent());
 }
 
-static void emitGetInjectionForSortOfTag(KOREDefinition *def, llvm::Module *mod) {
-  emitDataForSymbol("getInjectionForSortOfTag", llvm::Type::getInt32Ty(mod->getContext()), getIntDebugType(),
-      def, mod, false, getInjection);
+static void
+emitGetInjectionForSortOfTag(KOREDefinition *def, llvm::Module *mod) {
+  emitDataForSymbol(
+      "getInjectionForSortOfTag", llvm::Type::getInt32Ty(mod->getContext()),
+      getIntDebugType(), def, mod, false, getInjection);
 }
 
-static llvm::Value *getArgValue(llvm::Value *ArgumentsArray, int idx,
-    llvm::BasicBlock *CaseBlock, ValueType cat, llvm::Module *mod) {
+static llvm::Value *getArgValue(
+    llvm::Value *ArgumentsArray, int idx, llvm::BasicBlock *CaseBlock,
+    ValueType cat, llvm::Module *mod) {
   llvm::LLVMContext &Ctx = mod->getContext();
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto addr = llvm::GetElementPtrInst::Create(
-      llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0),
-      ArgumentsArray, {zero, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), idx)},
-      "", CaseBlock);
-  llvm::Value *arg = new llvm::LoadInst(addr->getType()->getPointerElementType(), addr, "", CaseBlock);
-  switch(cat.cat) {
+      llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0), ArgumentsArray,
+      {zero, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), idx)}, "",
+      CaseBlock);
+  llvm::Value *arg = new llvm::LoadInst(
+      addr->getType()->getPointerElementType(), addr, "", CaseBlock);
+  switch (cat.cat) {
   case SortCategory::Bool:
   case SortCategory::MInt: {
-    auto cast = new llvm::BitCastInst(arg,
-        llvm::PointerType::getUnqual(getValueType(cat, mod)), "", CaseBlock);
-    auto load = new llvm::LoadInst(cast->getType()->getPointerElementType(), cast, "", CaseBlock);
+    auto cast = new llvm::BitCastInst(
+        arg, llvm::PointerType::getUnqual(getValueType(cat, mod)), "",
+        CaseBlock);
+    auto load = new llvm::LoadInst(
+        cast->getType()->getPointerElementType(), cast, "", CaseBlock);
     arg = load;
     break;
   }
   case SortCategory::Map:
   case SortCategory::List:
   case SortCategory::Set:
-    arg = new llvm::BitCastInst(arg, llvm::PointerType::getUnqual(getValueType(cat, mod)), "", CaseBlock);
+    arg = new llvm::BitCastInst(
+        arg, llvm::PointerType::getUnqual(getValueType(cat, mod)), "",
+        CaseBlock);
     break;
   case SortCategory::Int:
   case SortCategory::Float:
@@ -250,14 +303,14 @@ static llvm::Value *getArgValue(llvm::Value *ArgumentsArray, int idx,
   case SortCategory::Variable:
     arg = new llvm::BitCastInst(arg, getValueType(cat, mod), "", CaseBlock);
     break;
-  case SortCategory::Uncomputed:
-    abort();
+  case SortCategory::Uncomputed: abort();
   }
   return arg;
 }
 
-static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(KOREDefinition *def, llvm::Module *mod,
-    KORESymbol *symbol, llvm::Instruction *inst) {
+static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(
+    KOREDefinition *def, llvm::Module *mod, KORESymbol *symbol,
+    llvm::Instruction *inst) {
   llvm::LLVMContext &Ctx = mod->getContext();
   llvm::BasicBlock *CaseBlock = inst->getParent();
   inst->removeFromParent();
@@ -267,7 +320,8 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(KOREDefinition *def,
   llvm::StringMap<llvm::Value *> subst;
   auto pattern = KORECompositePattern::Create(symbol);
   for (auto &sort : symbol->getArguments()) {
-    ValueType cat = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(def);
+    ValueType cat
+        = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(def);
     llvm::Value *arg = getArgValue(ArgumentsArray, idx, CaseBlock, cat, mod);
     std::string name = "_" + std::to_string(idx++);
     subst.insert({name, arg});
@@ -276,8 +330,9 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(KOREDefinition *def,
   CreateTerm creator(subst, def, CaseBlock, mod, false);
   llvm::Value *result = creator(pattern.get()).first;
   llvm::Value *retval;
-  ValueType cat = dynamic_cast<KORECompositeSort *>(symbol->getSort().get())->getCategory(def);
-  switch(cat.cat) {
+  ValueType cat = dynamic_cast<KORECompositeSort *>(symbol->getSort().get())
+                      ->getCategory(def);
+  switch (cat.cat) {
   case SortCategory::Int:
   case SortCategory::Float:
   case SortCategory::StringBuffer:
@@ -286,43 +341,49 @@ static std::pair<llvm::Value *, llvm::BasicBlock *> getEval(KOREDefinition *def,
   case SortCategory::Map:
   case SortCategory::List:
   case SortCategory::Set:
-    retval = new llvm::BitCastInst(result, llvm::Type::getInt8PtrTy(Ctx), "",
-        creator.getCurrentBlock());
+    retval = new llvm::BitCastInst(
+        result, llvm::Type::getInt8PtrTy(Ctx), "", creator.getCurrentBlock());
     break;
   case SortCategory::Bool:
   case SortCategory::MInt: {
     llvm::Instruction *Malloc = llvm::CallInst::CreateMalloc(
-        creator.getCurrentBlock(), llvm::Type::getInt64Ty(Ctx), result->getType(), 
-        llvm::ConstantExpr::getSizeOf(result->getType()), nullptr, nullptr);
+        creator.getCurrentBlock(), llvm::Type::getInt64Ty(Ctx),
+        result->getType(), llvm::ConstantExpr::getSizeOf(result->getType()),
+        nullptr, nullptr);
     creator.getCurrentBlock()->getInstList().push_back(Malloc);
     new llvm::StoreInst(result, Malloc, creator.getCurrentBlock());
-    retval = new llvm::BitCastInst(Malloc, llvm::Type::getInt8PtrTy(Ctx), "",
-        creator.getCurrentBlock());
+    retval = new llvm::BitCastInst(
+        Malloc, llvm::Type::getInt8PtrTy(Ctx), "", creator.getCurrentBlock());
     break;
   }
-  case SortCategory::Uncomputed:
-    abort();
+  case SortCategory::Uncomputed: abort();
   }
   creator.getCurrentBlock()->getInstList().push_back(inst);
   return std::make_pair(retval, creator.getCurrentBlock());
 }
 
 static void emitEvaluateFunctionSymbol(KOREDefinition *def, llvm::Module *mod) {
-  emitDataForSymbol("evaluateFunctionSymbol", llvm::Type::getInt8PtrTy(mod->getContext()), nullptr,
-      def, mod, true, getEval);
+  emitDataForSymbol(
+      "evaluateFunctionSymbol", llvm::Type::getInt8PtrTy(mod->getContext()),
+      nullptr, def, mod, true, getEval);
 }
 
-static void emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *module) {
+static void
+emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *module) {
   llvm::LLVMContext &Ctx = module->getContext();
-  auto func = getOrInsertFunction(module,
-      "getTagForFreshSort", llvm::Type::getInt32Ty(Ctx), llvm::Type::getInt8PtrTy(Ctx));
+  auto func = getOrInsertFunction(
+      module, "getTagForFreshSort", llvm::Type::getInt32Ty(Ctx),
+      llvm::Type::getInt8PtrTy(Ctx));
   auto CurrentBlock = llvm::BasicBlock::Create(Ctx, "");
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
-  auto Phi = llvm::PHINode::Create(llvm::Type::getInt32Ty(Ctx), definition->getSortDeclarations().size(), "phi", MergeBlock);
+  auto Phi = llvm::PHINode::Create(
+      llvm::Type::getInt32Ty(Ctx), definition->getSortDeclarations().size(),
+      "phi", MergeBlock);
   auto &sorts = definition->getSortDeclarations();
   llvm::Function *Strcmp = getStrcmp(module);
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
-  llvm::Constant *zero32 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
+  llvm::Constant *zero32
+      = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
   bool hasCase = false;
   for (auto iter = sorts.begin(); iter != sorts.end(); ++iter) {
     auto &entry = *iter;
@@ -334,23 +395,31 @@ static void emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *mod
     CurrentBlock->insertInto(func);
     CurrentBlock->setName("is_" + name);
     auto Str = llvm::ConstantDataArray::getString(Ctx, name, true);
-    auto global = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
-    llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto global
+        = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
+    llvm::GlobalVariable *globalVar
+        = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
     auto indices = std::vector<llvm::Constant *>{zero, zero};
-    auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), globalVar, indices);
-    auto compare = llvm::CallInst::Create(Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
-    auto icmp = new llvm::ICmpInst(*CurrentBlock, llvm::CmpInst::ICMP_EQ, 
-       compare, zero32);
+    auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+        Str->getType(), globalVar, indices);
+    auto compare = llvm::CallInst::Create(
+        Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
+    auto icmp = new llvm::ICmpInst(
+        *CurrentBlock, llvm::CmpInst::ICMP_EQ, compare, zero32);
     auto FalseBlock = llvm::BasicBlock::Create(Ctx, "");
     auto CaseBlock = llvm::BasicBlock::Create(Ctx, name, func);
     llvm::BranchInst::Create(CaseBlock, FalseBlock, icmp, CurrentBlock);
     auto symbol = definition->getFreshFunctions().at(name);
     std::ostringstream Out;
     symbol->print(Out);
-    Phi->addIncoming(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), definition->getAllSymbols().at(Out.str())->getTag()), CaseBlock);
+    Phi->addIncoming(
+        llvm::ConstantInt::get(
+            llvm::Type::getInt32Ty(Ctx),
+            definition->getAllSymbols().at(Out.str())->getTag()),
+        CaseBlock);
     llvm::BranchInst::Create(MergeBlock, CaseBlock);
     CurrentBlock = FalseBlock;
   }
@@ -362,23 +431,28 @@ static void emitGetTagForFreshSort(KOREDefinition *definition, llvm::Module *mod
   }
 }
 
-
 static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
   llvm::LLVMContext &Ctx = module->getContext();
-  auto getTokenType = llvm::FunctionType::get(llvm::Type::getInt8PtrTy(Ctx), { llvm::Type::getInt8PtrTy(Ctx),
-      llvm::Type::getInt64Ty(Ctx), llvm::Type::getInt8PtrTy(Ctx) }, false);
+  auto getTokenType = llvm::FunctionType::get(
+      llvm::Type::getInt8PtrTy(Ctx),
+      {llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx),
+       llvm::Type::getInt8PtrTy(Ctx)},
+      false);
   auto func = getOrInsertFunction(module, "getToken", getTokenType);
   auto CurrentBlock = llvm::BasicBlock::Create(Ctx, "");
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
-  auto Phi = llvm::PHINode::Create(llvm::Type::getInt8PtrTy(Ctx), definition->getSortDeclarations().size(), "phi", MergeBlock);
+  auto Phi = llvm::PHINode::Create(
+      llvm::Type::getInt8PtrTy(Ctx), definition->getSortDeclarations().size(),
+      "phi", MergeBlock);
   auto &sorts = definition->getSortDeclarations();
   llvm::Function *Strcmp = getStrcmp(module);
-  llvm::Function *StringEqual = getOrInsertFunction(module, "string_equal", 
-      llvm::Type::getInt1Ty(Ctx), llvm::Type::getInt8PtrTy(Ctx),
-      llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx),
-      llvm::Type::getInt64Ty(Ctx));
+  llvm::Function *StringEqual = getOrInsertFunction(
+      module, "string_equal", llvm::Type::getInt1Ty(Ctx),
+      llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx),
+      llvm::Type::getInt64Ty(Ctx), llvm::Type::getInt64Ty(Ctx));
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
-  llvm::Constant *zero32 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
+  llvm::Constant *zero32
+      = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
   for (auto iter = sorts.begin(); iter != sorts.end(); ++iter) {
     auto &entry = *iter;
     std::string name = entry.first;
@@ -394,47 +468,53 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     CurrentBlock->insertInto(func);
     CurrentBlock->setName("is_" + name);
     auto Str = llvm::ConstantDataArray::getString(Ctx, name, true);
-    auto global = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
-    llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto global
+        = module->getOrInsertGlobal("sort_name_" + name, Str->getType());
+    llvm::GlobalVariable *globalVar
+        = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
     auto indices = std::vector<llvm::Constant *>{zero, zero};
-    auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), globalVar, indices);
-    auto compare = llvm::CallInst::Create(Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
-    auto icmp = new llvm::ICmpInst(*CurrentBlock, llvm::CmpInst::ICMP_EQ, 
-       compare, zero32);
+    auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+        Str->getType(), globalVar, indices);
+    auto compare = llvm::CallInst::Create(
+        Strcmp, {func->arg_begin(), Ptr}, "", CurrentBlock);
+    auto icmp = new llvm::ICmpInst(
+        *CurrentBlock, llvm::CmpInst::ICMP_EQ, compare, zero32);
     auto FalseBlock = llvm::BasicBlock::Create(Ctx, "");
     auto CaseBlock = llvm::BasicBlock::Create(Ctx, name, func);
     llvm::BranchInst::Create(CaseBlock, FalseBlock, icmp, CurrentBlock);
-    switch(cat.cat) {
+    switch (cat.cat) {
     case SortCategory::Map:
     case SortCategory::List:
-    case SortCategory::Set:
-      addAbort(CaseBlock, module);
-      break;
+    case SortCategory::Set: addAbort(CaseBlock, module); break;
     case SortCategory::StringBuffer:
     case SortCategory::MInt:
-      //TODO: tokens
+      // TODO: tokens
       addAbort(CaseBlock, module);
       break;
     case SortCategory::Bool: {
       auto Str = llvm::ConstantDataArray::getString(Ctx, "true", false);
       auto global = module->getOrInsertGlobal("bool_true", Str->getType());
-      llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+      llvm::GlobalVariable *globalVar
+          = llvm::dyn_cast<llvm::GlobalVariable>(global);
       if (!globalVar->hasInitializer()) {
         globalVar->setInitializer(Str);
       }
-      auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), globalVar, indices);
+      auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+          Str->getType(), globalVar, indices);
       auto Len = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 4);
-      auto compare = llvm::CallInst::Create(StringEqual,
-          {func->arg_begin()+2, Ptr, func->arg_begin()+1, Len}, "", CaseBlock);
+      auto compare = llvm::CallInst::Create(
+          StringEqual, {func->arg_begin() + 2, Ptr, func->arg_begin() + 1, Len},
+          "", CaseBlock);
       llvm::Instruction *Malloc = llvm::CallInst::CreateMalloc(
-          CaseBlock, llvm::Type::getInt64Ty(Ctx), compare->getType(), 
+          CaseBlock, llvm::Type::getInt64Ty(Ctx), compare->getType(),
           llvm::ConstantExpr::getSizeOf(compare->getType()), nullptr, nullptr);
       CaseBlock->getInstList().push_back(Malloc);
       new llvm::StoreInst(compare, Malloc, CaseBlock);
-      auto result = new llvm::BitCastInst(Malloc, llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
+      auto result = new llvm::BitCastInst(
+          Malloc, llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
       Phi->addIncoming(result, CaseBlock);
       llvm::BranchInst::Create(MergeBlock, CaseBlock);
       break;
@@ -442,91 +522,117 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     case SortCategory::Float: {
       llvm::Type *Float = getTypeByName(module, FLOAT_STRUCT);
       llvm::Value *Term = allocateTerm(Float, CaseBlock, "koreAllocFloating");
-      llvm::Function *InitFloat = getOrInsertFunction(module, "init_float",
-          llvm::Type::getVoidTy(Ctx), llvm::PointerType::getUnqual(Float), 
-          llvm::Type::getInt8PtrTy(Ctx));
-      llvm::CallInst::Create(InitFloat, {Term, func->arg_begin()+2}, "", CaseBlock);
-      auto cast = new llvm::BitCastInst(Term,
-          llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
+      llvm::Function *InitFloat = getOrInsertFunction(
+          module, "init_float", llvm::Type::getVoidTy(Ctx),
+          llvm::PointerType::getUnqual(Float), llvm::Type::getInt8PtrTy(Ctx));
+      llvm::CallInst::Create(
+          InitFloat, {Term, func->arg_begin() + 2}, "", CaseBlock);
+      auto cast = new llvm::BitCastInst(
+          Term, llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
       Phi->addIncoming(cast, CaseBlock);
       llvm::BranchInst::Create(MergeBlock, CaseBlock);
       break;
     }
     case SortCategory::Int: {
       const auto &thirdArg = func->arg_begin() + 2;
-      llvm::Value *FirstChar = new llvm::LoadInst(thirdArg->getType()->getPointerElementType(), thirdArg, "", CaseBlock);
-      llvm::Constant *asciiPlus = llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), 43);
-      auto icmpFirst = new llvm::ICmpInst(*CaseBlock, llvm::CmpInst::ICMP_EQ, FirstChar, asciiPlus);
+      llvm::Value *FirstChar = new llvm::LoadInst(
+          thirdArg->getType()->getPointerElementType(), thirdArg, "",
+          CaseBlock);
+      llvm::Constant *asciiPlus
+          = llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), 43);
+      auto icmpFirst = new llvm::ICmpInst(
+          *CaseBlock, llvm::CmpInst::ICMP_EQ, FirstChar, asciiPlus);
       auto IfIsPlus = llvm::BasicBlock::Create(Ctx, "if_is_plus", func);
       auto ElseNoPlus = llvm::BasicBlock::Create(Ctx, "else_no_plus", func);
       llvm::BranchInst::Create(IfIsPlus, ElseNoPlus, icmpFirst, CaseBlock);
-      llvm::Constant *one = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1);
-      llvm::Value *Pruned = llvm::GetElementPtrInst::CreateInBounds(llvm::Type::getInt8Ty(Ctx), func->arg_begin()+2,
-        {one}, "", IfIsPlus);
+      llvm::Constant *one
+          = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1);
+      llvm::Value *Pruned = llvm::GetElementPtrInst::CreateInBounds(
+          llvm::Type::getInt8Ty(Ctx), func->arg_begin() + 2, {one}, "",
+          IfIsPlus);
       llvm::BranchInst::Create(ElseNoPlus, IfIsPlus);
-      auto phiStr = llvm::PHINode::Create(llvm::Type::getInt8PtrTy(Ctx), 2, "", ElseNoPlus);
-      phiStr->addIncoming(func->arg_begin()+2, CaseBlock);
+      auto phiStr = llvm::PHINode::Create(
+          llvm::Type::getInt8PtrTy(Ctx), 2, "", ElseNoPlus);
+      phiStr->addIncoming(func->arg_begin() + 2, CaseBlock);
       phiStr->addIncoming(Pruned, IfIsPlus);
       CaseBlock = ElseNoPlus;
       llvm::Type *Int = getTypeByName(module, INT_STRUCT);
       llvm::Value *Term = allocateTerm(Int, CaseBlock, "koreAllocInteger");
-      llvm::Function *MpzInitSet = getOrInsertFunction(module, "__gmpz_init_set_str",
-          llvm::Type::getInt32Ty(Ctx), llvm::PointerType::getUnqual(Int), 
-          llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt32Ty(Ctx));
-      auto Call = llvm::CallInst::Create(MpzInitSet, {Term, phiStr,
-          llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 10)}, "", CaseBlock);
-      auto icmp = new llvm::ICmpInst(*CaseBlock, llvm::CmpInst::ICMP_EQ, 
-          Call, zero32);
+      llvm::Function *MpzInitSet = getOrInsertFunction(
+          module, "__gmpz_init_set_str", llvm::Type::getInt32Ty(Ctx),
+          llvm::PointerType::getUnqual(Int), llvm::Type::getInt8PtrTy(Ctx),
+          llvm::Type::getInt32Ty(Ctx));
+      auto Call = llvm::CallInst::Create(
+          MpzInitSet,
+          {Term, phiStr,
+           llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 10)},
+          "", CaseBlock);
+      auto icmp = new llvm::ICmpInst(
+          *CaseBlock, llvm::CmpInst::ICMP_EQ, Call, zero32);
       auto AbortBlock = llvm::BasicBlock::Create(Ctx, "invalid_int", func);
       addAbort(AbortBlock, module);
-      auto cast = new llvm::BitCastInst(Term,
-          llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
+      auto cast = new llvm::BitCastInst(
+          Term, llvm::Type::getInt8PtrTy(Ctx), "", CaseBlock);
       llvm::BranchInst::Create(MergeBlock, AbortBlock, icmp, CaseBlock);
       Phi->addIncoming(cast, CaseBlock);
       break;
     }
     case SortCategory::Variable:
-    case SortCategory::Symbol:
-      break;
-    case SortCategory::Uncomputed:
-      abort();
+    case SortCategory::Symbol: break;
+    case SortCategory::Uncomputed: abort();
     }
     CurrentBlock = FalseBlock;
   }
   CurrentBlock->setName("symbol");
   CurrentBlock->insertInto(func);
   auto StringType = getTypeByName(module, STRING_STRUCT);
-  auto Len = llvm::BinaryOperator::Create(llvm::Instruction::Add,
-      func->arg_begin()+1, llvm::ConstantExpr::getSizeOf(StringType), "", CurrentBlock);
-  llvm::Value *Block = allocateTerm(StringType, Len, CurrentBlock, "koreAllocToken");
-  auto HdrPtr = llvm::GetElementPtrInst::CreateInBounds(Block,
-      {zero, zero32, zero32}, "", CurrentBlock);
-  auto BlockSize = module->getOrInsertGlobal("BLOCK_SIZE", llvm::Type::getInt64Ty(Ctx));
-  auto BlockSizeVal = new llvm::LoadInst(BlockSize->getType()->getPointerElementType(), BlockSize, "", CurrentBlock);
-  auto BlockAllocSize = llvm::BinaryOperator::Create(llvm::Instruction::Sub,
-      BlockSizeVal, llvm::ConstantExpr::getSizeOf(llvm::Type::getInt8PtrTy(Ctx)), "", CurrentBlock);
-  auto icmp = new llvm::ICmpInst(*CurrentBlock, llvm::CmpInst::ICMP_UGT,
-      Len, BlockAllocSize);
-  auto Mask = llvm::SelectInst::Create(icmp, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), NOT_YOUNG_OBJECT_BIT), llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), "", CurrentBlock);
-  auto HdrOred = llvm::BinaryOperator::Create(llvm::Instruction::Or,
-      func->arg_begin()+1, Mask, "", CurrentBlock);
+  auto Len = llvm::BinaryOperator::Create(
+      llvm::Instruction::Add, func->arg_begin() + 1,
+      llvm::ConstantExpr::getSizeOf(StringType), "", CurrentBlock);
+  llvm::Value *Block
+      = allocateTerm(StringType, Len, CurrentBlock, "koreAllocToken");
+  auto HdrPtr = llvm::GetElementPtrInst::CreateInBounds(
+      Block, {zero, zero32, zero32}, "", CurrentBlock);
+  auto BlockSize
+      = module->getOrInsertGlobal("BLOCK_SIZE", llvm::Type::getInt64Ty(Ctx));
+  auto BlockSizeVal = new llvm::LoadInst(
+      BlockSize->getType()->getPointerElementType(), BlockSize, "",
+      CurrentBlock);
+  auto BlockAllocSize = llvm::BinaryOperator::Create(
+      llvm::Instruction::Sub, BlockSizeVal,
+      llvm::ConstantExpr::getSizeOf(llvm::Type::getInt8PtrTy(Ctx)), "",
+      CurrentBlock);
+  auto icmp = new llvm::ICmpInst(
+      *CurrentBlock, llvm::CmpInst::ICMP_UGT, Len, BlockAllocSize);
+  auto Mask = llvm::SelectInst::Create(
+      icmp,
+      llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), NOT_YOUNG_OBJECT_BIT),
+      llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0), "", CurrentBlock);
+  auto HdrOred = llvm::BinaryOperator::Create(
+      llvm::Instruction::Or, func->arg_begin() + 1, Mask, "", CurrentBlock);
   new llvm::StoreInst(HdrOred, HdrPtr, CurrentBlock);
-  llvm::Function *Memcpy = getOrInsertFunction(module, "memcpy", 
+  llvm::Function *Memcpy = getOrInsertFunction(
+      module, "memcpy", llvm::Type::getInt8PtrTy(Ctx),
       llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx),
-      llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx));
-  auto StrPtr = llvm::GetElementPtrInst::CreateInBounds(Block,
-      {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1), zero}, "", CurrentBlock);
-  llvm::CallInst::Create(Memcpy, {StrPtr, func->arg_begin()+2, func->arg_begin()+1},
-      "", CurrentBlock);
-  auto cast = new llvm::BitCastInst(Block,
-      llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock);
+      llvm::Type::getInt64Ty(Ctx));
+  auto StrPtr = llvm::GetElementPtrInst::CreateInBounds(
+      Block,
+      {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 1), zero}, "",
+      CurrentBlock);
+  llvm::CallInst::Create(
+      Memcpy, {StrPtr, func->arg_begin() + 2, func->arg_begin() + 1}, "",
+      CurrentBlock);
+  auto cast = new llvm::BitCastInst(
+      Block, llvm::Type::getInt8PtrTy(Ctx), "", CurrentBlock);
   llvm::BranchInst::Create(MergeBlock, CurrentBlock);
   Phi->addIncoming(cast, CurrentBlock);
   llvm::ReturnInst::Create(Ctx, Phi, MergeBlock);
   MergeBlock->insertInto(func);
 }
 
-static llvm::PointerType *makeVisitorType(llvm::LLVMContext &Ctx, llvm::Type *file, llvm::Type *item, int numStrs, int numBools) {
+static llvm::PointerType *makeVisitorType(
+    llvm::LLVMContext &Ctx, llvm::Type *file, llvm::Type *item, int numStrs,
+    int numBools) {
   std::vector<llvm::Type *> types;
   types.push_back(file);
   types.push_back(item);
@@ -536,44 +642,73 @@ static llvm::PointerType *makeVisitorType(llvm::LLVMContext &Ctx, llvm::Type *fi
   for (int i = 0; i < numBools; i++) {
     types.push_back(llvm::Type::getInt1Ty(Ctx));
   }
-  return llvm::PointerType::getUnqual(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), types, false));
+  return llvm::PointerType::getUnqual(
+      llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), types, false));
 }
 
-static void emitTraversal(std::string name, KOREDefinition *definition, llvm::Module *module, 
-    bool isVisitor, void getter(
-      KOREDefinition *, 
-      llvm::Module *, 
-      KORESymbol *, 
-      llvm::BasicBlock *)) {
+static void emitTraversal(
+    std::string name, KOREDefinition *definition, llvm::Module *module,
+    bool isVisitor,
+    void getter(
+        KOREDefinition *, llvm::Module *, KORESymbol *, llvm::BasicBlock *)) {
   llvm::LLVMContext &Ctx = module->getContext();
   std::vector<llvm::Type *> argTypes;
   argTypes.push_back(getValueType({SortCategory::Symbol, 0}, module));
   if (isVisitor) {
     // cf runtime/util/header.h visitChildren
-    auto file = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
+    auto file
+        = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
     argTypes.push_back(file);
-    argTypes.push_back(makeVisitorType(Ctx, file, getValueType({SortCategory::Symbol, 0}, module), 1, 1));
-    argTypes.push_back(makeVisitorType(Ctx, file, llvm::PointerType::getUnqual(getValueType({SortCategory::Map, 0}, module)), 3, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, llvm::PointerType::getUnqual(getValueType({SortCategory::List, 0}, module)), 3, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, llvm::PointerType::getUnqual(getValueType({SortCategory::Set, 0}, module)), 3, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, getValueType({SortCategory::Int, 0}, module), 1, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, getValueType({SortCategory::Float, 0}, module), 1, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, getValueType({SortCategory::Bool, 0}, module), 1, 0));
-    argTypes.push_back(makeVisitorType(Ctx, file, getValueType({SortCategory::StringBuffer, 0}, module), 1, 0));
-    argTypes.push_back(llvm::PointerType::getUnqual(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, llvm::Type::getInt64PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx), llvm::Type::getInt8PtrTy(Ctx)}, false)));
-    argTypes.push_back(llvm::PointerType::getUnqual(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file}, false)));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file, getValueType({SortCategory::Symbol, 0}, module), 1, 1));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file,
+        llvm::PointerType::getUnqual(
+            getValueType({SortCategory::Map, 0}, module)),
+        3, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file,
+        llvm::PointerType::getUnqual(
+            getValueType({SortCategory::List, 0}, module)),
+        3, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file,
+        llvm::PointerType::getUnqual(
+            getValueType({SortCategory::Set, 0}, module)),
+        3, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file, getValueType({SortCategory::Int, 0}, module), 1, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file, getValueType({SortCategory::Float, 0}, module), 1, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file, getValueType({SortCategory::Bool, 0}, module), 1, 0));
+    argTypes.push_back(makeVisitorType(
+        Ctx, file, getValueType({SortCategory::StringBuffer, 0}, module), 1,
+        0));
+    argTypes.push_back(llvm::PointerType::getUnqual(llvm::FunctionType::get(
+        llvm::Type::getVoidTy(Ctx),
+        {file, llvm::Type::getInt64PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx),
+         llvm::Type::getInt8PtrTy(Ctx)},
+        false)));
+    argTypes.push_back(llvm::PointerType::getUnqual(
+        llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file}, false)));
   } else {
-    argTypes.push_back(llvm::PointerType::getUnqual(llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0)));
+    argTypes.push_back(llvm::PointerType::getUnqual(
+        llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0)));
   }
-  auto func = llvm::dyn_cast<llvm::Function>(getOrInsertFunction(module,
-      name, llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), argTypes, false)));
+  auto func = llvm::dyn_cast<llvm::Function>(getOrInsertFunction(
+      module, name,
+      llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), argTypes, false)));
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
-  llvm::Constant *zero32 = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
+  llvm::Constant *zero32
+      = llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), 0);
   auto EntryBlock = llvm::BasicBlock::Create(Ctx, "entry", func);
-  auto HdrPtr = llvm::GetElementPtrInst::CreateInBounds(func->arg_begin(),
-      {zero, zero32, zero32}, "", EntryBlock);
-  auto Hdr = new llvm::LoadInst(HdrPtr->getType()->getPointerElementType(), HdrPtr, "", EntryBlock);
-  auto Tag = new llvm::TruncInst(Hdr, llvm::Type::getInt32Ty(Ctx), "", EntryBlock);
+  auto HdrPtr = llvm::GetElementPtrInst::CreateInBounds(
+      func->arg_begin(), {zero, zero32, zero32}, "", EntryBlock);
+  auto Hdr = new llvm::LoadInst(
+      HdrPtr->getType()->getPointerElementType(), HdrPtr, "", EntryBlock);
+  auto Tag
+      = new llvm::TruncInst(Hdr, llvm::Type::getInt32Ty(Ctx), "", EntryBlock);
   auto stuck = llvm::BasicBlock::Create(Ctx, "stuck");
   auto &syms = definition->getSymbols();
   auto Switch = llvm::SwitchInst::Create(Tag, stuck, syms.size(), EntryBlock);
@@ -584,16 +719,19 @@ static void emitTraversal(std::string name, KOREDefinition *definition, llvm::Mo
     if (symbol->getArguments().empty()) {
       continue;
     }
-    auto CaseBlock = llvm::BasicBlock::Create(Ctx, "tag" + std::to_string(tag), func);
-    Switch->addCase(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CaseBlock);
+    auto CaseBlock
+        = llvm::BasicBlock::Create(Ctx, "tag" + std::to_string(tag), func);
+    Switch->addCase(
+        llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), tag), CaseBlock);
     getter(definition, module, symbol, CaseBlock);
     llvm::ReturnInst::Create(Ctx, CaseBlock);
   }
   addAbort(stuck, module);
-  stuck->insertInto(func); 
+  stuck->insertInto(func);
 }
 
-static void getStore(KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol, 
+static void getStore(
+    KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol,
     llvm::BasicBlock *CaseBlock) {
   llvm::LLVMContext &Ctx = module->getContext();
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
@@ -601,171 +739,288 @@ static void getStore(KOREDefinition *definition, llvm::Module *module, KORESymbo
   llvm::Value *ArgumentsArray = func->arg_begin() + 1;
   int idx = 0;
   auto BlockType = getBlockType(module, definition, symbol);
-  auto cast = new llvm::BitCastInst(func->arg_begin(),
-      llvm::PointerType::getUnqual(BlockType), "", CaseBlock);
+  auto cast = new llvm::BitCastInst(
+      func->arg_begin(), llvm::PointerType::getUnqual(BlockType), "",
+      CaseBlock);
   for (auto &sort : symbol->getArguments()) {
-    ValueType cat = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(definition);
+    ValueType cat = dynamic_cast<KORECompositeSort *>(sort.get())
+                        ->getCategory(definition);
     llvm::Value *arg = getArgValue(ArgumentsArray, idx, CaseBlock, cat, module);
-    llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, cast,
-        {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)}, "", CaseBlock);
+    llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(
+        BlockType, cast,
+        {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)},
+        "", CaseBlock);
     if (arg->getType() == ChildPtr->getType()) {
-      arg = new llvm::LoadInst(arg->getType()->getPointerElementType(), arg, "", CaseBlock);
+      arg = new llvm::LoadInst(
+          arg->getType()->getPointerElementType(), arg, "", CaseBlock);
     }
     new llvm::StoreInst(arg, ChildPtr, CaseBlock);
   }
 }
 
-static void emitStoreSymbolChildren(KOREDefinition *definition, llvm::Module *module) {
+static void
+emitStoreSymbolChildren(KOREDefinition *definition, llvm::Module *module) {
   emitTraversal("storeSymbolChildren", definition, module, false, getStore);
 }
 
-static llvm::Constant *getSymbolName(KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol) {
+static llvm::Constant *getSymbolName(
+    KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol) {
   return getSymbolNamePtr(symbol, nullptr, module);
 }
 
 static void emitGetSymbolNameForTag(KOREDefinition *def, llvm::Module *mod) {
-  emitDataTableForSymbol("getSymbolNameForTag", llvm::Type::getInt8PtrTy(mod->getContext()), getCharPtrDebugType(), def, mod, getSymbolName);
+  emitDataTableForSymbol(
+      "getSymbolNameForTag", llvm::Type::getInt8PtrTy(mod->getContext()),
+      getCharPtrDebugType(), def, mod, getSymbolName);
 }
 
-static void visitCollection(KOREDefinition *definition, llvm::Module *module, KORECompositeSort *compositeSort, llvm::Function *func, llvm::Value *ChildPtr, llvm::BasicBlock *CaseBlock, unsigned offset) {
+static void visitCollection(
+    KOREDefinition *definition, llvm::Module *module,
+    KORECompositeSort *compositeSort, llvm::Function *func,
+    llvm::Value *ChildPtr, llvm::BasicBlock *CaseBlock, unsigned offset) {
   llvm::LLVMContext &Ctx = module->getContext();
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
-  auto sortDecl = definition->getSortDeclarations().at(compositeSort->getName());
+  auto sortDecl
+      = definition->getSortDeclarations().at(compositeSort->getName());
   llvm::Constant *concatPtr;
   if (sortDecl->getAttributes().count("concat")) {
-    auto concat = (KORECompositePattern *)sortDecl->getAttributes().at("concat")->getArguments()[0].get();
+    auto concat = (KORECompositePattern *)sortDecl->getAttributes()
+                      .at("concat")
+                      ->getArguments()[0]
+                      .get();
     concatPtr = getSymbolNamePtr(concat->getConstructor(), nullptr, module);
   } else {
     concatPtr = llvm::ConstantPointerNull::get(llvm::Type::getInt8PtrTy(Ctx));
   }
-  auto unit = (KORECompositePattern *)sortDecl->getAttributes().at("unit")->getArguments()[0].get();
+  auto unit = (KORECompositePattern *)sortDecl->getAttributes()
+                  .at("unit")
+                  ->getArguments()[0]
+                  .get();
   auto unitPtr = getSymbolNamePtr(unit->getConstructor(), nullptr, module);
-  auto element = (KORECompositePattern *)sortDecl->getAttributes().at("element")->getArguments()[0].get();
-  auto elementPtr = getSymbolNamePtr(element->getConstructor(), nullptr, module);
-  auto file = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
-  auto fnType = llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, ChildPtr->getType(), llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx)}, false);
-  llvm::CallInst::Create(fnType, func->arg_begin()+offset, {func->arg_begin()+1, ChildPtr, unitPtr, elementPtr, concatPtr}, "", CaseBlock);
+  auto element = (KORECompositePattern *)sortDecl->getAttributes()
+                     .at("element")
+                     ->getArguments()[0]
+                     .get();
+  auto elementPtr
+      = getSymbolNamePtr(element->getConstructor(), nullptr, module);
+  auto file
+      = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
+  auto fnType = llvm::FunctionType::get(
+      llvm::Type::getVoidTy(Ctx),
+      {file, ChildPtr->getType(), llvm::Type::getInt8PtrTy(Ctx),
+       llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt8PtrTy(Ctx)},
+      false);
+  llvm::CallInst::Create(
+      fnType, func->arg_begin() + offset,
+      {func->arg_begin() + 1, ChildPtr, unitPtr, elementPtr, concatPtr}, "",
+      CaseBlock);
 }
 
-static void getVisitor(KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol, llvm::BasicBlock *CaseBlock) {
+static void getVisitor(
+    KOREDefinition *definition, llvm::Module *module, KORESymbol *symbol,
+    llvm::BasicBlock *CaseBlock) {
   llvm::LLVMContext &Ctx = module->getContext();
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
   llvm::Function *func = CaseBlock->getParent();
   int idx = 0;
   auto BlockType = getBlockType(module, definition, symbol);
-  auto cast = new llvm::BitCastInst(func->arg_begin(),
-      llvm::PointerType::getUnqual(BlockType), "", CaseBlock);
+  auto cast = new llvm::BitCastInst(
+      func->arg_begin(), llvm::PointerType::getUnqual(BlockType), "",
+      CaseBlock);
   unsigned i = 0;
-  auto file = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
+  auto file
+      = llvm::PointerType::getUnqual(llvm::StructType::create(Ctx, "writer"));
   for (auto sort : symbol->getArguments()) {
     auto compositeSort = dynamic_cast<KORECompositeSort *>(sort.get());
     ValueType cat = compositeSort->getCategory(definition);
-    llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(BlockType, cast,
-        {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)}, "", CaseBlock);
-    llvm::Value *Child = new llvm::LoadInst(ChildPtr->getType()->getPointerElementType(), ChildPtr, "", CaseBlock);
+    llvm::Value *ChildPtr = llvm::GetElementPtrInst::CreateInBounds(
+        BlockType, cast,
+        {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)},
+        "", CaseBlock);
+    llvm::Value *Child = new llvm::LoadInst(
+        ChildPtr->getType()->getPointerElementType(), ChildPtr, "", CaseBlock);
     std::ostringstream Out;
     sort->print(Out);
     auto Str = llvm::ConstantDataArray::getString(Ctx, Out.str(), true);
-    auto global = module->getOrInsertGlobal("sort_name_" + Out.str(), Str->getType());
-    llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+    auto global
+        = module->getOrInsertGlobal("sort_name_" + Out.str(), Str->getType());
+    llvm::GlobalVariable *globalVar
+        = llvm::dyn_cast<llvm::GlobalVariable>(global);
     if (!globalVar->hasInitializer()) {
       globalVar->setInitializer(Str);
     }
-    llvm::Constant *CharPtr = llvm::ConstantExpr::getInBoundsGetElementPtr(Str->getType(), global, indices);
-    switch(cat.cat) {
+    llvm::Constant *CharPtr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+        Str->getType(), global, indices);
+    switch (cat.cat) {
     case SortCategory::Variable:
     case SortCategory::Symbol:
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx), llvm::Type::getInt1Ty(Ctx)}, false), func->arg_begin()+2, {func->arg_begin()+1, Child, CharPtr, llvm::ConstantInt::get(llvm::Type::getInt1Ty(Ctx), cat.cat == SortCategory::Variable)}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(Ctx),
+              {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx),
+               llvm::Type::getInt1Ty(Ctx)},
+              false),
+          func->arg_begin() + 2,
+          {func->arg_begin() + 1, Child, CharPtr,
+           llvm::ConstantInt::get(
+               llvm::Type::getInt1Ty(Ctx), cat.cat == SortCategory::Variable)},
+          "", CaseBlock);
       break;
     case SortCategory::Int:
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false), func->arg_begin()+6, {func->arg_begin()+1, Child, CharPtr}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(Ctx),
+              {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false),
+          func->arg_begin() + 6, {func->arg_begin() + 1, Child, CharPtr}, "",
+          CaseBlock);
       break;
     case SortCategory::Float:
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false), func->arg_begin()+7, {func->arg_begin()+1, Child, CharPtr}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(Ctx),
+              {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false),
+          func->arg_begin() + 7, {func->arg_begin() + 1, Child, CharPtr}, "",
+          CaseBlock);
       break;
     case SortCategory::Bool:
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false), func->arg_begin()+8, {func->arg_begin()+1, Child, CharPtr}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(Ctx),
+              {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false),
+          func->arg_begin() + 8, {func->arg_begin() + 1, Child, CharPtr}, "",
+          CaseBlock);
       break;
     case SortCategory::StringBuffer:
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false), func->arg_begin()+9, {func->arg_begin()+1, Child, CharPtr}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(
+              llvm::Type::getVoidTy(Ctx),
+              {file, Child->getType(), llvm::Type::getInt8PtrTy(Ctx)}, false),
+          func->arg_begin() + 9, {func->arg_begin() + 1, Child, CharPtr}, "",
+          CaseBlock);
       break;
     case SortCategory::MInt: {
-      llvm::Value *mint = new llvm::LoadInst(ChildPtr->getType()->getPointerElementType(), ChildPtr, "mint", CaseBlock);
+      llvm::Value *mint = new llvm::LoadInst(
+          ChildPtr->getType()->getPointerElementType(), ChildPtr, "mint",
+          CaseBlock);
       size_t nwords = (cat.bits + 63) / 64;
-      auto nbits = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), cat.bits);
-      auto fnType = llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file, llvm::Type::getInt64PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx), llvm::Type::getInt8PtrTy(Ctx)}, false);
+      auto nbits
+          = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), cat.bits);
+      auto fnType = llvm::FunctionType::get(
+          llvm::Type::getVoidTy(Ctx),
+          {file, llvm::Type::getInt64PtrTy(Ctx), llvm::Type::getInt64Ty(Ctx),
+           llvm::Type::getInt8PtrTy(Ctx)},
+          false);
       if (nwords == 0) {
-        llvm::CallInst::Create(fnType, func->arg_begin()+10, {func->arg_begin()+1, llvm::ConstantPointerNull::get(llvm::Type::getInt64PtrTy(Ctx)), nbits, CharPtr}, "", CaseBlock);
+        llvm::CallInst::Create(
+            fnType, func->arg_begin() + 10,
+            {func->arg_begin() + 1,
+             llvm::ConstantPointerNull::get(llvm::Type::getInt64PtrTy(Ctx)),
+             nbits, CharPtr},
+            "", CaseBlock);
       } else {
-        auto Ptr = allocateTerm(llvm::Type::getInt64Ty(Ctx), llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), nwords * 8), CaseBlock, "koreAllocAlwaysGC");
+        auto Ptr = allocateTerm(
+            llvm::Type::getInt64Ty(Ctx),
+            llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), nwords * 8),
+            CaseBlock, "koreAllocAlwaysGC");
         if (nwords == 1) {
           llvm::Value *Word;
           if (cat.bits == 64) {
             Word = mint;
           } else {
-            Word = new llvm::ZExtInst(mint, llvm::Type::getInt64Ty(Ctx), "word", CaseBlock);
+            Word = new llvm::ZExtInst(
+                mint, llvm::Type::getInt64Ty(Ctx), "word", CaseBlock);
           }
           new llvm::StoreInst(Word, Ptr, CaseBlock);
-        } else { //nwords >= 2
+        } else { // nwords >= 2
           llvm::Value *Ptr2 = Ptr;
           llvm::Value *accum = mint;
           for (size_t i = 0; i < nwords; i++) {
-            auto Word = new llvm::TruncInst(accum, llvm::Type::getInt64Ty(Ctx), "word", CaseBlock);
+            auto Word = new llvm::TruncInst(
+                accum, llvm::Type::getInt64Ty(Ctx), "word", CaseBlock);
             new llvm::StoreInst(Word, Ptr2, CaseBlock);
-            Ptr2 = llvm::GetElementPtrInst::Create(llvm::Type::getInt64Ty(Ctx), Ptr2, {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 1)}, "ptr", CaseBlock);
-            accum = llvm::BinaryOperator::Create(llvm::Instruction::LShr, accum, llvm::ConstantInt::get(mint->getType(), 64), "shift", CaseBlock);
+            Ptr2 = llvm::GetElementPtrInst::Create(
+                llvm::Type::getInt64Ty(Ctx), Ptr2,
+                {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 1)}, "ptr",
+                CaseBlock);
+            accum = llvm::BinaryOperator::Create(
+                llvm::Instruction::LShr, accum,
+                llvm::ConstantInt::get(mint->getType(), 64), "shift",
+                CaseBlock);
           }
         }
-        llvm::CallInst::Create(fnType, func->arg_begin()+10, {func->arg_begin()+1, Ptr, nbits, CharPtr}, "", CaseBlock);
+        llvm::CallInst::Create(
+            fnType, func->arg_begin() + 10,
+            {func->arg_begin() + 1, Ptr, nbits, CharPtr}, "", CaseBlock);
       }
       break;
-    } case SortCategory::Map:
-      visitCollection(definition, module, compositeSort, func, ChildPtr, CaseBlock, 3);
+    }
+    case SortCategory::Map:
+      visitCollection(
+          definition, module, compositeSort, func, ChildPtr, CaseBlock, 3);
       break;
     case SortCategory::Set:
-      visitCollection(definition, module, compositeSort, func, ChildPtr, CaseBlock, 5);
+      visitCollection(
+          definition, module, compositeSort, func, ChildPtr, CaseBlock, 5);
       break;
     case SortCategory::List: {
-      visitCollection(definition, module, compositeSort, func, ChildPtr, CaseBlock, 4);
+      visitCollection(
+          definition, module, compositeSort, func, ChildPtr, CaseBlock, 4);
       break;
-    } case SortCategory::Uncomputed:
-      abort();
+    }
+    case SortCategory::Uncomputed: abort();
     }
     if (i != symbol->getArguments().size() - 1) {
-      llvm::CallInst::Create(llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file}, false), func->arg_begin()+11, {func->arg_begin()+1}, "", CaseBlock);
+      llvm::CallInst::Create(
+          llvm::FunctionType::get(llvm::Type::getVoidTy(Ctx), {file}, false),
+          func->arg_begin() + 11, {func->arg_begin() + 1}, "", CaseBlock);
     }
     i++;
   }
 }
 
-static llvm::Constant *getLayoutData(uint16_t layout, KORESymbol *symbol, llvm::Module *module, KOREDefinition *def) {
+static llvm::Constant *getLayoutData(
+    uint16_t layout, KORESymbol *symbol, llvm::Module *module,
+    KOREDefinition *def) {
   uint8_t len = symbol->getArguments().size();
   std::vector<llvm::Constant *> elements;
   llvm::LLVMContext &Ctx = module->getContext();
   auto BlockType = getBlockType(module, def, symbol);
   int i = 2;
   for (auto sort : symbol->getArguments()) {
-    ValueType cat = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(def);
+    ValueType cat
+        = dynamic_cast<KORECompositeSort *>(sort.get())->getCategory(def);
     auto offset = llvm::ConstantExpr::getOffsetOf(BlockType, i++);
-    elements.push_back(llvm::ConstantStruct::get(getTypeByName(module, LAYOUTITEM_STRUCT), offset, llvm::ConstantInt::get(llvm::Type::getInt16Ty(Ctx), (int)cat.cat + cat.bits)));
+    elements.push_back(llvm::ConstantStruct::get(
+        getTypeByName(module, LAYOUTITEM_STRUCT), offset,
+        llvm::ConstantInt::get(
+            llvm::Type::getInt16Ty(Ctx), (int)cat.cat + cat.bits)));
   }
-  auto Arr = llvm::ConstantArray::get(llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), len), elements);
-  auto global = module->getOrInsertGlobal("layout_item_" + std::to_string(layout), Arr->getType());
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  auto Arr = llvm::ConstantArray::get(
+      llvm::ArrayType::get(getTypeByName(module, LAYOUTITEM_STRUCT), len),
+      elements);
+  auto global = module->getOrInsertGlobal(
+      "layout_item_" + std::to_string(layout), Arr->getType());
+  llvm::GlobalVariable *globalVar
+      = llvm::dyn_cast<llvm::GlobalVariable>(global);
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(Arr);
   }
   llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
   auto indices = std::vector<llvm::Constant *>{zero, zero};
-  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(Arr->getType(), globalVar, indices);
+  auto Ptr = llvm::ConstantExpr::getInBoundsGetElementPtr(
+      Arr->getType(), globalVar, indices);
   std::string name = "layout_" + std::to_string(layout);
-  auto global2 = module->getOrInsertGlobal(name, getTypeByName(module, LAYOUT_STRUCT));
-  llvm::GlobalVariable *globalVar2 = llvm::dyn_cast<llvm::GlobalVariable>(global2);
+  auto global2
+      = module->getOrInsertGlobal(name, getTypeByName(module, LAYOUT_STRUCT));
+  llvm::GlobalVariable *globalVar2
+      = llvm::dyn_cast<llvm::GlobalVariable>(global2);
   initDebugGlobal(name, getForwardDecl(LAYOUT_STRUCT), globalVar2);
   if (!globalVar2->hasInitializer()) {
-    globalVar2->setInitializer(llvm::ConstantStruct::get(getTypeByName(module, LAYOUT_STRUCT), llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), len), Ptr));
+    globalVar2->setInitializer(llvm::ConstantStruct::get(
+        getTypeByName(module, LAYOUT_STRUCT),
+        llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), len), Ptr));
   }
   return globalVar2;
 }
@@ -778,23 +1033,36 @@ static void emitLayouts(KOREDefinition *definition, llvm::Module *module) {
   llvm::LLVMContext &Ctx = module->getContext();
   std::vector<llvm::Type *> argTypes;
   argTypes.push_back(llvm::Type::getInt16Ty(Ctx));
-  auto func = llvm::dyn_cast<llvm::Function>(getOrInsertFunction(module,
-      "getLayoutData", llvm::FunctionType::get(llvm::PointerType::getUnqual(getTypeByName(module, LAYOUT_STRUCT)), argTypes, false)));
-  initDebugFunction("getLayoutData", "getLayoutData", getDebugFunctionType(getPointerDebugType(getForwardDecl(LAYOUT_STRUCT), "layout *"), {getShortDebugType()}), definition, func);
+  auto func = llvm::dyn_cast<llvm::Function>(getOrInsertFunction(
+      module, "getLayoutData",
+      llvm::FunctionType::get(
+          llvm::PointerType::getUnqual(getTypeByName(module, LAYOUT_STRUCT)),
+          argTypes, false)));
+  initDebugFunction(
+      "getLayoutData", "getLayoutData",
+      getDebugFunctionType(
+          getPointerDebugType(getForwardDecl(LAYOUT_STRUCT), "layout *"),
+          {getShortDebugType()}),
+      definition, func);
   auto EntryBlock = llvm::BasicBlock::Create(Ctx, "entry", func);
   auto MergeBlock = llvm::BasicBlock::Create(Ctx, "exit");
   auto stuck = llvm::BasicBlock::Create(Ctx, "stuck");
-  auto Switch = llvm::SwitchInst::Create(func->arg_begin(), stuck, layouts.size(), EntryBlock);
-  auto Phi = llvm::PHINode::Create(llvm::PointerType::getUnqual(getTypeByName(module, LAYOUT_STRUCT)), layouts.size(), "phi", MergeBlock);
+  auto Switch = llvm::SwitchInst::Create(
+      func->arg_begin(), stuck, layouts.size(), EntryBlock);
+  auto Phi = llvm::PHINode::Create(
+      llvm::PointerType::getUnqual(getTypeByName(module, LAYOUT_STRUCT)),
+      layouts.size(), "phi", MergeBlock);
   for (auto iter = layouts.begin(); iter != layouts.end(); ++iter) {
     auto entry = *iter;
     uint16_t layout = entry.first;
     auto symbol = entry.second;
-    auto CaseBlock = llvm::BasicBlock::Create(Ctx, "layout" + std::to_string(layout), func);
+    auto CaseBlock = llvm::BasicBlock::Create(
+        Ctx, "layout" + std::to_string(layout), func);
     llvm::BranchInst::Create(MergeBlock, CaseBlock);
     auto data = getLayoutData(layout, symbol, module, definition);
     Phi->addIncoming(data, CaseBlock);
-    Switch->addCase(llvm::ConstantInt::get(llvm::Type::getInt16Ty(Ctx), layout), CaseBlock);
+    Switch->addCase(
+        llvm::ConstantInt::get(llvm::Type::getInt16Ty(Ctx), layout), CaseBlock);
   }
   llvm::ReturnInst::Create(Ctx, Phi, MergeBlock);
   MergeBlock->insertInto(func);
@@ -808,17 +1076,21 @@ static void emitVisitChildren(KOREDefinition *def, llvm::Module *mod) {
 
 static void emitInjTags(KOREDefinition *def, llvm::Module *mod) {
   llvm::LLVMContext &Ctx = mod->getContext();
-  auto global = mod->getOrInsertGlobal("first_inj_tag", llvm::Type::getInt32Ty(Ctx));
-  llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
+  auto global
+      = mod->getOrInsertGlobal("first_inj_tag", llvm::Type::getInt32Ty(Ctx));
+  llvm::GlobalVariable *globalVar
+      = llvm::dyn_cast<llvm::GlobalVariable>(global);
   globalVar->setConstant(true);
   if (!globalVar->hasInitializer()) {
-    globalVar->setInitializer(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), def->getInjSymbol()->getFirstTag()));
+    globalVar->setInitializer(llvm::ConstantInt::get(
+        llvm::Type::getInt32Ty(Ctx), def->getInjSymbol()->getFirstTag()));
   }
   global = mod->getOrInsertGlobal("last_inj_tag", llvm::Type::getInt32Ty(Ctx));
   globalVar = llvm::dyn_cast<llvm::GlobalVariable>(global);
   globalVar->setConstant(true);
   if (!globalVar->hasInitializer()) {
-    globalVar->setInitializer(llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), def->getInjSymbol()->getLastTag()));
+    globalVar->setInitializer(llvm::ConstantInt::get(
+        llvm::Type::getInt32Ty(Ctx), def->getInjSymbol()->getLastTag()));
   }
 }
 
@@ -830,45 +1102,65 @@ static void emitSortTable(KOREDefinition *definition, llvm::Module *module) {
   auto tableType = llvm::ArrayType::get(ty, syms.size());
   auto table = module->getOrInsertGlobal("sort_table", tableType);
   llvm::GlobalVariable *globalVar = llvm::dyn_cast<llvm::GlobalVariable>(table);
-  initDebugGlobal("sort_table", getArrayDebugType(dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)), globalVar);
+  initDebugGlobal(
+      "sort_table",
+      getArrayDebugType(
+          dity, syms.size(), llvm::DataLayout(module).getABITypeAlignment(ty)),
+      globalVar);
   std::vector<llvm::Constant *> values;
   for (auto iter = syms.begin(); iter != syms.end(); ++iter) {
     auto entry = *iter;
     auto symbol = entry.second;
 
-    auto subtableType = llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), symbol->getArguments().size());
+    auto subtableType = llvm::ArrayType::get(
+        llvm::Type::getInt8PtrTy(Ctx), symbol->getArguments().size());
     std::ostringstream Out;
     symbol->print(Out);
-    auto subtable = module->getOrInsertGlobal("sorts_" + Out.str(), subtableType);
-    llvm::GlobalVariable *subtableVar = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
-    initDebugGlobal("sorts_" + symbol->getName(), getArrayDebugType(getCharPtrDebugType(), symbol->getArguments().size(), llvm::DataLayout(module).getABITypeAlignment(llvm::Type::getInt8PtrTy(Ctx))), subtableVar);
-    llvm::Constant *zero = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
+    auto subtable
+        = module->getOrInsertGlobal("sorts_" + Out.str(), subtableType);
+    llvm::GlobalVariable *subtableVar
+        = llvm::dyn_cast<llvm::GlobalVariable>(subtable);
+    initDebugGlobal(
+        "sorts_" + symbol->getName(),
+        getArrayDebugType(
+            getCharPtrDebugType(), symbol->getArguments().size(),
+            llvm::DataLayout(module).getABITypeAlignment(
+                llvm::Type::getInt8PtrTy(Ctx))),
+        subtableVar);
+    llvm::Constant *zero
+        = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0);
     auto indices = std::vector<llvm::Constant *>{zero, zero};
-    values.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(subtableType, subtableVar, indices));
+    values.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(
+        subtableType, subtableVar, indices));
 
     std::vector<llvm::Constant *> subvalues;
     for (size_t i = 0; i < symbol->getArguments().size(); ++i) {
       std::ostringstream Out;
       symbol->getArguments()[i]->print(Out);
-      auto strType = llvm::ArrayType::get(llvm::Type::getInt8Ty(Ctx), Out.str().size() + 1);
-      auto sortName = module->getOrInsertGlobal("sort_name_" + Out.str(), strType);
-      subvalues.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(strType, sortName, indices));
+      auto strType = llvm::ArrayType::get(
+          llvm::Type::getInt8Ty(Ctx), Out.str().size() + 1);
+      auto sortName
+          = module->getOrInsertGlobal("sort_name_" + Out.str(), strType);
+      subvalues.push_back(llvm::ConstantExpr::getInBoundsGetElementPtr(
+          strType, sortName, indices));
     }
-    subtableVar->setInitializer(llvm::ConstantArray::get(subtableType, subvalues));
+    subtableVar->setInitializer(
+        llvm::ConstantArray::get(subtableType, subvalues));
   }
   if (!globalVar->hasInitializer()) {
     globalVar->setInitializer(llvm::ConstantArray::get(tableType, values));
   }
 }
 
-void emitConfigParserFunctions(KOREDefinition *definition, llvm::Module *module) {
-  emitGetTagForSymbolName(definition, module); 
-  emitGetBlockHeaderForSymbol(definition, module); 
-  emitIsSymbolAFunction(definition, module); 
-  emitIsSymbolABinder(definition, module); 
-  emitStoreSymbolChildren(definition, module); 
-  emitEvaluateFunctionSymbol(definition, module); 
-  emitGetToken(definition, module); 
+void emitConfigParserFunctions(
+    KOREDefinition *definition, llvm::Module *module) {
+  emitGetTagForSymbolName(definition, module);
+  emitGetBlockHeaderForSymbol(definition, module);
+  emitIsSymbolAFunction(definition, module);
+  emitIsSymbolABinder(definition, module);
+  emitStoreSymbolChildren(definition, module);
+  emitEvaluateFunctionSymbol(definition, module);
+  emitGetToken(definition, module);
   emitGetTagForFreshSort(definition, module);
   emitGetInjectionForSortOfTag(definition, module);
 
@@ -882,4 +1174,4 @@ void emitConfigParserFunctions(KOREDefinition *definition, llvm::Module *module)
   emitSortTable(definition, module);
 }
 
-}
+} // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -4,13 +4,15 @@
 
 namespace kllvm {
 
-llvm::Function* koreHeapAlloc(std::string name, llvm::Module *module) {
-  llvm::Type* size_type = llvm::Type::getInt64Ty(module->getContext());
-  auto allocType = llvm::FunctionType::get(llvm::Type::getInt8PtrTy(module->getContext()), llvm::ArrayRef<llvm::Type*>(size_type), false);
+llvm::Function *koreHeapAlloc(std::string name, llvm::Module *module) {
+  llvm::Type *size_type = llvm::Type::getInt64Ty(module->getContext());
+  auto allocType = llvm::FunctionType::get(
+      llvm::Type::getInt8PtrTy(module->getContext()),
+      llvm::ArrayRef<llvm::Type *>(size_type), false);
   return getOrInsertFunction(module, name, allocType);
 }
 
-llvm::Function *castToFunctionOrAbort(llvm::Value* value) {
+llvm::Function *castToFunctionOrAbort(llvm::Value *value) {
   llvm::Function *func = llvm::dyn_cast<llvm::Function>(value);
   if (!func) {
     value->print(llvm::errs());
@@ -29,6 +31,4 @@ llvm::StructType *getTypeByName(llvm::Module *module, std::string name) {
   return t;
 }
 
-
-
-}
+} // namespace kllvm

--- a/lib/parser/KOREParser.cpp
+++ b/lib/parser/KOREParser.cpp
@@ -1,13 +1,12 @@
+#include "kllvm/parser/KOREParser.h"
 #include "kllvm/ast/AST.h"
 #include "kllvm/parser/KOREScanner.h"
-#include "kllvm/parser/KOREParser.h"
 #include <iostream>
 
 namespace kllvm {
 namespace parser {
 
-void KOREParser::error(
-      const location &loc, const std::string &err_message) {
+void KOREParser::error(const location &loc, const std::string &err_message) {
   std::cerr << "Syntax error at " << loc << ": " << err_message << "\n";
   exit(-1);
 }
@@ -51,7 +50,8 @@ std::string KOREParser::consume(token next) {
     data = buffer.data;
     buffer.tok = token::EMPTY;
   }
-  if (actual == next) return data;
+  if (actual == next)
+    return data;
   error(loc, "Expected: " + str(next) + " Actual: " + str(actual));
 }
 
@@ -138,7 +138,7 @@ std::vector<ptr<KOREDeclaration>> KOREParser::declarations(void) {
 ptr<KOREDeclaration> KOREParser::sentence() {
   std::string name;
   token current = peek();
-  switch(current) {
+  switch (current) {
   case token::IMPORT: {
     consume(token::IMPORT);
     name = consume(token::ID);
@@ -147,24 +147,28 @@ ptr<KOREDeclaration> KOREParser::sentence() {
     attributes(import.get());
     consume(token::RIGHTBRACKET);
     return import;
-  } case token::SORT:
+  }
+  case token::SORT:
   case token::HOOKEDSORT: {
     consume(current);
     name = consume(token::ID);
     consume(token::LEFTBRACE);
-    auto sortDecl = KORECompositeSortDeclaration::Create(name, current == token::HOOKEDSORT);
+    auto sortDecl = KORECompositeSortDeclaration::Create(
+        name, current == token::HOOKEDSORT);
     sortVariables(sortDecl.get());
     consume(token::RIGHTBRACE);
     consume(token::LEFTBRACKET);
     attributes(sortDecl.get());
     consume(token::RIGHTBRACKET);
     return sortDecl;
-  } case token::SYMBOL:
+  }
+  case token::SYMBOL:
   case token::HOOKEDSYMBOL: {
     consume(current);
     name = consume(token::ID);
     consume(token::LEFTBRACE);
-    auto symbol = KORESymbolDeclaration::Create(name, current == token::HOOKEDSYMBOL);
+    auto symbol
+        = KORESymbolDeclaration::Create(name, current == token::HOOKEDSYMBOL);
     sortVariables(symbol.get());
     consume(token::RIGHTBRACE);
     consume(token::LEFTPAREN);
@@ -177,7 +181,8 @@ ptr<KOREDeclaration> KOREParser::sentence() {
     attributes(symbol.get());
     consume(token::RIGHTBRACKET);
     return symbol;
-  } case token::ALIAS: {
+  }
+  case token::ALIAS: {
     consume(token::ALIAS);
     name = consume(token::ID);
     consume(token::LEFTBRACE);
@@ -200,7 +205,8 @@ ptr<KOREDeclaration> KOREParser::sentence() {
     attributes(alias.get());
     consume(token::RIGHTBRACKET);
     return alias;
-  } case token::AXIOM:
+  }
+  case token::AXIOM:
   case token::CLAIM: {
     consume(current);
     consume(token::LEFTBRACE);
@@ -213,8 +219,12 @@ ptr<KOREDeclaration> KOREParser::sentence() {
     attributes(axiom.get());
     consume(token::RIGHTBRACKET);
     return axiom;
-  } default:
-    error(loc, "Expected: [import, sort, hooked-sort, symbol, hooked-symbol, alias, axiom, claim] Actual: " + str(current));
+  }
+  default:
+    error(
+        loc, "Expected: [import, sort, hooked-sort, symbol, hooked-symbol, "
+             "alias, axiom, claim] Actual: "
+                 + str(current));
   }
 }
 
@@ -258,7 +268,7 @@ sptr<KORESort> KOREParser::sort() {
   std::string name = consume(token::ID);
   if (peek() == token::LEFTBRACE) {
     consume(token::LEFTBRACE);
-    auto sort = KORECompositeSort::Create(name); 
+    auto sort = KORECompositeSort::Create(name);
     sorts(sort.get());
     consume(token::RIGHTBRACE);
     return sort;
@@ -269,23 +279,20 @@ sptr<KORESort> KOREParser::sort() {
 
 ptr<KOREPattern> KOREParser::_pattern() {
   token current = peek();
-  switch(current) {
+  switch (current) {
   case token::ID: {
     std::string name = consume(token::ID);
     current = peek();
-    switch(current) {
+    switch (current) {
     case token::COLON:
       consume(token::COLON);
       return KOREVariablePattern::Create(name, sort());
-    case token::LEFTBRACE:
-      return applicationPattern(name);
-    default:
-      error(loc, "Expected: [:, {] Actual: " + str(current));
+    case token::LEFTBRACE: return applicationPattern(name);
+    default: error(loc, "Expected: [:, {] Actual: " + str(current));
     }
-  } case token::STRING:
-    return KOREStringPattern::Create(consume(token::STRING));
-  default:
-    error(loc, "Expected: [<id>, <string>] Actual: " + str(current));
+  }
+  case token::STRING: return KOREStringPattern::Create(consume(token::STRING));
+  default: error(loc, "Expected: [<id>, <string>] Actual: " + str(current));
   }
 }
 
@@ -322,7 +329,7 @@ ptr<KOREPattern> KOREParser::applicationPattern(std::string name) {
       }
       return accum;
     } else {
-      ptr<KOREPattern> accum = std::move(pats[pats.size()-1]);
+      ptr<KOREPattern> accum = std::move(pats[pats.size() - 1]);
       for (int i = pats.size() - 2; i >= 0; i--) {
         auto newAccum = KORECompositePattern::Create(pat->getConstructor());
         newAccum->addArgument(std::move(pats[i]));
@@ -348,7 +355,8 @@ ptr<KORECompositePattern> KOREParser::_applicationPattern(std::string name) {
 }
 
 void KOREParser::patterns(KORECompositePattern *node) {
-  if (peek() == token::RIGHTPAREN) return;
+  if (peek() == token::RIGHTPAREN)
+    return;
   patternsNE(node);
 }
 
@@ -363,7 +371,8 @@ void KOREParser::patternsNE(KORECompositePattern *node) {
 }
 
 void KOREParser::patterns(std::vector<ptr<KOREPattern>> &node) {
-  if (peek() == token::RIGHTPAREN) return;
+  if (peek() == token::RIGHTPAREN)
+    return;
   patternsNE(node);
 }
 
@@ -377,5 +386,5 @@ void KOREParser::patternsNE(std::vector<ptr<KOREPattern>> &node) {
   }
 }
 
-}
-}
+} // namespace parser
+} // namespace kllvm

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -1,13 +1,13 @@
 #include <gmp.h>
-#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <stdbool.h>
+#include <string.h>
 
 #include "runtime/alloc.h"
-#include "runtime/header.h"
 #include "runtime/arena.h"
+#include "runtime/header.h"
 
 extern "C" {
 
@@ -46,11 +46,13 @@ size_t youngspace_size(void) {
 bool youngspaceAlmostFull(size_t threshold) {
   char *nextBlock = *(char **)youngspace.block_start;
   if (nextBlock) {
-    // not on the last block, so short circuit and assume that we can keep allocating for now.
+    // not on the last block, so short circuit and assume that we can keep
+    // allocating for now.
     return false;
   }
   ptrdiff_t freeBytes = youngspace.block_end - youngspace.block;
-  size_t totalBytes = youngspace.num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
+  size_t totalBytes
+      = youngspace.num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
   return (totalBytes - freeBytes) * 100 > threshold * 95;
 }
 
@@ -63,86 +65,87 @@ void koreAllocSwap(bool swapOld) {
 }
 
 void setKoreMemoryFunctionsForGMP() {
-   mp_set_memory_functions(koreAllocMP, koreReallocMP, koreFree);
+  mp_set_memory_functions(koreAllocMP, koreReallocMP, koreFree);
 }
 
-__attribute__ ((always_inline)) void* koreAlloc(size_t requested) {
+__attribute__((always_inline)) void *koreAlloc(size_t requested) {
   return arenaAlloc(&youngspace, requested);
 }
 
-__attribute__ ((always_inline)) void* koreAllocToken(size_t requested) {
+__attribute__((always_inline)) void *koreAllocToken(size_t requested) {
   size_t size = (requested + 7) & ~7;
   return arenaAlloc(&youngspace, size < 16 ? 16 : size);
 }
 
-__attribute__ ((always_inline)) void* koreAllocOld(size_t requested) {
+__attribute__((always_inline)) void *koreAllocOld(size_t requested) {
   return arenaAlloc(&oldspace, requested);
 }
 
-__attribute__ ((always_inline)) void* koreAllocTokenOld(size_t requested) {
+__attribute__((always_inline)) void *koreAllocTokenOld(size_t requested) {
   size_t size = (requested + 7) & ~7;
   return arenaAlloc(&oldspace, size < 16 ? 16 : size);
 }
 
-__attribute__ ((always_inline)) void* koreAllocAlwaysGC(size_t requested) {
+__attribute__((always_inline)) void *koreAllocAlwaysGC(size_t requested) {
   return arenaAlloc(&alwaysgcspace, requested);
 }
 
-void* koreResizeLastAlloc(void* oldptr, size_t newrequest, size_t last_size) {
+void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t last_size) {
   newrequest = (newrequest + 7) & ~7;
   last_size = (last_size + 7) & ~7;
   if (oldptr != *arenaEndPtr(&youngspace) - last_size) {
-    MEM_LOG("May only reallocate last allocation. Tried to reallocate %p to %zd\n", oldptr, newrequest);
+    MEM_LOG(
+        "May only reallocate last allocation. Tried to reallocate %p to %zd\n",
+        oldptr, newrequest);
     exit(255);
   }
   ssize_t increase = newrequest - last_size;
   if (arenaResizeLastAlloc(&youngspace, increase)) {
     return oldptr;
   } else {
-    void* newptr = koreAlloc(newrequest);
-    memcpy(newptr,oldptr,last_size);
+    void *newptr = koreAlloc(newrequest);
+    memcpy(newptr, oldptr, last_size);
     return newptr;
   }
 }
 
-void* koreAllocMP(size_t requested) {
-  string* _new = (string *) koreAllocToken(sizeof(string) + requested);
+void *koreAllocMP(size_t requested) {
+  string *_new = (string *)koreAllocToken(sizeof(string) + requested);
   set_len(_new, requested);
   return _new->data;
 }
 
-void* koreReallocMP(void* ptr, size_t old_size, size_t new_size) {
-  string* _new = (string *) koreAllocToken(sizeof(string) + new_size);
+void *koreReallocMP(void *ptr, size_t old_size, size_t new_size) {
+  string *_new = (string *)koreAllocToken(sizeof(string) + new_size);
   size_t min = old_size > new_size ? new_size : old_size;
   memcpy(_new->data, ptr, min);
   set_len(_new, new_size);
   return _new->data;
 }
 
-void koreFree(void* ptr, size_t size) {}
+void koreFree(void *ptr, size_t size) { }
 
-__attribute__ ((always_inline)) void* koreAllocInteger(size_t requested) {
-  mpz_hdr *result = (mpz_hdr *) koreAlloc(sizeof(mpz_hdr));
+__attribute__((always_inline)) void *koreAllocInteger(size_t requested) {
+  mpz_hdr *result = (mpz_hdr *)koreAlloc(sizeof(mpz_hdr));
   set_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
-__attribute__ ((always_inline)) void* koreAllocFloating(size_t requested) {
-  floating_hdr *result = (floating_hdr *) koreAlloc(sizeof(floating_hdr));
+__attribute__((always_inline)) void *koreAllocFloating(size_t requested) {
+  floating_hdr *result = (floating_hdr *)koreAlloc(sizeof(floating_hdr));
   set_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }
 
-__attribute__ ((always_inline)) void* koreAllocIntegerOld(size_t requested) {
-  mpz_hdr *result = (mpz_hdr *) koreAllocOld(sizeof(mpz_hdr));
+__attribute__((always_inline)) void *koreAllocIntegerOld(size_t requested) {
+  mpz_hdr *result = (mpz_hdr *)koreAllocOld(sizeof(mpz_hdr));
   set_len(result, sizeof(mpz_hdr) - sizeof(blockheader));
   return &result->i;
 }
 
-__attribute__ ((always_inline)) void* koreAllocFloatingOld(size_t requested) {
-  floating_hdr *result = (floating_hdr *) koreAllocOld(sizeof(floating_hdr));
+__attribute__((always_inline)) void *koreAllocFloatingOld(size_t requested) {
+  floating_hdr *result = (floating_hdr *)koreAllocOld(sizeof(floating_hdr));
   set_len(result, sizeof(floating_hdr) - sizeof(blockheader));
   return &result->f;
 }
-
 }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -1,20 +1,19 @@
-#include <string.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
-#include <stdbool.h>
+#include <string.h>
 
+#include "runtime/alloc.h"
 #include "runtime/arena.h"
 #include "runtime/header.h"
-#include "runtime/alloc.h"
- 
+
 const size_t BLOCK_SIZE = 1024 * 1024;
 
-#define mem_block_header(ptr) \
-  ((memory_block_header *)(((uintptr_t)(ptr) - 1) & ~(BLOCK_SIZE-1)))
+#define mem_block_header(ptr)                                                  \
+  ((memory_block_header *)(((uintptr_t)(ptr)-1) & ~(BLOCK_SIZE - 1)))
 
-__attribute__ ((always_inline))
-void arenaReset(struct arena *Arena) {
+__attribute__((always_inline)) void arenaReset(struct arena *Arena) {
   char id = Arena->allocation_semispace_id;
   if (id < 0) {
     id = ~Arena->allocation_semispace_id;
@@ -29,29 +28,30 @@ void arenaReset(struct arena *Arena) {
   Arena->allocation_semispace_id = id;
 }
 
-__attribute__ ((always_inline))
-char getArenaAllocationSemispaceID(const struct arena *Arena) {
+__attribute__((always_inline)) char
+getArenaAllocationSemispaceID(const struct arena *Arena) {
   return Arena->allocation_semispace_id;
 }
 
-__attribute__ ((always_inline))
-char getArenaCollectionSemispaceID(const struct arena *Arena) {
+__attribute__((always_inline)) char
+getArenaCollectionSemispaceID(const struct arena *Arena) {
   return ~Arena->allocation_semispace_id;
 }
 
-__attribute__ ((always_inline)) char getArenaSemispaceIDOfObject(void *ptr) {
+__attribute__((always_inline)) char getArenaSemispaceIDOfObject(void *ptr) {
   return mem_block_header(ptr)->semispace;
 }
 
-static void* first_superblock_ptr = 0;
-static void* superblock_ptr = 0;
-static char** next_superblock_ptr = 0;
+static void *first_superblock_ptr = 0;
+static void *superblock_ptr = 0;
+static char **next_superblock_ptr = 0;
 static unsigned blocks_left = 0;
 
-static void* megabyte_malloc() {
+static void *megabyte_malloc() {
   if (blocks_left == 0) {
     blocks_left = 15;
-    if (int result = posix_memalign(&superblock_ptr, BLOCK_SIZE, BLOCK_SIZE * 15)) {
+    if (int result
+        = posix_memalign(&superblock_ptr, BLOCK_SIZE, BLOCK_SIZE * 15)) {
       errno = result;
       perror("posix_memalign");
     }
@@ -66,72 +66,84 @@ static void* megabyte_malloc() {
     hdr->next_superblock = 0;
   }
   blocks_left--;
-  void* result = superblock_ptr;
+  void *result = superblock_ptr;
   superblock_ptr = (char *)superblock_ptr + BLOCK_SIZE;
   return result;
 }
 
 static void freshBlock(struct arena *Arena) {
-    char *nextBlock;
-    if (Arena->block_start == 0) {
+  char *nextBlock;
+  if (Arena->block_start == 0) {
+    nextBlock = (char *)megabyte_malloc();
+    Arena->first_block = nextBlock;
+    memory_block_header *nextHeader = (memory_block_header *)nextBlock;
+    nextHeader->next_block = 0;
+    nextHeader->semispace = Arena->allocation_semispace_id;
+    Arena->num_blocks++;
+  } else {
+    nextBlock = *(char **)Arena->block_start;
+    if (Arena->block != Arena->block_end) {
+      if (Arena->block_end - Arena->block == 8) {
+        *(uint64_t *)Arena->block
+            = NOT_YOUNG_OBJECT_BIT; // 8 bit sentinel value
+      } else {
+        *(uint64_t *)Arena->block = Arena->block_end - Arena->block
+                                    - 8; // 16-bit or more sentinel value
+      }
+    }
+    if (!nextBlock) {
+      MEM_LOG(
+          "Allocating new block for the first time in arena %d\n",
+          Arena->allocation_semispace_id);
       nextBlock = (char *)megabyte_malloc();
-      Arena->first_block = nextBlock;
+      *(char **)Arena->block_start = nextBlock;
       memory_block_header *nextHeader = (memory_block_header *)nextBlock;
       nextHeader->next_block = 0;
       nextHeader->semispace = Arena->allocation_semispace_id;
       Arena->num_blocks++;
-    } else {
-      nextBlock = *(char**)Arena->block_start;
-      if (Arena->block != Arena->block_end) {
-        if (Arena->block_end - Arena->block == 8) {
-          *(uint64_t *)Arena->block = NOT_YOUNG_OBJECT_BIT; // 8 bit sentinel value
-        } else {
-          *(uint64_t *)Arena->block = Arena->block_end - Arena->block - 8; // 16-bit or more sentinel value
-        }
-      }
-      if (!nextBlock) {
-        MEM_LOG("Allocating new block for the first time in arena %d\n", Arena->allocation_semispace_id);
-        nextBlock = (char *)megabyte_malloc();
-        *(char **)Arena->block_start = nextBlock;
-        memory_block_header *nextHeader = (memory_block_header *)nextBlock;
-        nextHeader->next_block = 0;
-        nextHeader->semispace = Arena->allocation_semispace_id;
-        Arena->num_blocks++;
-      }
     }
-    Arena->block = nextBlock + sizeof(memory_block_header);
-    Arena->block_start = nextBlock;
-    Arena->block_end = nextBlock + BLOCK_SIZE;
-    MEM_LOG("New block at %p (remaining %zd)\n", Arena->block, BLOCK_SIZE - sizeof(memory_block_header));
+  }
+  Arena->block = nextBlock + sizeof(memory_block_header);
+  Arena->block_start = nextBlock;
+  Arena->block_end = nextBlock + BLOCK_SIZE;
+  MEM_LOG(
+      "New block at %p (remaining %zd)\n", Arena->block,
+      BLOCK_SIZE - sizeof(memory_block_header));
 }
 
-static __attribute__ ((noinline))
-void *doAllocSlow(size_t requested, struct arena *Arena) {
-  MEM_LOG("Block at %p too small, %zd remaining but %zd needed\n", Arena->block, Arena->block_end-Arena->block, requested);
+static __attribute__((noinline)) void *
+doAllocSlow(size_t requested, struct arena *Arena) {
+  MEM_LOG(
+      "Block at %p too small, %zd remaining but %zd needed\n", Arena->block,
+      Arena->block_end - Arena->block, requested);
   if (requested > BLOCK_SIZE - sizeof(memory_block_header)) {
     return malloc(requested);
   } else {
     freshBlock(Arena);
-    void* result = Arena->block;
+    void *result = Arena->block;
     Arena->block += requested;
-    MEM_LOG("Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result, requested, Arena->block);
+    MEM_LOG(
+        "Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result,
+        requested, Arena->block);
     return result;
   }
 }
 
-__attribute__ ((always_inline))
-void *arenaAlloc(struct arena *Arena, size_t requested) {
+__attribute__((always_inline)) void *
+arenaAlloc(struct arena *Arena, size_t requested) {
   if (Arena->block + requested > Arena->block_end) {
     return doAllocSlow(requested, Arena);
   }
-  void* result = Arena->block;
+  void *result = Arena->block;
   Arena->block += requested;
-  MEM_LOG("Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result, requested, Arena->block);
+  MEM_LOG(
+      "Allocation at %p (size %zd), next alloc at %p (if it fits)\n", result,
+      requested, Arena->block);
   return result;
 }
 
-__attribute__ ((always_inline))
-void *arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
+__attribute__((always_inline)) void *
+arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
   if (Arena->block + increase <= Arena->block_end) {
     Arena->block += increase;
     return Arena->block;
@@ -139,7 +151,7 @@ void *arenaResizeLastAlloc(struct arena *Arena, ssize_t increase) {
   return 0;
 }
 
-__attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
+__attribute__((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
   char *tmp = Arena->first_block;
   Arena->first_block = Arena->first_collection_block;
   Arena->first_collection_block = tmp;
@@ -150,17 +162,20 @@ __attribute__ ((always_inline)) void arenaSwapAndClear(struct arena *Arena) {
   arenaClear(Arena);
 }
 
-__attribute__ ((always_inline)) void arenaClear(struct arena *Arena) {
-  Arena->block = Arena->first_block ? Arena->first_block + sizeof(memory_block_header) : 0;
+__attribute__((always_inline)) void arenaClear(struct arena *Arena) {
+  Arena->block = Arena->first_block
+                     ? Arena->first_block + sizeof(memory_block_header)
+                     : 0;
   Arena->block_start = Arena->first_block;
   Arena->block_end = Arena->first_block ? Arena->first_block + BLOCK_SIZE : 0;
 }
 
-__attribute__ ((always_inline)) char *arenaStartPtr(const struct arena *Arena) {
-  return Arena->first_block ? Arena->first_block + sizeof(memory_block_header) : 0;
+__attribute__((always_inline)) char *arenaStartPtr(const struct arena *Arena) {
+  return Arena->first_block ? Arena->first_block + sizeof(memory_block_header)
+                            : 0;
 }
 
-__attribute__ ((always_inline)) char **arenaEndPtr(struct arena *Arena) {
+__attribute__((always_inline)) char **arenaEndPtr(struct arena *Arena) {
   return &Arena->block;
 }
 
@@ -195,7 +210,7 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
     hdr = (memory_block_header *)hdr->next_block;
   }
   if (hdr == mem_block_header(ptr1)) {
-    result += ptr1 - (char *)(hdr+1);
+    result += ptr1 - (char *)(hdr + 1);
     return result;
   } else {
     // reached the end of the arena and didn't find the block
@@ -203,20 +218,24 @@ ssize_t ptrDiff(char *ptr1, char *ptr2) {
     // case the block will have been prior to the block we started
     // at. To handle this, we recurse with reversed arguments and
     // negate the result. This means that the code might not
-    // terminate if the two pointers do not belong to the same 
+    // terminate if the two pointers do not belong to the same
     // arena.
     return -ptrDiff(ptr2, ptr1);
   }
 }
 
 size_t arenaSize(const struct arena *Arena) {
-  return (Arena->num_blocks > Arena->num_collection_blocks ? Arena->num_blocks : Arena->num_collection_blocks) * (BLOCK_SIZE - sizeof(memory_block_header));
+  return (Arena->num_blocks > Arena->num_collection_blocks
+              ? Arena->num_blocks
+              : Arena->num_collection_blocks)
+         * (BLOCK_SIZE - sizeof(memory_block_header));
 }
 
 void freeAllMemory() {
   memory_block_header *superblock = (memory_block_header *)first_superblock_ptr;
   while (superblock) {
-    memory_block_header* next_superblock = (memory_block_header *)superblock->next_superblock;
+    memory_block_header *next_superblock
+        = (memory_block_header *)superblock->next_superblock;
     free(superblock);
     superblock = next_superblock;
   }

--- a/runtime/alloc/register_gc_roots_enum.cpp
+++ b/runtime/alloc/register_gc_roots_enum.cpp
@@ -1,7 +1,7 @@
 #include <vector>
 
-#include "runtime/header.h"
 #include "runtime/collect.h"
+#include "runtime/header.h"
 
 std::vector<BlockEnumerator> blockEnumerators;
 

--- a/runtime/arithmetic/float.cpp
+++ b/runtime/arithmetic/float.cpp
@@ -1,35 +1,37 @@
-#include<gmp.h>
-#include<mpfr.h>
-#include<stdexcept>
+#include <gmp.h>
+#include <mpfr.h>
+#include <stdexcept>
 
 #include "runtime/header.h"
 
 #if MPFR_VERSION_MAJOR < 4
-  #define mpfr_rootn_ui mpfr_root
+#define mpfr_rootn_ui mpfr_root
 #endif
 
 static mpfr_exp_t emin(mpfr_exp_t e, mpfr_prec_t p) {
-  return (- (1 << (e-1))) + 2;
+  return (-(1 << (e - 1))) + 2;
 }
 
 static mpfr_exp_t emax(mpfr_exp_t e) {
-  return (1 << (e-1)) - 1;
+  return (1 << (e - 1)) - 1;
 }
 
 static mpfr_exp_t default_emax, default_emin;
 
 /* Each floating point number contains a number of exponent bits (here e) and
- * a precision (p). Here we initialize the result of a floating point computation
- * with that exponent range and precision and then prepare mpfr to perform the calculation
- * by transferring ourselves to that exponent range. An overload also exists to
- * get the value from a floating * if one already exists in the arguments to the function. */
+ * a precision (p). Here we initialize the result of a floating point
+ * computation with that exponent range and precision and then prepare mpfr to
+ * perform the calculation by transferring ourselves to that exponent range. An
+ * overload also exists to
+ * get the value from a floating * if one already exists in the arguments to the
+ * function. */
 static void mpfr_enter(mpfr_prec_t p, mpfr_exp_t e, floating *result) {
   mpfr_init2(result->f, p);
   result->exp = e;
   default_emax = mpfr_get_emax();
   default_emin = mpfr_get_emin();
-  mpfr_set_emin(emin(e, p)-p+2);
-  mpfr_set_emax(emax(e)+1);
+  mpfr_set_emin(emin(e, p) - p + 2);
+  mpfr_set_emax(emax(e) + 1);
 }
 
 static void mpfr_enter(floating *arg, floating *result) {
@@ -37,9 +39,9 @@ static void mpfr_enter(floating *arg, floating *result) {
   mpfr_enter(p, arg->exp, result);
 }
 
-/* Here we finalize the computation by ensuring that the value is correctly rounded into
- * The result exponent range, including subnormal arithmetic, and then restore the previous
- * values for emin and emax within mpfr. */
+/* Here we finalize the computation by ensuring that the value is correctly
+ * rounded into The result exponent range, including subnormal arithmetic, and
+ * then restore the previous values for emin and emax within mpfr. */
 static void mpfr_leave(int t, floating *result) {
   t = mpfr_check_range(result->f, t, MPFR_RNDN);
   mpfr_subnormalize(result->f, t, MPFR_RNDN);
@@ -61,7 +63,7 @@ SortFloat hook_FLOAT_ceil(SortFloat a) {
   mpfr_enter(a, result);
   int t = mpfr_ceil(result->f, a->f);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 SortFloat hook_FLOAT_floor(SortFloat a) {
@@ -220,15 +222,15 @@ mpz_ptr hook_FLOAT_exponent(SortFloat a) {
   mpfr_exp_t min = emin(a->exp, mpfr_get_prec(a->f));
   if (mpfr_regular_p(a->f)) {
     if (mpfr_get_exp(a->f) - 1 < min) {
-      //subnormal
-      mpz_set_si(result, min-1);
+      // subnormal
+      mpz_set_si(result, min - 1);
     } else {
-      mpz_set_si(result, mpfr_get_exp(a->f)-1);
+      mpz_set_si(result, mpfr_get_exp(a->f) - 1);
     }
   } else if (mpfr_zero_p(a->f)) {
-    mpz_set_si(result, min-1);
+    mpz_set_si(result, min - 1);
   } else { // nan or infinity
-    mpz_set_si(result, emax(a->exp)+1);
+    mpz_set_si(result, emax(a->exp) + 1);
   }
   return move_int(result);
 }
@@ -249,7 +251,7 @@ void *hook_FLOAT_significand(SortFloat a) {
   mpfr_exp_t exp = mpfr_get_exp(a->f);
   mpfr_exp_t min = emin(a->exp, prec);
   if (exp - 1 < min) {
-    //subnormal
+    // subnormal
     mpz_fdiv_q_2exp(z, z, min - (exp - 1));
   }
   return move_mint(z, len);
@@ -344,7 +346,7 @@ SortFloat hook_FLOAT_abs(SortFloat a) {
   mpfr_enter(a, result);
   int t = mpfr_abs(result->f, a->f, MPFR_RNDN);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 SortFloat hook_FLOAT_neg(SortFloat a) {
@@ -352,7 +354,7 @@ SortFloat hook_FLOAT_neg(SortFloat a) {
   mpfr_enter(a, result);
   int t = mpfr_neg(result->f, a->f, MPFR_RNDN);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 SortFloat hook_FLOAT_min(SortFloat a, SortFloat b) {
@@ -428,7 +430,7 @@ SortFloat hook_FLOAT_root(SortFloat a, SortInt b) {
   mpfr_enter(a, result);
   int t = mpfr_rootn_ui(result->f, a->f, root, MPFR_RNDN);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 SortFloat hook_FLOAT_log(SortFloat a) {
@@ -436,7 +438,7 @@ SortFloat hook_FLOAT_log(SortFloat a) {
   mpfr_enter(a, result);
   int t = mpfr_log(result->f, a->f, MPFR_RNDN);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 SortFloat hook_FLOAT_exp(SortFloat a) {
@@ -444,14 +446,15 @@ SortFloat hook_FLOAT_exp(SortFloat a) {
   mpfr_enter(a, result);
   int t = mpfr_exp(result->f, a->f, MPFR_RNDN);
   mpfr_leave(t, result);
-  return move_float(result); 
+  return move_float(result);
 }
 
 bool hook_FLOAT_sign(SortFloat a) {
   return mpfr_signbit(a->f);
 }
 
-SortFloat hook_FLOAT_rat2float(SortInt numerator, SortInt denominator, SortInt prec, SortInt exp) {
+SortFloat hook_FLOAT_rat2float(
+    SortInt numerator, SortInt denominator, SortInt prec, SortInt exp) {
   if (!mpz_fits_ulong_p(prec)) {
     throw std::invalid_argument("Precision out of range");
   }
@@ -482,5 +485,4 @@ void float_hash(SortFloat f, void *hasher) {
     add_hash64(hasher, f->f[0]._mpfr_d[i]);
   }
 }
-
 }

--- a/runtime/arithmetic/int.cpp
+++ b/runtime/arithmetic/int.cpp
@@ -1,7 +1,7 @@
-#include<gmp.h>
-#include<cstdlib>
-#include<cstring>
-#include<stdexcept>
+#include <cstdlib>
+#include <cstring>
+#include <gmp.h>
+#include <stdexcept>
 
 #include "runtime/header.h"
 
@@ -232,8 +232,8 @@ SortInt hook_INT_log2(SortInt a) {
 
 void extract(mpz_t result, mpz_t i, size_t off, size_t len) {
   ssize_t size = (len + LIMB_BITS - 1) / LIMB_BITS;
-  mpz_init2(result, len+LIMB_BITS);
-  memset(result->_mp_d, 0, result->_mp_alloc*sizeof(mp_limb_t));
+  mpz_init2(result, len + LIMB_BITS);
+  memset(result->_mp_d, 0, result->_mp_alloc * sizeof(mp_limb_t));
   size_t off_words = off / LIMB_BITS;
   size_t off_bits = off % LIMB_BITS;
   size_t num_limbs = mpz_size(i);
@@ -244,9 +244,9 @@ void extract(mpz_t result, mpz_t i, size_t off, size_t len) {
   mp_limb_t carry = 0;
   if (copy_size > 0) {
     if (off_bits) {
-      carry = mpn_rshift(result->_mp_d, i->_mp_d + off_words, copy_size, off_bits);
-    }
-    else {
+      carry = mpn_rshift(
+          result->_mp_d, i->_mp_d + off_words, copy_size, off_bits);
+    } else {
       mpn_copyi(result->_mp_d, i->_mp_d + off_words, copy_size);
     }
   } else {
@@ -263,9 +263,9 @@ void extract(mpz_t result, mpz_t i, size_t off, size_t len) {
   }
   len %= LIMB_BITS;
   if (len) {
-    result->_mp_d[size-1] &= ((mp_limb_t)-1) >> (LIMB_BITS - len);
+    result->_mp_d[size - 1] &= ((mp_limb_t)-1) >> (LIMB_BITS - len);
   }
-  while (size > 0 && result->_mp_d[size-1] == 0) {
+  while (size > 0 && result->_mp_d[size - 1] == 0) {
     size--;
   }
   result->_mp_size = size;
@@ -308,7 +308,7 @@ void signed_extract(mpz_t result, mpz_t i, size_t off, size_t len) {
     mpz_init(max);
     mpz_init(tmp);
     mpz_set_ui(max, 1);
-    mpz_mul_2exp(max, max, len-1);
+    mpz_mul_2exp(max, max, len - 1);
     extract(result, i, off, len);
     mpz_add(result, result, max);
     extract(tmp, result, 0, len);
@@ -356,7 +356,7 @@ void int_hash(mpz_t i, void *hasher) {
   }
 }
 
-static block * dotK = leaf_block(getTagForSymbolName("dotk{}"));
+static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));
 
 gmp_randstate_t kllvm_randState;
 bool kllvm_randStateInitialized = false;
@@ -388,10 +388,12 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
   mpz_t twos;
   mpz_init(twos);
   extract(twos, in, 0, nwords * 64);
-  if (nwords == 0) return nullptr;
-  uint64_t numb = 8*sizeof(size_t);
-  uint64_t count = (mpz_sizeinbase (twos, 2) + numb-1) / numb;
-  if (mpz_sgn(twos) == 0) count = 0;
+  if (nwords == 0)
+    return nullptr;
+  uint64_t numb = 8 * sizeof(size_t);
+  uint64_t count = (mpz_sizeinbase(twos, 2) + numb - 1) / numb;
+  if (mpz_sgn(twos) == 0)
+    count = 0;
   uint64_t alloccount = nwords > count ? nwords : count;
   size_t allocsize = alloccount * sizeof(size_t);
   size_t *allocptr = (size_t *)koreAllocAlwaysGC(allocsize);
@@ -400,13 +402,14 @@ size_t *hook_MINT_export(mpz_t in, uint64_t bits) {
   size_t actualcount;
   mpz_export(exportptr, &actualcount, 1, sizeof(size_t), 0, 0, twos);
   assert(count == actualcount);
-  if (count == 0) return allocptr;
+  if (count == 0)
+    return allocptr;
   size_t *resultptr = nwords > count ? allocptr : allocptr + count - nwords;
   return resultptr;
 }
 
 mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned) {
-  mpz_t result, twos;	
+  mpz_t result, twos;
   mpz_init(twos);
   mpz_init(result);
   uint64_t nwords = (bits + 63) / 64;
@@ -418,5 +421,4 @@ mpz_ptr hook_MINT_import(size_t *i, uint64_t bits, bool isSigned) {
     return move_int(twos);
   }
 }
-
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -1,20 +1,20 @@
-#include<cstdbool>
-#include<cstdint>
-#include<cstdio>
-#include<cstdlib>
-#include<cstring>
-#include<cassert>
-#include "runtime/alloc.h"
-#include "runtime/header.h"
-#include "runtime/arena.h"
 #include "runtime/collect.h"
+#include "runtime/alloc.h"
+#include "runtime/arena.h"
+#include "runtime/header.h"
+#include <cassert>
+#include <cstdbool>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 extern "C" {
 
 char **young_alloc_ptr(void);
 char **old_alloc_ptr(void);
-char* youngspace_ptr(void);
-char* oldspace_ptr(void);
+char *youngspace_ptr(void);
+char *oldspace_ptr(void);
 
 static bool is_gc = false;
 bool collect_old = false;
@@ -35,15 +35,15 @@ bool during_gc() {
 
 size_t get_size(uint64_t hdr, uint16_t layout) {
   if (!layout) {
-    size_t size = (len_hdr(hdr)  + sizeof(blockheader) + 7) & ~7;
+    size_t size = (len_hdr(hdr) + sizeof(blockheader) + 7) & ~7;
     return hdr == NOT_YOUNG_OBJECT_BIT ? 8 : size < 16 ? 16 : size;
   } else {
     return size_hdr(hdr);
   }
 }
 
-void migrate(block** blockPtr) {
-  block* currBlock = *blockPtr;
+void migrate(block **blockPtr) {
+  block *currBlock = *blockPtr;
   if (is_leaf_block(currBlock)) {
     return;
   }
@@ -51,7 +51,7 @@ void migrate(block** blockPtr) {
   initialize_migrate();
   uint16_t layout = layout_hdr(hdr);
   size_t lenInBytes = get_size(hdr, layout);
-  block** forwardingAddress = (block**)(currBlock + 1);
+  block **forwardingAddress = (block **)(currBlock + 1);
   if (!hasForwardingAddress) {
     block *newBlock;
     if (shouldPromote || (isInOldGen && collect_old)) {
@@ -72,21 +72,23 @@ void migrate(block** blockPtr) {
   }
 }
 
-// call this function instead of migrate on objects directly referenced by shared objects (like collection nodes)
-// that are not tracked by gc
-void migrate_once(block** blockPtr) {
-  block* currBlock = *blockPtr;
+// call this function instead of migrate on objects directly referenced by
+// shared objects (like collection nodes) that are not tracked by gc
+void migrate_once(block **blockPtr) {
+  block *currBlock = *blockPtr;
   if (is_leaf_block(currBlock)) {
     return;
   }
-  if (youngspace_collection_id() == getArenaSemispaceIDOfObject((void *)currBlock) ||
-      oldspace_collection_id() == getArenaSemispaceIDOfObject((void *)currBlock)) {
+  if (youngspace_collection_id()
+          == getArenaSemispaceIDOfObject((void *)currBlock)
+      || oldspace_collection_id()
+             == getArenaSemispaceIDOfObject((void *)currBlock)) {
     migrate(blockPtr);
   }
 }
 
-static void migrate_string_buffer(stringbuffer** bufferPtr) {
-  stringbuffer* buffer = *bufferPtr;
+static void migrate_string_buffer(stringbuffer **bufferPtr) {
+  stringbuffer *buffer = *bufferPtr;
   const uint64_t hdr = buffer->h.hdr;
   const uint64_t cap = len(buffer->contents);
   initialize_migrate();
@@ -101,7 +103,8 @@ static void migrate_string_buffer(stringbuffer** bufferPtr) {
       newContents = (string *)koreAllocToken(sizeof(string) + cap);
     }
 #ifdef GC_DBG
-    numBytesLiveAtCollection[oldAge] += cap + sizeof(stringbuffer) + sizeof(string);
+    numBytesLiveAtCollection[oldAge]
+        += cap + sizeof(stringbuffer) + sizeof(string);
 #endif
     memcpy(newContents, buffer->contents, sizeof(string) + buffer->strlen);
     memcpy(newBuffer, buffer, sizeof(stringbuffer));
@@ -136,10 +139,10 @@ static void migrate_mpz(mpz_ptr *mpzPtr) {
 
       if (shouldPromote || (isInOldGen && collect_old)) {
         newIntgr = struct_base(mpz_hdr, i, koreAllocIntegerOld(0));
-        newLimbs = (string *) koreAllocTokenOld(sizeof(string) + lenLimbs);
+        newLimbs = (string *)koreAllocTokenOld(sizeof(string) + lenLimbs);
       } else {
         newIntgr = struct_base(mpz_hdr, i, koreAllocInteger(0));
-        newLimbs = (string *) koreAllocToken(sizeof(string) + lenLimbs);
+        newLimbs = (string *)koreAllocToken(sizeof(string) + lenLimbs);
       }
       memcpy(newLimbs, limbs, sizeof(string) + lenLimbs);
     } else {
@@ -167,65 +170,56 @@ static void migrate_floating(floating **floatingPtr) {
   if (!hasForwardingAddress) {
     floating_hdr *newFlt;
     string *newLimbs;
-    string *limbs = struct_base(string, data, flt->f.f->_mpfr_d-1);
+    string *limbs = struct_base(string, data, flt->f.f->_mpfr_d - 1);
     size_t lenLimbs = len(limbs);
 
 #ifdef GC_DBG
-    numBytesLiveAtCollection[oldAge] += sizeof(floating_hdr) + sizeof(string) + lenLimbs;
+    numBytesLiveAtCollection[oldAge]
+        += sizeof(floating_hdr) + sizeof(string) + lenLimbs;
 #endif
 
-    assert(((flt->f.f->_mpfr_prec + mp_bits_per_limb - 1) / mp_bits_per_limb) * sizeof(mp_limb_t) <= lenLimbs);
+    assert(
+        ((flt->f.f->_mpfr_prec + mp_bits_per_limb - 1) / mp_bits_per_limb)
+            * sizeof(mp_limb_t)
+        <= lenLimbs);
 
     if (shouldPromote || (isInOldGen && collect_old)) {
       newFlt = struct_base(floating_hdr, f, koreAllocFloatingOld(0));
-      newLimbs = (string *) koreAllocTokenOld(sizeof(string) + lenLimbs);
+      newLimbs = (string *)koreAllocTokenOld(sizeof(string) + lenLimbs);
     } else {
       newFlt = struct_base(floating_hdr, f, koreAllocFloating(0));
-      newLimbs = (string *) koreAllocToken(sizeof(string) + lenLimbs);
+      newLimbs = (string *)koreAllocToken(sizeof(string) + lenLimbs);
     }
     memcpy(newLimbs, limbs, sizeof(string) + lenLimbs);
     memcpy(newFlt, flt, sizeof(floating_hdr));
     migrate_header(newFlt);
-    newFlt->f.f->_mpfr_d = (mp_limb_t *)newLimbs->data+1;
+    newFlt->f.f->_mpfr_d = (mp_limb_t *)newLimbs->data + 1;
     *(floating **)(flt->f.f->_mpfr_d) = &newFlt->f;
     flt->h.hdr |= FWD_PTR_BIT;
   }
   *floatingPtr = *(floating **)(flt->f.f->_mpfr_d);
 }
 
-static void migrate_child(void* currBlock, layoutitem *args, unsigned i, bool ptr) {
+static void
+migrate_child(void *currBlock, layoutitem *args, unsigned i, bool ptr) {
   layoutitem *argData = args + i;
   void *arg = ((char *)currBlock) + argData->offset;
-  switch(argData->cat) {
-  case MAP_LAYOUT:
-    migrate_map(ptr ? *(map**)arg : arg);
-    break;
-  case LIST_LAYOUT:
-    migrate_list(ptr ? *(list**)arg : arg);
-    break;
-  case SET_LAYOUT:
-    migrate_set(ptr ? *(set**)arg : arg);
-    break;
-  case STRINGBUFFER_LAYOUT:
-    migrate_string_buffer((stringbuffer **)arg);
-    break;
+  switch (argData->cat) {
+  case MAP_LAYOUT: migrate_map(ptr ? *(map **)arg : arg); break;
+  case LIST_LAYOUT: migrate_list(ptr ? *(list **)arg : arg); break;
+  case SET_LAYOUT: migrate_set(ptr ? *(set **)arg : arg); break;
+  case STRINGBUFFER_LAYOUT: migrate_string_buffer((stringbuffer **)arg); break;
   case SYMBOL_LAYOUT:
-  case VARIABLE_LAYOUT:
-    migrate((block **)arg);
-    break;
-  case INT_LAYOUT:
-    migrate_mpz((mpz_ptr *)arg);
-    break;
-  case FLOAT_LAYOUT:
-    migrate_floating((floating **)arg);
-    break;
+  case VARIABLE_LAYOUT: migrate((block **)arg); break;
+  case INT_LAYOUT: migrate_mpz((mpz_ptr *)arg); break;
+  case FLOAT_LAYOUT: migrate_floating((floating **)arg); break;
   case BOOL_LAYOUT:
-  default: //mint
+  default: // mint
     break;
   }
 }
 
-static char* evacuate(char* scan_ptr, char** alloc_ptr) {
+static char *evacuate(char *scan_ptr, char **alloc_ptr) {
   block *currBlock = (block *)scan_ptr;
   const uint64_t hdr = currBlock->h.hdr;
   uint16_t layoutInt = layout_hdr(hdr);
@@ -262,7 +256,7 @@ void initStaticObjects(void) {
   setKoreMemoryFunctionsForGMP();
 }
 
-void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
+void koreCollect(void **roots, uint8_t nroots, layoutitem *typeInfo) {
   is_gc = true;
   collect_old = shouldCollectOldGen();
   MEM_LOG("Starting garbage collection\n");
@@ -286,14 +280,15 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
   char *scan_ptr = youngspace_ptr();
   if (scan_ptr != *young_alloc_ptr()) {
     MEM_LOG("Evacuating young generation\n");
-    while(scan_ptr) {
+    while (scan_ptr) {
       scan_ptr = evacuate(scan_ptr, young_alloc_ptr());
     }
   }
   if (collect_old || !previous_oldspace_alloc_ptr) {
     scan_ptr = oldspace_ptr();
   } else {
-    if (mem_block_start(previous_oldspace_alloc_ptr+1) == previous_oldspace_alloc_ptr) {
+    if (mem_block_start(previous_oldspace_alloc_ptr + 1)
+        == previous_oldspace_alloc_ptr) {
       // this means that the previous oldspace allocation pointer points to an
       // address that is megabyte-aligned. This can only happen if we have just
       // filled up a block but have not yet allocated the next block in the
@@ -310,17 +305,18 @@ void koreCollect(void** roots, uint8_t nroots, layoutitem *typeInfo) {
   }
   if (scan_ptr != *old_alloc_ptr()) {
     MEM_LOG("Evacuating old generation\n");
-    while(scan_ptr) {
+    while (scan_ptr) {
       scan_ptr = evacuate(scan_ptr, old_alloc_ptr());
     }
   }
 #ifdef GC_DBG
-  ssize_t numBytesAllocedSinceLastCollection = ptrDiff(current_alloc_ptr, last_alloc_ptr);
+  ssize_t numBytesAllocedSinceLastCollection
+      = ptrDiff(current_alloc_ptr, last_alloc_ptr);
   assert(numBytesAllocedSinceLastCollection >= 0);
   fwrite(&numBytesAllocedSinceLastCollection, sizeof(ssize_t), 1, stderr);
   last_alloc_ptr = *young_alloc_ptr();
-  fwrite(numBytesLiveAtCollection, 
-      sizeof(numBytesLiveAtCollection[0]),
+  fwrite(
+      numBytesLiveAtCollection, sizeof(numBytesLiveAtCollection[0]),
       sizeof(numBytesLiveAtCollection) / sizeof(numBytesLiveAtCollection[0]),
       stderr);
 #endif
@@ -337,5 +333,4 @@ bool is_collection() {
   size_t threshold = get_gc_threshold();
   return youngspaceAlmostFull(threshold);
 }
-
 }

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -9,34 +9,34 @@ extern bool kllvm_randStateInitialized;
 
 extern "C" {
 
-  void migrate(block** blockPtr);
+void migrate(block **blockPtr);
 
-  void migrateRoots() {
-    auto &l = list_impl::empty();
-    migrate_list((void *)&l);
-    auto &s = set_impl::empty();
-    migrate_set((void *)&s);
-    auto &m = map_impl::empty();
-    migrate_map((void *)&m);
-    if (kllvm_randStateInitialized) {
-      auto &rand = kllvm_randState->_mp_seed->_mp_d;
-      string *limbs = struct_base(string, data, rand);
-      migrate((block **)&limbs);
-      rand = (mp_limb_t *)limbs->data;
-    }
-    if (blockEnumerators.empty()) {
-      return;
-    }
+void migrateRoots() {
+  auto &l = list_impl::empty();
+  migrate_list((void *)&l);
+  auto &s = set_impl::empty();
+  migrate_set((void *)&s);
+  auto &m = map_impl::empty();
+  migrate_map((void *)&m);
+  if (kllvm_randStateInitialized) {
+    auto &rand = kllvm_randState->_mp_seed->_mp_d;
+    string *limbs = struct_base(string, data, rand);
+    migrate((block **)&limbs);
+    rand = (mp_limb_t *)limbs->data;
+  }
+  if (blockEnumerators.empty()) {
+    return;
+  }
 
-    for (auto iter = blockEnumerators.begin(); iter != blockEnumerators.end(); iter++) {
-      auto BlockIteratorPair = (*(*iter))();
-      block_iterator BlockStartIt = BlockIteratorPair.first;
-      block_iterator BlockEndIt = BlockIteratorPair.second;
-      
-      for (block_iterator it =  BlockStartIt; it != BlockEndIt; ++it) {
-        migrate(*it);
-      }
+  for (auto iter = blockEnumerators.begin(); iter != blockEnumerators.end();
+       iter++) {
+    auto BlockIteratorPair = (*(*iter))();
+    block_iterator BlockStartIt = BlockIteratorPair.first;
+    block_iterator BlockEndIt = BlockIteratorPair.second;
+
+    for (block_iterator it = BlockStartIt; it != BlockEndIt; ++it) {
+      migrate(*it);
     }
   }
 }
-
+}

--- a/runtime/collections/hash.cpp
+++ b/runtime/collections/hash.cpp
@@ -1,123 +1,124 @@
 #include "runtime/header.h"
 
 extern "C" {
-  void map_hash(map *, void *);
-  void list_hash(list *, void *);
-  void set_hash(set *, void *);
-  void int_hash(mpz_ptr, void *);
-  void float_hash(floating *, void *);
+void map_hash(map *, void *);
+void list_hash(list *, void *);
+void set_hash(set *, void *);
+void int_hash(mpz_ptr, void *);
+void float_hash(floating *, void *);
 
-  static thread_local uint32_t hash_length;
-  static thread_local uint32_t hash_depth;
-  static constexpr uint32_t HASH_THRESHOLD = 5;
-  static constexpr uint32_t HASH_LENGTH_THRESHOLD = 1024;
+static thread_local uint32_t hash_length;
+static thread_local uint32_t hash_depth;
+static constexpr uint32_t HASH_THRESHOLD = 5;
+static constexpr uint32_t HASH_LENGTH_THRESHOLD = 1024;
 
-  __attribute__((always_inline)) void add_hash8(void *h, uint8_t data) {
-    size_t *hash = (size_t *)h;
-    *hash = ((*hash) ^ ((size_t)data)) * 1099511628211UL;
-    hash_length++;
+__attribute__((always_inline)) void add_hash8(void *h, uint8_t data) {
+  size_t *hash = (size_t *)h;
+  *hash = ((*hash) ^ ((size_t)data)) * 1099511628211UL;
+  hash_length++;
+}
+
+__attribute__((always_inline)) void add_hash64(void *h, uint64_t data) {
+  uint8_t *buf = (uint8_t *)&data;
+  add_hash8(h, buf[0]);
+  add_hash8(h, buf[1]);
+  add_hash8(h, buf[2]);
+  add_hash8(h, buf[3]);
+  add_hash8(h, buf[4]);
+  add_hash8(h, buf[5]);
+  add_hash8(h, buf[6]);
+  add_hash8(h, buf[7]);
+}
+
+__attribute__((always_inline)) void
+add_hash_str(void *h, char *data, size_t len) {
+  if (len + hash_length > HASH_LENGTH_THRESHOLD) {
+    len = HASH_LENGTH_THRESHOLD - hash_length;
   }
-
-  __attribute__((always_inline)) void add_hash64(void *h, uint64_t data) {
-    uint8_t *buf = (uint8_t *)&data;
-    add_hash8(h, buf[0]);
-    add_hash8(h, buf[1]);
-    add_hash8(h, buf[2]);
-    add_hash8(h, buf[3]);
-    add_hash8(h, buf[4]);
-    add_hash8(h, buf[5]);
-    add_hash8(h, buf[6]);
-    add_hash8(h, buf[7]);
+  for (size_t i = 0; i < len; i++) {
+    add_hash8(h, data[i]);
   }
+}
 
-  __attribute__((always_inline)) void add_hash_str(void *h, char *data, size_t len) {
-    if (len + hash_length > HASH_LENGTH_THRESHOLD) {
-      len = HASH_LENGTH_THRESHOLD - hash_length;
-    }
-    for (size_t i = 0; i < len; i++) {
-      add_hash8(h, data[i]);
-    }
-  }
+size_t hash_k(block *term) {
+  size_t hash = 14695981039346656037ULL;
+  hash_length = 0;
+  k_hash(term, &hash);
 
-  size_t hash_k(block *term) {
-    size_t hash = 14695981039346656037ULL;
-    hash_length = 0;
-    k_hash(term, &hash);
+  return hash;
+}
 
-    return hash;
-  }
+bool hash_enter() {
+  bool result
+      = hash_depth < HASH_THRESHOLD && hash_length < HASH_LENGTH_THRESHOLD;
+  hash_depth = hash_depth + 1;
+  return result;
+}
 
-  bool hash_enter() {
-    bool result = hash_depth < HASH_THRESHOLD && hash_length < HASH_LENGTH_THRESHOLD;
-    hash_depth = hash_depth + 1;
-    return result;
-  }
+void hash_exit() {
+  hash_depth = hash_depth - 1;
+}
 
-  void hash_exit() {
-    hash_depth = hash_depth - 1;
-  }
-
-  void k_hash(block *arg, void *h) {
-    if (hash_enter()) {
-      uint64_t argintptr = (uint64_t)arg;
-      if (is_leaf_block(argintptr)) {
-        add_hash64(h, argintptr);
-      } else {
-        uint64_t arghdrcanon = arg->h.hdr & HDR_MASK;
-        if (uint16_t arglayout = layout(arg)) {
-          add_hash64(h, arghdrcanon);
-          layout *layoutPtr = getLayoutData(arglayout);
-          uint8_t length = layoutPtr->nargs;
-          for (uint8_t i = 0; i < length; i++) {
-            uint64_t offset = layoutPtr->args[i].offset;
-            uint16_t cat = layoutPtr->args[i].cat;
-            switch(cat) {
-            case MAP_LAYOUT: {
-              map *mapptr = (map *)(argintptr+offset);
-              map_hash(mapptr, h);
-              break;
-            }
-            case LIST_LAYOUT: {
-              list *listptr = (list *)(argintptr+offset);
-              list_hash(listptr, h);
-              break;
-            }
-            case SET_LAYOUT: {
-              set *setptr = (set *)(argintptr+offset);
-              set_hash(setptr, h);
-              break;
-            }
-            case INT_LAYOUT: {
-              mpz_ptr *intptrptr = (mpz_ptr *)(argintptr+offset);
-              int_hash(*intptrptr, h);
-              break;
-            }
-            case FLOAT_LAYOUT: {
-              floating **floatptrptr = (floating **)(argintptr+offset);
-              float_hash(*floatptrptr, h);
-              break;
-            }
-            case BOOL_LAYOUT: {
-              bool *boolptr = (bool *)(argintptr+offset);
-              add_hash8(h, *boolptr);
-              break;
-            }
-            case SYMBOL_LAYOUT:
-            case VARIABLE_LAYOUT: {
-              block **childptrptr = (block **)(argintptr+offset);
-              k_hash(*childptrptr, h);
-              break;
-            }
-            default:
-              abort();
-            }
+void k_hash(block *arg, void *h) {
+  if (hash_enter()) {
+    uint64_t argintptr = (uint64_t)arg;
+    if (is_leaf_block(argintptr)) {
+      add_hash64(h, argintptr);
+    } else {
+      uint64_t arghdrcanon = arg->h.hdr & HDR_MASK;
+      if (uint16_t arglayout = layout(arg)) {
+        add_hash64(h, arghdrcanon);
+        layout *layoutPtr = getLayoutData(arglayout);
+        uint8_t length = layoutPtr->nargs;
+        for (uint8_t i = 0; i < length; i++) {
+          uint64_t offset = layoutPtr->args[i].offset;
+          uint16_t cat = layoutPtr->args[i].cat;
+          switch (cat) {
+          case MAP_LAYOUT: {
+            map *mapptr = (map *)(argintptr + offset);
+            map_hash(mapptr, h);
+            break;
           }
-        } else {
-          string *str = (string *)arg;
-          add_hash_str(h, str->data, len(arg));
+          case LIST_LAYOUT: {
+            list *listptr = (list *)(argintptr + offset);
+            list_hash(listptr, h);
+            break;
+          }
+          case SET_LAYOUT: {
+            set *setptr = (set *)(argintptr + offset);
+            set_hash(setptr, h);
+            break;
+          }
+          case INT_LAYOUT: {
+            mpz_ptr *intptrptr = (mpz_ptr *)(argintptr + offset);
+            int_hash(*intptrptr, h);
+            break;
+          }
+          case FLOAT_LAYOUT: {
+            floating **floatptrptr = (floating **)(argintptr + offset);
+            float_hash(*floatptrptr, h);
+            break;
+          }
+          case BOOL_LAYOUT: {
+            bool *boolptr = (bool *)(argintptr + offset);
+            add_hash8(h, *boolptr);
+            break;
+          }
+          case SYMBOL_LAYOUT:
+          case VARIABLE_LAYOUT: {
+            block **childptrptr = (block **)(argintptr + offset);
+            k_hash(*childptrptr, h);
+            break;
+          }
+          default: abort();
+          }
         }
+      } else {
+        string *str = (string *)arg;
+        add_hash_str(h, str->data, len(arg));
       }
     }
-    hash_exit();
   }
+  hash_exit();
+}
 }

--- a/runtime/collections/lists.cpp
+++ b/runtime/collections/lists.cpp
@@ -5,241 +5,243 @@
 #include "immer/flex_vector_transient.hpp"
 
 extern "C" {
-  list hook_LIST_unit() {
-    return list();
+list hook_LIST_unit() {
+  return list();
+}
+
+list hook_LIST_element(SortKItem value) {
+  return list{value};
+}
+
+list hook_LIST_concat(SortList l1, SortList l2) {
+  if (l2->size() < 32) {
+    auto tmp = l1->transient();
+    for (auto iter = l2->begin(); iter != l2->end(); ++iter) {
+      tmp.push_back(*iter);
+    }
+    return tmp.persistent();
+  } else {
+    return (*l1) + (*l2);
+  }
+}
+
+bool hook_LIST_in(SortKItem value, SortList list) {
+  for (auto iter = list->begin(); iter != list->end(); ++iter) {
+    if (hook_KEQUAL_eq(*iter, value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool hook_LIST_in_keys(SortInt index, SortList list) {
+  if (!mpz_fits_ulong_p(index)) {
+    throw std::invalid_argument("Index is too large for in_keys");
+  }
+  size_t idx = mpz_get_ui(index);
+  return idx < list->size();
+}
+
+SortKItem hook_LIST_get_long(SortList list, ssize_t idx) {
+  size_t size = list->size();
+  size_t abs_idx = idx < 0 ? (long)size + idx : idx;
+  return list->at(abs_idx);
+}
+
+SortKItem hook_LIST_get(SortList list, SortInt index) {
+  if (!mpz_fits_slong_p(index)) {
+    throw std::invalid_argument("Index is too large for get");
+  }
+  ssize_t idx = mpz_get_si(index);
+  return hook_LIST_get_long(list, idx);
+}
+
+SortKItem hook_LIST_lookup(SortList list, SortInt index) {
+  return hook_LIST_get(list, index);
+}
+
+list hook_LIST_range_long(SortList list, size_t front, size_t back) {
+  size_t size = list->size();
+
+  if (size < front + back) {
+    throw std::out_of_range("Index out of range range_long");
   }
 
-  list hook_LIST_element(SortKItem value) {
-    return list{value};
+  auto tmp = list->transient();
+  tmp.drop(front);
+  tmp.take(size - back - front);
+  return tmp.persistent();
+}
+
+list hook_LIST_range(SortList list, SortInt from_front, SortInt from_back) {
+  if (!mpz_fits_ulong_p(from_front) || !mpz_fits_ulong_p(from_back)) {
+    throw std::invalid_argument("Range index too large for range");
   }
 
-  list hook_LIST_concat(SortList l1, SortList l2) {
-    if (l2->size() < 32) {
-      auto tmp = l1->transient();
-      for (auto iter = l2->begin(); iter != l2->end(); ++iter) {
-        tmp.push_back(*iter);
-      }
-      return tmp.persistent();
-    } else {
-      return (*l1) + (*l2);
+  size_t front = mpz_get_ui(from_front);
+  size_t back = mpz_get_ui(from_back);
+
+  return hook_LIST_range_long(list, front, back);
+}
+
+size_t hook_LIST_size_long(SortList list) {
+  return list->size();
+}
+
+SortInt hook_LIST_size(SortList list) {
+  mpz_t size;
+  mpz_init_set_ui(size, list->size());
+  return move_int(size);
+}
+
+list hook_LIST_make(SortInt len, SortKItem value) {
+  if (!mpz_fits_ulong_p(len)) {
+    throw std::invalid_argument("Length is too large for make");
+  }
+
+  size_t length = mpz_get_ui(len);
+  return list(length, value);
+}
+
+list hook_LIST_update(SortList list, SortInt index, SortKItem value) {
+  if (!mpz_fits_ulong_p(index)) {
+    throw std::invalid_argument("Length is too large for update");
+  }
+
+  size_t idx = mpz_get_ui(index);
+  if (idx >= list->size()) {
+    throw std::invalid_argument("Index out of range for update");
+  }
+
+  return list->set(idx, value);
+}
+
+list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
+  if (!mpz_fits_ulong_p(index)) {
+    throw std::invalid_argument("Length is too large for updateAll");
+  }
+
+  size_t idx = mpz_get_ui(index);
+  size_t size = l1->size();
+  size_t size2 = l2->size();
+  if (idx != 0 && size2 != 0) {
+    if (idx + size2 - 1 >= size) {
+      throw std::invalid_argument("Index out of range for updateAll");
     }
   }
 
-  bool hook_LIST_in(SortKItem value, SortList list) {
-    for (auto iter = list->begin(); iter != list->end(); ++iter) {
-      if (hook_KEQUAL_eq(*iter, value)) {
-        return true;
-      }
-    }
-    return false;
-  }
+  if (size2 < 32) {
+    auto tmp = l1->transient();
 
-  bool hook_LIST_in_keys(SortInt index, SortList list) {
-    if (!mpz_fits_ulong_p(index)) {
-      throw std::invalid_argument("Index is too large for in_keys");
-    }
-    size_t idx = mpz_get_ui(index);
-    return idx < list->size();
-  }
-
-  SortKItem hook_LIST_get_long(SortList list, ssize_t idx) {
-    size_t size = list->size();
-    size_t abs_idx = idx < 0 ? (long) size + idx : idx;
-    return list->at(abs_idx);
-  }
-
-  SortKItem hook_LIST_get(SortList list, SortInt index) {
-    if (!mpz_fits_slong_p(index)) {
-      throw std::invalid_argument("Index is too large for get");
-    }
-    ssize_t idx = mpz_get_si(index);
-    return hook_LIST_get_long(list, idx);
-  }
-
-  SortKItem hook_LIST_lookup(SortList list, SortInt index) {
-    return hook_LIST_get(list, index);
-  }
-
-  list hook_LIST_range_long(SortList list, size_t front, size_t back) {
-    size_t size = list->size();
-
-    if (size < front + back) {
-      throw std::out_of_range("Index out of range range_long");
+    for (int i = idx, j = 0; j < size2; ++i, ++j) {
+      tmp.set(i, l2->at(j));
     }
 
-    auto tmp = list->transient();
-    tmp.drop(front);
-    tmp.take(size-back-front);
+    return tmp.persistent();
+  } else {
+    auto tmp = l1->transient();
+    tmp.take(idx);
+    tmp.append(l2->transient());
+    auto tmp2 = l1->transient();
+    tmp2.drop(idx + size2);
+    tmp.append(tmp2);
     return tmp.persistent();
   }
+}
 
-  list hook_LIST_range(SortList list, SortInt from_front, SortInt from_back) {
-    if (!mpz_fits_ulong_p(from_front) || !mpz_fits_ulong_p(from_back)) {
-      throw std::invalid_argument("Range index too large for range");
-    }
-
-    size_t front = mpz_get_ui(from_front);
-    size_t back = mpz_get_ui(from_back);
-
-    return hook_LIST_range_long(list, front, back);
+list hook_LIST_fill(SortList l, SortInt index, SortInt len, SortKItem val) {
+  if (!mpz_fits_ulong_p(index)) {
+    throw std::invalid_argument("Index is too large for fill");
   }
 
-  size_t hook_LIST_size_long(SortList list) {
-    return list->size();
+  if (!mpz_fits_ulong_p(len)) {
+    throw std::invalid_argument("Length is too large for fill");
   }
 
-  SortInt hook_LIST_size(SortList list) {
-    mpz_t size;
-    mpz_init_set_ui(size, list->size());
-    return move_int(size);
-  }
+  size_t idx = mpz_get_ui(index);
+  size_t length = mpz_get_ui(len);
 
-  list hook_LIST_make(SortInt len, SortKItem value) {
-    if (!mpz_fits_ulong_p(len)) {
-      throw std::invalid_argument("Length is too large for make");
-    }
-
-    size_t length = mpz_get_ui(len);
-    return list(length, value);
-  }
-
-  list hook_LIST_update(SortList list, SortInt index, SortKItem value) {
-    if (!mpz_fits_ulong_p(index)) {
-      throw std::invalid_argument("Length is too large for update");
-    }
-    
-    size_t idx = mpz_get_ui(index);
-    if (idx >= list->size()) {
-      throw std::invalid_argument("Index out of range for update");
-    }
-
-    return list->set(idx, value);
-  }
-
-  list hook_LIST_updateAll(SortList l1, SortInt index, SortList l2) {
-    if (!mpz_fits_ulong_p(index)) {
-      throw std::invalid_argument("Length is too large for updateAll");
-    }
-
-    size_t idx = mpz_get_ui(index);
-    size_t size = l1->size();
-    size_t size2 = l2->size();
-    if (idx != 0 && size2 != 0) {
-      if (idx + size2 - 1 >= size) {
-        throw std::invalid_argument("Index out of range for updateAll");
-      }
-    }
-
-    if (size2 < 32) {
-      auto tmp = l1->transient();
-
-      for (int i = idx, j = 0; j < size2; ++i, ++j) {
-        tmp.set(i, l2->at(j));
-      }
-
-      return tmp.persistent();
-    } else {
-      auto tmp = l1->transient();
-      tmp.take(idx);
-      tmp.append(l2->transient());
-      auto tmp2 = l1->transient();
-      tmp2.drop(idx + size2);
-      tmp.append(tmp2);
-      return tmp.persistent();
+  if (idx != 0 && length != 0) {
+    if (idx + length - 1 >= l->size()) {
+      throw std::out_of_range("Index out of range for fill");
     }
   }
 
-  list hook_LIST_fill(SortList l, SortInt index, SortInt len, SortKItem val) {
-    if (!mpz_fits_ulong_p(index)) {
-      throw std::invalid_argument("Index is too large for fill");
+  if (length < 32) {
+    auto tmp = l->transient();
+
+    for (auto i = idx; i < idx + length; ++i) {
+      tmp.set(i, val);
     }
 
-    if (!mpz_fits_ulong_p(len)) {
-      throw std::invalid_argument("Length is too large for fill");
-    }
-
-    size_t idx = mpz_get_ui(index);
-    size_t length = mpz_get_ui(len);
-
-    if (idx != 0 && length != 0) {
-      if (idx + length - 1 >= l->size()) {
-        throw std::out_of_range("Index out of range for fill");
-      }
-    }
-
-    if (length < 32) {
-      auto tmp = l->transient();
-
-      for (auto i = idx; i < idx + length; ++i) {
-        tmp.set(i, val);
-      }
-
-      return tmp.persistent();
-    } else {
-      auto tmp = l->transient();
-      tmp.take(idx);
-      auto l2 = list{length, val}.transient();
-      tmp.append(l2);
-      auto tmp2 = l->transient();
-      tmp2.drop(idx + length);
-      tmp.append(tmp2);
-      return tmp.persistent();
-    }
+    return tmp.persistent();
+  } else {
+    auto tmp = l->transient();
+    tmp.take(idx);
+    auto l2 = list{length, val}.transient();
+    tmp.append(l2);
+    auto tmp2 = l->transient();
+    tmp2.drop(idx + length);
+    tmp.append(tmp2);
+    return tmp.persistent();
   }
+}
 
-  bool hook_LIST_eq(SortList l1, SortList l2) {
-    return (*l1) == (*l2);
-  }
+bool hook_LIST_eq(SortList l1, SortList l2) {
+  return (*l1) == (*l2);
+}
 
-  void list_hash(list *l, void *hasher) {
-    if (hash_enter()) {
-      for (auto iter = l->begin(); iter != l->end(); ++iter) {
-        k_hash(*iter, hasher);
-      }
-    }
-    hash_exit();
-  }
-
-  void list_foreach(list * list, void (process)(block **)) {
-    for (auto iter = list->begin(); iter != list->end(); ++iter) {
-      process((block **)&*iter);
-    }
-  }
-
-  list list_map(list * l, block * (process)(block *)) {
-    auto tmp = list().transient();
-
+void list_hash(list *l, void *hasher) {
+  if (hash_enter()) {
     for (auto iter = l->begin(); iter != l->end(); ++iter) {
-      tmp.push_back(process(*iter));
+      k_hash(*iter, hasher);
     }
+  }
+  hash_exit();
+}
 
-    return tmp.persistent();
+void list_foreach(list *list, void(process)(block **)) {
+  for (auto iter = list->begin(); iter != list->end(); ++iter) {
+    process((block **)&*iter);
+  }
+}
+
+list list_map(list *l, block *(process)(block *)) {
+  auto tmp = list().transient();
+
+  for (auto iter = l->begin(); iter != l->end(); ++iter) {
+    tmp.push_back(process(*iter));
   }
 
-  list list_push_back(list * list, block * value) {
-    return list->push_back(value);
+  return tmp.persistent();
+}
+
+list list_push_back(list *list, block *value) {
+  return list->push_back(value);
+}
+
+void printList(
+    writer *file, list *list, const char *unit, const char *element,
+    const char *concat) {
+  size_t size = list->size();
+  if (size == 0) {
+    sfprintf(file, "%s()", unit);
+    return;
   }
 
-  void printList(writer * file, list * list, const char * unit, const char * element, const char * concat) {
-    size_t size = list->size();
-    if (size == 0) {
-      sfprintf(file, "%s()", unit);
-      return;
-    }
+  sfprintf(file, "\\left-assoc{}(%s(", concat);
 
-    sfprintf(file, "\\left-assoc{}(%s(", concat);
-
-    bool once = true;
-    for (auto iter = list->begin(); iter != list->end(); ++iter) {
-      if (once) {
-        once = false;
-      } else {
-        sfprintf(file, ",");
-      }
-      sfprintf(file, "%s(", element);
-      printConfigurationInternal(file, *iter, "SortKItem{}", false);
-      sfprintf(file, ")");
+  bool once = true;
+  for (auto iter = list->begin(); iter != list->end(); ++iter) {
+    if (once) {
+      once = false;
+    } else {
+      sfprintf(file, ",");
     }
-    sfprintf(file, "))");
+    sfprintf(file, "%s(", element);
+    printConfigurationInternal(file, *iter, "SortKItem{}", false);
+    sfprintf(file, ")");
   }
+  sfprintf(file, "))");
+}
 }

--- a/runtime/collections/maps.cpp
+++ b/runtime/collections/maps.cpp
@@ -3,217 +3,220 @@
 #include "immer/flex_vector_transient.hpp"
 
 extern "C" {
-  mapiter map_iterator(map *map) {
-    return mapiter{map->begin(), map};
-  }
+mapiter map_iterator(map *map) {
+  return mapiter{map->begin(), map};
+}
 
-  block *map_iterator_next(mapiter *iter) {
-    if (iter->curr == iter->map->end()) {
-      return nullptr;
-    }
-    return (iter->curr++)->first;
-  }
-
-  map hook_MAP_element(SortKItem key, SortKItem value) {
-    return map().set(key, value);
-  }
-
-  map hook_MAP_unit() {
-    return map();
-  }
-
-  map hook_MAP_concat(SortMap m1, SortMap m2) {
-    auto from = m1->size() < m2->size() ? m1 : m2;
-    auto to = m1->size() < m2->size() ? *m2 : *m1;
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-      auto entry = *iter;
-	if (to.find(entry.first)) {
-        throw std::invalid_argument("Duplicate keys");
-	}
-      to = to.insert(*iter);
-    }
-    return to;
-  }
-
-  SortKItem hook_MAP_lookup_null(SortMap m, SortKItem key) {
-    if (auto val = m->find(key)) {
-      return *val;
-    }
+block *map_iterator_next(mapiter *iter) {
+  if (iter->curr == iter->map->end()) {
     return nullptr;
   }
+  return (iter->curr++)->first;
+}
 
-  SortKItem hook_MAP_lookup(SortMap m, SortKItem key) {
-    auto res = hook_MAP_lookup_null(m, key);
-    if(!res) {
-      throw std::invalid_argument("key not found");
+map hook_MAP_element(SortKItem key, SortKItem value) {
+  return map().set(key, value);
+}
+
+map hook_MAP_unit() {
+  return map();
+}
+
+map hook_MAP_concat(SortMap m1, SortMap m2) {
+  auto from = m1->size() < m2->size() ? m1 : m2;
+  auto to = m1->size() < m2->size() ? *m2 : *m1;
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    auto entry = *iter;
+    if (to.find(entry.first)) {
+      throw std::invalid_argument("Duplicate keys");
     }
-    return res;
+    to = to.insert(*iter);
   }
+  return to;
+}
 
-  SortKItem hook_MAP_lookupOrDefault(SortMap m, SortKItem key, SortKItem _default) {
-    auto res = hook_MAP_lookup_null(m, key);
-    if (!res) {
-      return _default;
-    }
-    return res;
+SortKItem hook_MAP_lookup_null(SortMap m, SortKItem key) {
+  if (auto val = m->find(key)) {
+    return *val;
   }
+  return nullptr;
+}
 
-  map hook_MAP_update(SortMap m, SortKItem key, SortKItem value) {
-    return m->set(key, value);
+SortKItem hook_MAP_lookup(SortMap m, SortKItem key) {
+  auto res = hook_MAP_lookup_null(m, key);
+  if (!res) {
+    throw std::invalid_argument("key not found");
   }
+  return res;
+}
 
-  map hook_MAP_remove(SortMap m, SortKItem key) {
-    return m->erase(key);
+SortKItem
+hook_MAP_lookupOrDefault(SortMap m, SortKItem key, SortKItem _default) {
+  auto res = hook_MAP_lookup_null(m, key);
+  if (!res) {
+    return _default;
   }
+  return res;
+}
 
-  map hook_MAP_difference(SortMap m1, SortMap m2) {
-    auto from = m2;
-    auto to = *m1;
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-      auto entry = *iter;
-	if (auto value = to.find(entry.first)) {
-        if (*value == entry.second) {
-          to = to.erase(entry.first);
-	  }
-	}
-    }
-    return to;
-  }
+map hook_MAP_update(SortMap m, SortKItem key, SortKItem value) {
+  return m->set(key, value);
+}
 
-  set hook_SET_unit(void);
-  set hook_SET_element(block *);
-  set hook_SET_concat(set *, set *);
+map hook_MAP_remove(SortMap m, SortKItem key) {
+  return m->erase(key);
+}
 
-  set hook_MAP_keys(SortMap m) {
-    auto tmp = hook_SET_unit();
-    for (auto iter = m->begin(); iter != m->end(); ++iter) {
-      auto elem = hook_SET_element(iter->first);
-      tmp = hook_SET_concat(&tmp, &elem);
-    }
-    return tmp;
-  }
-
-  list hook_MAP_keys_list(SortMap m) {
-    auto tmp = list().transient();
-    for (auto iter = m->begin(); iter != m->end(); ++iter) {
-      tmp.push_back(iter->first);
-    }
-    return tmp.persistent();
-  }
-
-  bool hook_MAP_in_keys(SortKItem key, SortMap m) {
-    return m->find(key);
-  }
-
-  list hook_MAP_values(SortMap m) {
-    auto tmp = list().transient();
-    for (auto iter = m->begin(); iter != m->end(); ++iter) {
-      tmp.push_back(iter->second);
-    }
-    return tmp.persistent();
-  }
-
-  SortKItem hook_MAP_choice(SortMap m) {
-    if (m->empty()) {
-      throw std::invalid_argument("Map is empty");
-    }
-    return m->begin()->first;
-  }
-
-  size_t hook_MAP_size_long(SortMap m) {
-    return m->size();
-  }
-
-  SortInt hook_MAP_size(SortMap m) {
-    auto size = hook_MAP_size_long(m);
-    mpz_t result;
-    mpz_init_set_ui(result, size);
-    return move_int(result);
-  }
-
-  bool hook_MAP_inclusion(SortMap m1, SortMap m2) {
-    for (auto iter = m1->begin(); iter != m1->end(); ++iter) {
-      auto entry = *iter;
-      auto val = m2->find(entry.first);
-      if (!val || *val != entry.second) {
-        return false;
+map hook_MAP_difference(SortMap m1, SortMap m2) {
+  auto from = m2;
+  auto to = *m1;
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    auto entry = *iter;
+    if (auto value = to.find(entry.first)) {
+      if (*value == entry.second) {
+        to = to.erase(entry.first);
       }
     }
-    return true;
   }
+  return to;
+}
 
-  map hook_MAP_updateAll(SortMap m1, SortMap m2) {
-    auto from = m2;
-    auto to = *m1;
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-      to = to.insert(*iter);
+set hook_SET_unit(void);
+set hook_SET_element(block *);
+set hook_SET_concat(set *, set *);
+
+set hook_MAP_keys(SortMap m) {
+  auto tmp = hook_SET_unit();
+  for (auto iter = m->begin(); iter != m->end(); ++iter) {
+    auto elem = hook_SET_element(iter->first);
+    tmp = hook_SET_concat(&tmp, &elem);
+  }
+  return tmp;
+}
+
+list hook_MAP_keys_list(SortMap m) {
+  auto tmp = list().transient();
+  for (auto iter = m->begin(); iter != m->end(); ++iter) {
+    tmp.push_back(iter->first);
+  }
+  return tmp.persistent();
+}
+
+bool hook_MAP_in_keys(SortKItem key, SortMap m) {
+  return m->find(key);
+}
+
+list hook_MAP_values(SortMap m) {
+  auto tmp = list().transient();
+  for (auto iter = m->begin(); iter != m->end(); ++iter) {
+    tmp.push_back(iter->second);
+  }
+  return tmp.persistent();
+}
+
+SortKItem hook_MAP_choice(SortMap m) {
+  if (m->empty()) {
+    throw std::invalid_argument("Map is empty");
+  }
+  return m->begin()->first;
+}
+
+size_t hook_MAP_size_long(SortMap m) {
+  return m->size();
+}
+
+SortInt hook_MAP_size(SortMap m) {
+  auto size = hook_MAP_size_long(m);
+  mpz_t result;
+  mpz_init_set_ui(result, size);
+  return move_int(result);
+}
+
+bool hook_MAP_inclusion(SortMap m1, SortMap m2) {
+  for (auto iter = m1->begin(); iter != m1->end(); ++iter) {
+    auto entry = *iter;
+    auto val = m2->find(entry.first);
+    if (!val || *val != entry.second) {
+      return false;
     }
-    return to;
   }
+  return true;
+}
 
-  map hook_MAP_removeAll(SortMap map, SortSet set) {
-    auto tmp = *map;
-    for (auto iter = set->begin(); iter != set->end(); ++iter) {
-      tmp = tmp.erase(*iter);
-    }
-    return tmp;
+map hook_MAP_updateAll(SortMap m1, SortMap m2) {
+  auto from = m2;
+  auto to = *m1;
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    to = to.insert(*iter);
   }
+  return to;
+}
 
-  bool hook_MAP_eq(SortMap m1, SortMap m2) {
-    return (*m1) == (*m2);
+map hook_MAP_removeAll(SortMap map, SortSet set) {
+  auto tmp = *map;
+  for (auto iter = set->begin(); iter != set->end(); ++iter) {
+    tmp = tmp.erase(*iter);
   }
+  return tmp;
+}
 
-  void map_hash(map *m, void *hasher) {
-    if (hash_enter()) {
-      for (auto iter = m->begin(); iter != m->end(); ++iter) {
-        auto entry = *iter;
-        k_hash(entry.first, hasher);
-        k_hash(entry.second, hasher);
-      }
-    }
-    hash_exit();
-  }
+bool hook_MAP_eq(SortMap m1, SortMap m2) {
+  return (*m1) == (*m2);
+}
 
-  void map_foreach(map *map, void(process)(block **)) {
-    for (auto iter = map->begin(); iter != map->end(); ++iter) {
-      process((block **)&iter->first);
-      process((block **)&iter->second);
-    }
-  }
-
-  map map_map(map *map, block *(process)(block *)) {
-    auto tmp = *map;
-    for (auto iter = map->begin(); iter != map->end(); ++iter) {
+void map_hash(map *m, void *hasher) {
+  if (hash_enter()) {
+    for (auto iter = m->begin(); iter != m->end(); ++iter) {
       auto entry = *iter;
-      tmp = tmp.set(entry.first, process(entry.second));
+      k_hash(entry.first, hasher);
+      k_hash(entry.second, hasher);
     }
-    return tmp;
+  }
+  hash_exit();
+}
+
+void map_foreach(map *map, void(process)(block **)) {
+  for (auto iter = map->begin(); iter != map->end(); ++iter) {
+    process((block **)&iter->first);
+    process((block **)&iter->second);
+  }
+}
+
+map map_map(map *map, block *(process)(block *)) {
+  auto tmp = *map;
+  for (auto iter = map->begin(); iter != map->end(); ++iter) {
+    auto entry = *iter;
+    tmp = tmp.set(entry.first, process(entry.second));
+  }
+  return tmp;
+}
+
+void printMap(
+    writer *file, map *map, const char *unit, const char *element,
+    const char *concat) {
+  size_t size = map->size();
+  if (size == 0) {
+    sfprintf(file, "%s()", unit);
+    return;
   }
 
-  void printMap(writer *file, map *map, const char *unit, const char *element, const char *concat) {
-    size_t size = map->size();
-    if (size == 0) {
-      sfprintf(file, "%s()", unit);
-      return;
-    }
+  sfprintf(file, "\\left-assoc{}(%s(", concat);
 
-    sfprintf(file, "\\left-assoc{}(%s(", concat); 
-
-    bool once = true;
-    for (auto iter = map->begin(); iter != map->end(); ++iter) {
-      if (once) {
-        once = false;
-      } else {
-        sfprintf(file, ",");
-      }
-
-      sfprintf(file, "%s(", element);
-      auto entry = *iter;
-      printConfigurationInternal(file, entry.first, "SortKItem{}", false);
+  bool once = true;
+  for (auto iter = map->begin(); iter != map->end(); ++iter) {
+    if (once) {
+      once = false;
+    } else {
       sfprintf(file, ",");
-      printConfigurationInternal(file, entry.second, "SortKItem{}", false);
-      sfprintf(file, ")");
     }
-    sfprintf(file, "))");
+
+    sfprintf(file, "%s(", element);
+    auto entry = *iter;
+    printConfigurationInternal(file, entry.first, "SortKItem{}", false);
+    sfprintf(file, ",");
+    printConfigurationInternal(file, entry.second, "SortKItem{}", false);
+    sfprintf(file, ")");
   }
+  sfprintf(file, "))");
+}
 }

--- a/runtime/collections/sets.cpp
+++ b/runtime/collections/sets.cpp
@@ -3,161 +3,163 @@
 #include "immer/flex_vector_transient.hpp"
 
 extern "C" {
-  setiter set_iterator(set *set) {
-    return setiter{set->begin(), set};
-  }
+setiter set_iterator(set *set) {
+  return setiter{set->begin(), set};
+}
 
-  block *set_iterator_next(setiter *iter) {
-    if (iter->curr == iter->set->end()) {
-      return nullptr;
+block *set_iterator_next(setiter *iter) {
+  if (iter->curr == iter->set->end()) {
+    return nullptr;
+  }
+  return *(iter->curr++);
+}
+
+set hook_SET_element(SortKItem elem) {
+  return set().insert(elem);
+}
+
+set hook_SET_unit() {
+  return set();
+}
+
+bool hook_SET_in(SortKItem elem, SortSet set) {
+  return set->count(elem);
+}
+
+set hook_SET_concat(SortSet s1, SortSet s2) {
+  auto from = s1->size() < s2->size() ? s1 : s2;
+  auto to = s1->size() < s2->size() ? *s2 : *s1;
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    to = to.insert(*iter);
+  }
+  return to;
+}
+
+set hook_SET_union(SortSet s1, SortSet s2) {
+  // TODO: make concat nilpotent
+  return hook_SET_concat(s1, s2);
+}
+
+set hook_SET_difference(SortSet s1, SortSet s2) {
+  auto from = s2;
+  auto to = *s1;
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    to = to.erase(*iter);
+  }
+  return to;
+}
+
+set hook_SET_remove(SortSet s, SortKItem elem) {
+  return s->erase(elem);
+}
+
+bool hook_SET_inclusion(SortSet s1, SortSet s2) {
+  for (auto iter = s1->begin(); iter != s1->end(); ++iter) {
+    if (!s2->count(*iter)) {
+      return false;
     }
-    return *(iter->curr++);
   }
+  return true;
+}
 
-  set hook_SET_element(SortKItem elem) {
-    return set().insert(elem);
-  }
-
-  set hook_SET_unit() {
-    return set();
-  }
-
-  bool hook_SET_in(SortKItem elem, SortSet set) {
-    return set->count(elem);
-  }
-
-  set hook_SET_concat(SortSet s1, SortSet s2) {
-    auto from = s1->size() < s2->size() ? s1 : s2;
-    auto to = s1->size() < s2->size() ? *s2 : *s1;
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-      to = to.insert(*iter);
+set hook_SET_intersection(SortSet s1, SortSet s2) {
+  auto from = s1->size() < s2->size() ? s1 : s2;
+  auto to = s1->size() < s2->size() ? s2 : s1;
+  auto result = set();
+  for (auto iter = from->begin(); iter != from->end(); ++iter) {
+    auto elem = *iter;
+    if (to->count(elem)) {
+      result = result.insert(elem);
     }
-    return to;
   }
+  return result;
+}
 
-  set hook_SET_union(SortSet s1, SortSet s2) {
-    // TODO: make concat nilpotent
-    return hook_SET_concat(s1, s2);
+SortKItem hook_SET_choice(SortSet s) {
+  if (s->empty()) {
+    throw std::invalid_argument("Set is empty");
   }
+  return *s->begin();
+}
 
-  set hook_SET_difference(SortSet s1, SortSet s2) {
-    auto from = s2;
-    auto to = *s1;
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-	to = to.erase(*iter);
-    }
-    return to;
+size_t hook_SET_size_long(SortSet s) {
+  return s->size();
+}
+
+SortInt hook_SET_size(SortSet s) {
+  auto size = hook_SET_size_long(s);
+  mpz_t result;
+  mpz_init_set_ui(result, size);
+  return move_int(result);
+}
+
+list hook_SET_set2list(SortSet s) {
+  auto res = list().transient();
+  for (auto iter = s->begin(); iter != s->end(); ++iter) {
+    res.push_back(*iter);
   }
+  return res.persistent();
+}
 
-  set hook_SET_remove(SortSet s, SortKItem elem) {
-    return s->erase(elem);
+set hook_SET_list2set(SortList l) {
+  auto res = set();
+  for (auto iter = l->begin(); iter != l->end(); ++iter) {
+    res = res.insert(*iter);
   }
+  return res;
+}
 
-  bool hook_SET_inclusion(SortSet s1, SortSet s2) {
-    for (auto iter = s1->begin(); iter != s1->end(); ++iter) {
-      if (!s2->count(*iter)) {
-	return false;
-      }
-    }
-    return true;
-  }
+bool hook_SET_eq(SortSet s1, SortSet s2) {
+  return (*s1) == (*s2);
+}
 
-  set hook_SET_intersection(SortSet s1, SortSet s2) {
-    auto from = s1->size() < s2->size() ? s1 : s2;
-    auto to = s1->size() < s2->size() ? s2 : s1;
-    auto result = set();
-    for (auto iter = from->begin(); iter != from->end(); ++iter) {
-      auto elem = *iter;
-      if (to->count(elem)) {
-	result = result.insert(elem);
-      }
-    }
-    return result;
-  }
-
-  SortKItem hook_SET_choice(SortSet s) {
-    if (s->empty()) {
-      throw std::invalid_argument("Set is empty");
-    }
-    return *s->begin();
-  }
-
-  size_t hook_SET_size_long(SortSet s) {
-    return s->size();
-  }
-
-  SortInt hook_SET_size(SortSet s) {
-    auto size = hook_SET_size_long(s);
-    mpz_t result;
-    mpz_init_set_ui(result, size);
-    return move_int(result);
-  }
-
-  list hook_SET_set2list(SortSet s) {
-    auto res = list().transient();
+void set_hash(set *s, void *hasher) {
+  if (hash_enter()) {
     for (auto iter = s->begin(); iter != s->end(); ++iter) {
-      res.push_back(*iter);
-    }
-    return res.persistent();
-  }
-
-  set hook_SET_list2set(SortList l) {
-    auto res = set();
-    for (auto iter = l->begin(); iter != l->end(); ++iter) {
-      res = res.insert(*iter);
-    }
-    return res;
-  }
-
-  bool hook_SET_eq(SortSet s1, SortSet s2) {
-    return (*s1) == (*s2);
-  }
-
-  void set_hash(set *s, void *hasher) {
-    if (hash_enter()) {
-      for (auto iter = s->begin(); iter != s->end(); ++iter) {
-        k_hash(*iter, hasher);
-      }
-    }
-    hash_exit();
-  }
-
-  void set_foreach(set *set, void(process)(block **)) {
-    for (auto iter = set->begin(); iter != set->end(); ++iter) {
-      process((block **)&*iter);
+      k_hash(*iter, hasher);
     }
   }
+  hash_exit();
+}
 
-  set set_map(set *s, block *(process)(block *)) {
-    auto tmp = set();
-    for (auto iter = s->begin(); iter != s->end(); ++iter) {
-      auto elem = *iter;
-      tmp = tmp.insert(process(elem));
-    }
-    return tmp;
+void set_foreach(set *set, void(process)(block **)) {
+  for (auto iter = set->begin(); iter != set->end(); ++iter) {
+    process((block **)&*iter);
+  }
+}
+
+set set_map(set *s, block *(process)(block *)) {
+  auto tmp = set();
+  for (auto iter = s->begin(); iter != s->end(); ++iter) {
+    auto elem = *iter;
+    tmp = tmp.insert(process(elem));
+  }
+  return tmp;
+}
+
+void printSet(
+    writer *file, set *set, const char *unit, const char *element,
+    const char *concat) {
+  size_t size = set->size();
+  if (size == 0) {
+    sfprintf(file, "%s()", unit);
+    return;
   }
 
-  void printSet(writer *file, set *set, const char *unit, const char *element, const char *concat) {
-    size_t size = set->size();
-    if (size == 0) {
-      sfprintf(file, "%s()", unit);
-      return;
+  sfprintf(file, "\\left-assoc{}(%s(", concat);
+
+  bool once = true;
+  for (auto iter = set->begin(); iter != set->end(); ++iter) {
+    if (once) {
+      once = false;
+    } else {
+      sfprintf(file, ",");
     }
 
-    sfprintf(file, "\\left-assoc{}(%s(", concat); 
-
-    bool once = true;
-    for (auto iter = set->begin(); iter != set->end(); ++iter) {
-      if (once) {
-        once = false;
-      } else {
-        sfprintf(file, ",");
-      }
-
-      sfprintf(file, "%s(", element);
-      printConfigurationInternal(file, *iter, "SortKItem{}", false);
-      sfprintf(file, ")");
-    }
-    sfprintf(file, "))");
+    sfprintf(file, "%s(", element);
+    printConfigurationInternal(file, *iter, "SortKItem{}", false);
+    sfprintf(file, ")");
   }
+  sfprintf(file, "))");
+}
 }

--- a/runtime/io/io.cpp
+++ b/runtime/io/io.cpp
@@ -1,16 +1,16 @@
-#include <gmp.h>
-#include <cstring>
-#include <stdexcept>
-#include <map>
-#include <fcntl.h>
-#include <libgen.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <string>
 #include <cerrno>
-#include <sys/wait.h>
+#include <cstring>
+#include <fcntl.h>
+#include <gmp.h>
+#include <libgen.h>
+#include <map>
+#include <stdexcept>
+#include <string>
 #include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <time.h>
+#include <unistd.h>
 
 #include "runtime/alloc.h"
 #include "runtime/header.h"
@@ -21,152 +21,160 @@ extern "C" {
 #define GETTAG(symbol) "Lbl'Hash'" #symbol "{}"
 #define IOBUFSIZE 1024
 
-  extern char kompiled_directory;
+extern char kompiled_directory;
 
-  mpz_ptr move_int(mpz_t);
-  char * getTerminatedString(string * str);
+mpz_ptr move_int(mpz_t);
+char *getTerminatedString(string *str);
 
-  static block * dotK = leaf_block(getTagForSymbolName("dotk{}"));
-  static blockheader kseqHeader = {getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("kseq{}"))};
+static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));
+static blockheader kseqHeader
+    = {getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("kseq{}"))};
 
-  static std::map<std::string, std::string> logFiles;
+static std::map<std::string, std::string> logFiles;
 
-  static block * block_errno() {
-    const char * errStr;
-    switch (errno) {
-    case EOF: errStr = GETTAG(EOF); break;
-    case E2BIG: errStr = GETTAG(E2BIG); break;
-    case EACCES: errStr = GETTAG(EACCES); break;
-    case EAGAIN: errStr = GETTAG(EAGAIN); break;
-    case EBADF: errStr = GETTAG(EBADF); break;
-    case EBUSY: errStr = GETTAG(EBUSY); break;
-    case ECHILD: errStr = GETTAG(ECHILD); break;
-    case EDEADLK: errStr = GETTAG(EDEADLK); break;
-    case EDOM: errStr = GETTAG(EDOM); break;
-    case EEXIST: errStr = GETTAG(EEXIST); break;
-    case EFAULT: errStr = GETTAG(EFAULT); break;
-    case EFBIG: errStr = GETTAG(EFBIG); break;
-    case EINTR: errStr = GETTAG(EINTR); break;
-    case EINVAL: errStr = GETTAG(EINVAL); break;
-    case EIO: errStr = GETTAG(EIO); break;
-    case EISDIR: errStr = GETTAG(EISDIR); break;
-    case EMFILE: errStr = GETTAG(EMFILE); break;
-    case EMLINK: errStr = GETTAG(EMLINK); break;
-    case ENAMETOOLONG: errStr = GETTAG(ENAMETOOLONG); break;
-    case ENFILE: errStr = GETTAG(ENFILE); break;
-    case ENODEV: errStr = GETTAG(ENODEV); break;
-    case ENOENT: errStr = GETTAG(ENOENT); break;
-    case ENOEXEC: errStr = GETTAG(ENOEXEC); break;
-    case ENOLCK: errStr = GETTAG(ENOLCK); break;
-    case ENOMEM: errStr = GETTAG(ENOMEM); break;
-    case ENOSPC: errStr = GETTAG(ENOSPC); break;
-    case ENOSYS: errStr = GETTAG(ENOSYS); break;
-    case ENOTDIR: errStr = GETTAG(ENOTDIR); break;
-    case ENOTEMPTY: errStr = GETTAG(ENOTEMPTY); break;
-    case ENOTTY: errStr = GETTAG(ENOTTY); break;
-    case ENXIO: errStr = GETTAG(ENXIO); break;
-    case EPERM: errStr = GETTAG(EPERM); break;
-    case EPIPE: errStr = GETTAG(EPIPE); break;
-    case ERANGE: errStr = GETTAG(ERANGE); break;
-    case EROFS: errStr = GETTAG(EROFS); break;
-    case ESPIPE: errStr = GETTAG(ESPIPE); break;
-    case ESRCH: errStr = GETTAG(ESRCH); break;
-    case EXDEV: errStr = GETTAG(EXDEV); break;
+static block *block_errno() {
+  const char *errStr;
+  switch (errno) {
+  case EOF: errStr = GETTAG(EOF); break;
+  case E2BIG: errStr = GETTAG(E2BIG); break;
+  case EACCES: errStr = GETTAG(EACCES); break;
+  case EAGAIN: errStr = GETTAG(EAGAIN); break;
+  case EBADF: errStr = GETTAG(EBADF); break;
+  case EBUSY: errStr = GETTAG(EBUSY); break;
+  case ECHILD: errStr = GETTAG(ECHILD); break;
+  case EDEADLK: errStr = GETTAG(EDEADLK); break;
+  case EDOM: errStr = GETTAG(EDOM); break;
+  case EEXIST: errStr = GETTAG(EEXIST); break;
+  case EFAULT: errStr = GETTAG(EFAULT); break;
+  case EFBIG: errStr = GETTAG(EFBIG); break;
+  case EINTR: errStr = GETTAG(EINTR); break;
+  case EINVAL: errStr = GETTAG(EINVAL); break;
+  case EIO: errStr = GETTAG(EIO); break;
+  case EISDIR: errStr = GETTAG(EISDIR); break;
+  case EMFILE: errStr = GETTAG(EMFILE); break;
+  case EMLINK: errStr = GETTAG(EMLINK); break;
+  case ENAMETOOLONG: errStr = GETTAG(ENAMETOOLONG); break;
+  case ENFILE: errStr = GETTAG(ENFILE); break;
+  case ENODEV: errStr = GETTAG(ENODEV); break;
+  case ENOENT: errStr = GETTAG(ENOENT); break;
+  case ENOEXEC: errStr = GETTAG(ENOEXEC); break;
+  case ENOLCK: errStr = GETTAG(ENOLCK); break;
+  case ENOMEM: errStr = GETTAG(ENOMEM); break;
+  case ENOSPC: errStr = GETTAG(ENOSPC); break;
+  case ENOSYS: errStr = GETTAG(ENOSYS); break;
+  case ENOTDIR: errStr = GETTAG(ENOTDIR); break;
+  case ENOTEMPTY: errStr = GETTAG(ENOTEMPTY); break;
+  case ENOTTY: errStr = GETTAG(ENOTTY); break;
+  case ENXIO: errStr = GETTAG(ENXIO); break;
+  case EPERM: errStr = GETTAG(EPERM); break;
+  case EPIPE: errStr = GETTAG(EPIPE); break;
+  case ERANGE: errStr = GETTAG(ERANGE); break;
+  case EROFS: errStr = GETTAG(EROFS); break;
+  case ESPIPE: errStr = GETTAG(ESPIPE); break;
+  case ESRCH: errStr = GETTAG(ESRCH); break;
+  case EXDEV: errStr = GETTAG(EXDEV); break;
 #if EWOULDBLOCK != EAGAIN
-    case EWOULDBLOCK: errStr = GETTAG(EWOULDBLOCK); break;
-#endif 
-    case EINPROGRESS: errStr = GETTAG(EINPROGRESS); break;
-    case EALREADY: errStr = GETTAG(EALREADY); break;
-    case ENOTSOCK: errStr = GETTAG(ENOTSOCK); break;
-    case EDESTADDRREQ: errStr = GETTAG(EDESTADDRREQ); break;
-    case EMSGSIZE: errStr = GETTAG(EMSGSIZE); break;
-    case EPROTOTYPE: errStr = GETTAG(EPROTOTYPE); break;
-    case ENOPROTOOPT: errStr = GETTAG(ENOPROTOOPT); break;
-    case EPROTONOSUPPORT: errStr = GETTAG(EPROTONOSUPPORT); break;
-    case ESOCKTNOSUPPORT: errStr = GETTAG(ESOCKTNOSUPPORT); break;
-    case EOPNOTSUPP: errStr = GETTAG(EOPNOTSUPP); break;
-    case EPFNOSUPPORT: errStr = GETTAG(EPFNOSUPPORT); break;
-    case EAFNOSUPPORT: errStr = GETTAG(EAFNOSUPPORT); break;
-    case EADDRINUSE: errStr = GETTAG(EADDRINUSE); break;
-    case EADDRNOTAVAIL: errStr = GETTAG(EADDRNOTAVAIL); break;
-    case ENETDOWN: errStr = GETTAG(ENETDOWN); break;
-    case ENETUNREACH: errStr = GETTAG(ENETUNREACH); break;
-    case ENETRESET: errStr = GETTAG(ENETRESET); break;
-    case ECONNABORTED: errStr = GETTAG(ECONNABORTED); break;
-    case ECONNRESET: errStr = GETTAG(ECONNRESET); break;
-    case ENOBUFS: errStr = GETTAG(ENOBUFS); break;
-    case EISCONN: errStr = GETTAG(EISCONN); break;
-    case ENOTCONN: errStr = GETTAG(ENOTCONN); break;
-    case ESHUTDOWN: errStr = GETTAG(ESHUTDOWN); break;
-    case ETOOMANYREFS: errStr = GETTAG(ETOOMANYREFS); break;
-    case ETIMEDOUT: errStr = GETTAG(ETIMEDOUT); break;
-    case ECONNREFUSED: errStr = GETTAG(ECONNREFUSED); break;
-    case EHOSTDOWN: errStr = GETTAG(EHOSTDOWN); break;
-    case EHOSTUNREACH: errStr = GETTAG(EHOSTUNREACH); break;
-    case ELOOP: errStr = GETTAG(ELOOP); break;
-    case EOVERFLOW: errStr = GETTAG(EOVERFLOW); break;
-    default:
-      block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
-      retBlock->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("Lbl'Hash'unknownIOError{}"));
-      mpz_t err;
-      mpz_init_set_si(err, errno);
-      mpz_ptr p = move_int(err);
-      memcpy(retBlock->children, &p, sizeof(mpz_ptr));
-      return retBlock;
-    }
-
-    return leaf_block(getTagForSymbolName(errStr));
-  }
-
-  static blockheader header_int() {
-    static blockheader header = {(uint64_t)-1};
-
-    if (header.hdr == -1) {
-      header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"));
-    }
-
-    return header;
-  }
-
-  blockheader header_err() {
-    static blockheader header = {(uint64_t)-1};
-
-    if (header.hdr == -1) {
-      header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"));
-    }
-
-    return header;
-  }
-
-  static blockheader header_string() {
-    static blockheader header = {(uint64_t)-1};
-
-    if (header.hdr == -1) {
-      header = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortString{}, SortIOString{}}"));
-    }
-
-    return header;
-  }
-
-  static inline block * getKSeqErrorBlock() {
-    block * err = block_errno();
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + 2 * sizeof(block *)));
-    block * inj = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-    retBlock->h = kseqHeader;
-    inj->h = header_err();
-    memcpy(inj->children, &err, sizeof(block *));
-    memcpy(retBlock->children, &inj, sizeof(block *));
-    memcpy(retBlock->children + 1, &dotK, sizeof(block *));
+  case EWOULDBLOCK: errStr = GETTAG(EWOULDBLOCK); break;
+#endif
+  case EINPROGRESS: errStr = GETTAG(EINPROGRESS); break;
+  case EALREADY: errStr = GETTAG(EALREADY); break;
+  case ENOTSOCK: errStr = GETTAG(ENOTSOCK); break;
+  case EDESTADDRREQ: errStr = GETTAG(EDESTADDRREQ); break;
+  case EMSGSIZE: errStr = GETTAG(EMSGSIZE); break;
+  case EPROTOTYPE: errStr = GETTAG(EPROTOTYPE); break;
+  case ENOPROTOOPT: errStr = GETTAG(ENOPROTOOPT); break;
+  case EPROTONOSUPPORT: errStr = GETTAG(EPROTONOSUPPORT); break;
+  case ESOCKTNOSUPPORT: errStr = GETTAG(ESOCKTNOSUPPORT); break;
+  case EOPNOTSUPP: errStr = GETTAG(EOPNOTSUPP); break;
+  case EPFNOSUPPORT: errStr = GETTAG(EPFNOSUPPORT); break;
+  case EAFNOSUPPORT: errStr = GETTAG(EAFNOSUPPORT); break;
+  case EADDRINUSE: errStr = GETTAG(EADDRINUSE); break;
+  case EADDRNOTAVAIL: errStr = GETTAG(EADDRNOTAVAIL); break;
+  case ENETDOWN: errStr = GETTAG(ENETDOWN); break;
+  case ENETUNREACH: errStr = GETTAG(ENETUNREACH); break;
+  case ENETRESET: errStr = GETTAG(ENETRESET); break;
+  case ECONNABORTED: errStr = GETTAG(ECONNABORTED); break;
+  case ECONNRESET: errStr = GETTAG(ECONNRESET); break;
+  case ENOBUFS: errStr = GETTAG(ENOBUFS); break;
+  case EISCONN: errStr = GETTAG(EISCONN); break;
+  case ENOTCONN: errStr = GETTAG(ENOTCONN); break;
+  case ESHUTDOWN: errStr = GETTAG(ESHUTDOWN); break;
+  case ETOOMANYREFS: errStr = GETTAG(ETOOMANYREFS); break;
+  case ETIMEDOUT: errStr = GETTAG(ETIMEDOUT); break;
+  case ECONNREFUSED: errStr = GETTAG(ECONNREFUSED); break;
+  case EHOSTDOWN: errStr = GETTAG(EHOSTDOWN); break;
+  case EHOSTUNREACH: errStr = GETTAG(EHOSTUNREACH); break;
+  case ELOOP: errStr = GETTAG(ELOOP); break;
+  case EOVERFLOW: errStr = GETTAG(EOVERFLOW); break;
+  default:
+    block *retBlock
+        = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
+    retBlock->h = getBlockHeaderForSymbol(
+        (uint64_t)getTagForSymbolName("Lbl'Hash'unknownIOError{}"));
+    mpz_t err;
+    mpz_init_set_si(err, errno);
+    mpz_ptr p = move_int(err);
+    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
     return retBlock;
   }
 
-  static inline block* getInjErrorBlock() {
-    block * p = block_errno();
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-    retBlock->h = header_err();
-    memcpy(retBlock->children, &p, sizeof(block *));
-    return retBlock;
+  return leaf_block(getTagForSymbolName(errStr));
+}
+
+static blockheader header_int() {
+  static blockheader header = {(uint64_t)-1};
+
+  if (header.hdr == -1) {
+    header = getBlockHeaderForSymbol(
+        (uint64_t)getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"));
   }
+
+  return header;
+}
+
+blockheader header_err() {
+  static blockheader header = {(uint64_t)-1};
+
+  if (header.hdr == -1) {
+    header = getBlockHeaderForSymbol(
+        (uint64_t)getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"));
+  }
+
+  return header;
+}
+
+static blockheader header_string() {
+  static blockheader header = {(uint64_t)-1};
+
+  if (header.hdr == -1) {
+    header = getBlockHeaderForSymbol(
+        (uint64_t)getTagForSymbolName("inj{SortString{}, SortIOString{}}"));
+  }
+
+  return header;
+}
+
+static inline block *getKSeqErrorBlock() {
+  block *err = block_errno();
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + 2 * sizeof(block *)));
+  block *inj = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  retBlock->h = kseqHeader;
+  inj->h = header_err();
+  memcpy(inj->children, &err, sizeof(block *));
+  memcpy(retBlock->children, &inj, sizeof(block *));
+  memcpy(retBlock->children + 1, &dotK, sizeof(block *));
+  return retBlock;
+}
+
+static inline block *getInjErrorBlock() {
+  block *p = block_errno();
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  retBlock->h = header_err();
+  memcpy(retBlock->children, &p, sizeof(block *));
+  return retBlock;
+}
 
 #define MODE_R 1
 #define MODE_W 2
@@ -176,560 +184,570 @@ extern "C" {
 #define MODE_B 32
 #define MODE_P 64
 
-  static int getFileModes(string * modes) {
-    int flags = 0;
-    int length = len(modes);
+static int getFileModes(string *modes) {
+  int flags = 0;
+  int length = len(modes);
 
-    if (length <= 0) {
-      return -1;
-    }
-
-    switch (modes->data[0]) {
-      case 'r': flags |= MODE_R; break;
-      case 'w': flags |= MODE_W; break;
-      case 'a': flags |= MODE_A; break;
-      default: return -1;
-    }
-
-    for (int i = 1; i < length; i++) {
-      switch (modes->data[i]) {
-        case 'e':
-          flags |= (flags & MODE_E) ? -1 : MODE_E;
-          break;
-        case 'x':
-          flags |= (flags & MODE_X) ? -1 : MODE_X;
-          break;
-        case 'b':
-          flags |= (flags & MODE_B) ? -1 : MODE_B;
-          break;
-        case '+':
-          flags |= (flags & MODE_P) ? -1 : MODE_P;
-          break;
-        default: return -1;
-      }
-    }
-
-    return (flags < 0) ? -1 : flags;
+  if (length <= 0) {
+    return -1;
   }
 
-  SortIOInt hook_IO_open(SortString filename, SortString control) {
-    int flags = 0;
-    int access = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
-    int modes = getFileModes(control);
-    int fd;
-    mpz_t result;
+  switch (modes->data[0]) {
+  case 'r': flags |= MODE_R; break;
+  case 'w': flags |= MODE_W; break;
+  case 'a': flags |= MODE_A; break;
+  default: return -1;
+  }
 
-    if (-1 != modes) {
-      switch (modes & 7) {
-        case MODE_R:
-          flags = (modes & MODE_P) ? O_RDWR : O_RDONLY;
-          break;
-        case MODE_W:
-          flags = (modes & MODE_P) ? O_RDWR : O_WRONLY;
-          flags |= O_TRUNC | O_CREAT;
-          break;
-        case MODE_A:
-          flags = (modes & MODE_P) ? O_RDWR : O_WRONLY;
-          flags |= O_APPEND | O_CREAT;
-          break;
-      }
+  for (int i = 1; i < length; i++) {
+    switch (modes->data[i]) {
+    case 'e': flags |= (flags & MODE_E) ? -1 : MODE_E; break;
+    case 'x': flags |= (flags & MODE_X) ? -1 : MODE_X; break;
+    case 'b': flags |= (flags & MODE_B) ? -1 : MODE_B; break;
+    case '+': flags |= (flags & MODE_P) ? -1 : MODE_P; break;
+    default: return -1;
+    }
+  }
 
-      if (modes & MODE_E) {
-        flags |= O_CLOEXEC;
-      }
+  return (flags < 0) ? -1 : flags;
+}
 
-      if (modes & MODE_X) {
-        flags |= O_EXCL;
-      }
+SortIOInt hook_IO_open(SortString filename, SortString control) {
+  int flags = 0;
+  int access = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH;
+  int modes = getFileModes(control);
+  int fd;
+  mpz_t result;
 
-      if (modes & MODE_B) {
-      }
-
-      char * f = getTerminatedString(filename);
-      fd = open(f, flags, access);
-    } else {
-      errno = EINVAL;
-      fd = -1;
+  if (-1 != modes) {
+    switch (modes & 7) {
+    case MODE_R: flags = (modes & MODE_P) ? O_RDWR : O_RDONLY; break;
+    case MODE_W:
+      flags = (modes & MODE_P) ? O_RDWR : O_WRONLY;
+      flags |= O_TRUNC | O_CREAT;
+      break;
+    case MODE_A:
+      flags = (modes & MODE_P) ? O_RDWR : O_WRONLY;
+      flags |= O_APPEND | O_CREAT;
+      break;
     }
 
-    if (-1 == fd) {
-      return getInjErrorBlock();
+    if (modes & MODE_E) {
+      flags |= O_CLOEXEC;
     }
 
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
-    retBlock->h = header_int();
-    mpz_init_set_si(result, fd);
-    mpz_ptr p = move_int(result);
-    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
+    if (modes & MODE_X) {
+      flags |= O_EXCL;
+    }
+
+    if (modes & MODE_B) {
+    }
+
+    char *f = getTerminatedString(filename);
+    fd = open(f, flags, access);
+  } else {
+    errno = EINVAL;
+    fd = -1;
+  }
+
+  if (-1 == fd) {
+    return getInjErrorBlock();
+  }
+
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
+  retBlock->h = header_int();
+  mpz_init_set_si(result, fd);
+  mpz_ptr p = move_int(result);
+  memcpy(retBlock->children, &p, sizeof(mpz_ptr));
+  return retBlock;
+}
+
+SortIOInt hook_IO_tell(SortInt i) {
+  if (!mpz_fits_sint_p(i)) {
+    throw std::invalid_argument("Arg too large for int");
+  }
+
+  int fd = mpz_get_si(i);
+  off_t loc = lseek(fd, 0, SEEK_CUR);
+
+  if (-1 == loc) {
+    return getInjErrorBlock();
+  }
+
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
+  retBlock->h = header_int();
+  mpz_t result;
+  mpz_init_set_si(result, (long)loc);
+  mpz_ptr p = move_int(result);
+  memcpy(retBlock->children, &p, sizeof(mpz_ptr));
+  return retBlock;
+}
+
+SortIOInt hook_IO_getc(SortInt i) {
+  if (!mpz_fits_sint_p(i)) {
+    throw std::invalid_argument("Arg too large for int");
+  }
+
+  int fd = mpz_get_si(i);
+  char c;
+  ssize_t ret = read(fd, &c, sizeof(char));
+
+  if (0 == ret) {
+    block *p = leaf_block(getTagForSymbolName(GETTAG(EOF)));
+    block *retBlock
+        = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+    retBlock->h = header_err();
+    memcpy(retBlock->children, &p, sizeof(block *));
     return retBlock;
+  } else if (-1 == ret) {
+    return getInjErrorBlock();
   }
 
-  SortIOInt hook_IO_tell(SortInt i) {
-    if (!mpz_fits_sint_p(i)) {
-      throw std::invalid_argument("Arg too large for int");
-    }
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
+  retBlock->h = header_int();
+  mpz_t result;
+  mpz_init_set_si(result, (int)c);
+  mpz_ptr p = move_int(result);
+  memcpy(retBlock->children, &p, sizeof(mpz_ptr));
+  return retBlock;
+}
 
-    int fd = mpz_get_si(i);
-    off_t loc = lseek(fd, 0, SEEK_CUR);
-
-    if (-1 == loc) {
-      return getInjErrorBlock();
-    }
-
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
-    retBlock->h = header_int();
-    mpz_t result;
-    mpz_init_set_si(result, (long) loc);
-    mpz_ptr p =  move_int(result);
-    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
-    return retBlock;
+SortIOString hook_IO_read(SortInt i, SortInt len) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_ulong_p(len)) {
+    throw std::invalid_argument("Arg too large");
   }
 
-  SortIOInt hook_IO_getc(SortInt i) {
-    if (!mpz_fits_sint_p(i)) {
-      throw std::invalid_argument("Arg too large for int");
-    }
+  int fd = mpz_get_si(i);
+  size_t length = mpz_get_ui(len);
 
-    int fd = mpz_get_si(i);
-    char c;
-    ssize_t ret = read(fd, &c, sizeof(char));
+  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + length));
+  int bytes = read(fd, &(result->data), length);
 
-
-    if (0 == ret) {
-      block * p = leaf_block(getTagForSymbolName(GETTAG(EOF)));
-      block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-      retBlock->h = header_err();
-      memcpy(retBlock->children, &p, sizeof(block *));
-      return retBlock;
-    } else if (-1 == ret) {
-      return getInjErrorBlock();
-    }
-
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
-    retBlock->h = header_int();
-    mpz_t result;
-    mpz_init_set_si(result, (int) c);
-    mpz_ptr p = move_int(result);
-    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
-    return retBlock;
+  if (-1 == bytes) {
+    return getInjErrorBlock();
   }
 
-  SortIOString hook_IO_read(SortInt i, SortInt len) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_ulong_p(len)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  result = static_cast<string *>(koreResizeLastAlloc(
+      result, sizeof(string) + bytes, sizeof(string) + length));
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  retBlock->h = header_string();
+  set_len(result, bytes);
+  memcpy(retBlock->children, &result, sizeof(string *));
+  return retBlock;
+}
 
-    int fd = mpz_get_si(i);
-    size_t length = mpz_get_ui(len);
-
-    auto result = static_cast<string *>(koreAllocToken(sizeof(string) + length));
-    int bytes = read(fd, &(result->data), length);
-
-    if (-1 == bytes) {
-      return getInjErrorBlock();
-    }
-
-    result = static_cast<string *>(koreResizeLastAlloc(result, sizeof(string) + bytes, sizeof(string) + length));
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-    retBlock->h = header_string();
-    set_len(result, bytes);
-    memcpy(retBlock->children, &result, sizeof(string *));
-    return retBlock;
+SortK hook_IO_close(SortInt i) {
+  if (!mpz_fits_sint_p(i)) {
+    throw std::invalid_argument("Arg too large for int");
   }
 
-  SortK hook_IO_close(SortInt i) {
-    if (!mpz_fits_sint_p(i)) {
-      throw std::invalid_argument("Arg too large for int");
-    }
+  int fd = mpz_get_si(i);
+  int ret = close(fd);
 
-    int fd = mpz_get_si(i);
-    int ret = close(fd);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+  if (ret == -1) {
+    return getKSeqErrorBlock();
   }
 
-  SortK hook_IO_seek(SortInt i, SortInt loc) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  return dotK;
+}
 
-    int fd = mpz_get_si(i);
-    off_t l = mpz_get_si(loc);
-    int ret = lseek(fd, l, SEEK_SET);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+SortK hook_IO_seek(SortInt i, SortInt loc) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
+    throw std::invalid_argument("Arg too large");
   }
 
-  SortK hook_IO_seekEnd(SortInt i, SortInt loc) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  int fd = mpz_get_si(i);
+  off_t l = mpz_get_si(loc);
+  int ret = lseek(fd, l, SEEK_SET);
 
-    int fd = mpz_get_si(i);
-    off_t l = mpz_get_si(loc);
-    int ret = lseek(fd, l, SEEK_END);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+  if (ret == -1) {
+    return getKSeqErrorBlock();
   }
 
-  SortK hook_IO_putc(SortInt i, SortInt c) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_sint_p(c)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  return dotK;
+}
 
-    int fd = mpz_get_si(i);
-    int ch = mpz_get_si(c);
-    int ret = write(fd, &ch, 1);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+SortK hook_IO_seekEnd(SortInt i, SortInt loc) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(loc)) {
+    throw std::invalid_argument("Arg too large");
   }
 
-  SortK hook_IO_write(SortInt i, SortString str) {
-    if (!mpz_fits_sint_p(i)) {
-      throw std::invalid_argument("Arg too large for int");
-    }
+  int fd = mpz_get_si(i);
+  off_t l = mpz_get_si(loc);
+  int ret = lseek(fd, l, SEEK_END);
 
-    int fd = mpz_get_si(i);
-    int ret = write(fd, str->data, len(str));
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+  if (ret == -1) {
+    return getKSeqErrorBlock();
   }
 
-  SortK hook_IO_lock(SortInt i, SortInt len) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
-      throw std::invalid_argument("Arg too large");
+  return dotK;
+}
+
+SortK hook_IO_putc(SortInt i, SortInt c) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_sint_p(c)) {
+    throw std::invalid_argument("Arg too large");
+  }
+
+  int fd = mpz_get_si(i);
+  int ch = mpz_get_si(c);
+  int ret = write(fd, &ch, 1);
+
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+SortK hook_IO_write(SortInt i, SortString str) {
+  if (!mpz_fits_sint_p(i)) {
+    throw std::invalid_argument("Arg too large for int");
+  }
+
+  int fd = mpz_get_si(i);
+  int ret = write(fd, str->data, len(str));
+
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+SortK hook_IO_lock(SortInt i, SortInt len) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
+    throw std::invalid_argument("Arg too large");
+  }
+
+  int fd = mpz_get_si(i);
+  off_t l = mpz_get_si(len);
+
+  struct flock lockp = {0};
+  lockp.l_type = F_WRLCK;
+  lockp.l_whence = SEEK_CUR;
+  lockp.l_start = 0;
+  lockp.l_len = l;
+  int ret = fcntl(fd, F_SETLKW, &lockp);
+
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+SortK hook_IO_unlock(SortInt i, SortInt len) {
+  if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
+    throw std::invalid_argument("Arg too large");
+  }
+
+  int fd = mpz_get_si(i);
+  off_t l = mpz_get_si(len);
+
+  struct flock lockp = {0};
+  lockp.l_type = F_UNLCK;
+  lockp.l_whence = SEEK_CUR;
+  lockp.l_start = 0;
+  lockp.l_len = l;
+  int ret = fcntl(fd, F_SETLKW, &lockp);
+
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+SortK hook_IO_remove(SortString path) {
+  char *p = getTerminatedString(path);
+
+  int ret = unlink(p);
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+SortIOInt hook_IO_accept(SortInt sock) {
+  if (!mpz_fits_sint_p(sock)) {
+    throw std::invalid_argument("Arg too large");
+  }
+
+  int fd = mpz_get_si(sock);
+  int clientsock = accept(fd, NULL, NULL);
+
+  if (clientsock == -1) {
+    return getInjErrorBlock();
+  }
+
+  block *retBlock
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
+  retBlock->h = header_int();
+
+  mpz_t result;
+  mpz_init_set_si(result, clientsock);
+  mpz_ptr p = move_int(result);
+  memcpy(retBlock->children, &p, sizeof(mpz_ptr));
+  return retBlock;
+}
+
+SortK hook_IO_shutdownWrite(SortInt sock) {
+  if (!mpz_fits_sint_p(sock)) {
+    throw std::invalid_argument("Arg too large");
+  }
+
+  int fd = mpz_get_si(sock);
+  int ret = shutdown(fd, SHUT_WR);
+
+  if (ret == -1) {
+    return getKSeqErrorBlock();
+  }
+
+  return dotK;
+}
+
+void flush_IO_logs() {
+  std::string pid = std::to_string(getpid());
+  for (auto const &log : logFiles) {
+    std::string pathStr = log.first;
+    std::string msg = log.second;
+    size_t length = pathStr.length();
+    char *path1 = (char *)malloc(sizeof(char) * (length + 1));
+    strcpy(path1, pathStr.c_str());
+    char *path2 = (char *)malloc(sizeof(char) * (length + 1));
+    strcpy(path2, pathStr.c_str());
+    char *dir = dirname(path1);
+    if (getenv("K_LOG_DIR")) {
+      dir = getenv("K_LOG_DIR");
     }
-
-    int fd = mpz_get_si(i);
-    off_t l = mpz_get_si(len);
-
-    struct flock lockp = {0};
-    lockp.l_type = F_WRLCK; lockp.l_whence = SEEK_CUR; lockp.l_start = 0; lockp.l_len = l;
-    int ret = fcntl(fd, F_SETLKW, &lockp);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
+    char fulldir[PATH_MAX];
+    if (!realpath(dir, fulldir)) {
+      abort();
     }
-
-    return dotK;
-  }
-
-  SortK hook_IO_unlock(SortInt i, SortInt len) {
-    if (!mpz_fits_sint_p(i) || !mpz_fits_slong_p(len)) {
-      throw std::invalid_argument("Arg too large");
+    char *base = basename(path2);
+    std::string prefix = "";
+    if (getenv("K_LOG_PREFIX")) {
+      prefix = getenv("K_LOG_PREFIX");
     }
+    std::string fullPath
+        = std::string(fulldir) + "/" + prefix + pid + "_" + std::string(base);
+    FILE *f = fopen(fullPath.c_str(), "a+");
+    fwrite(msg.c_str(), sizeof(char), msg.length(), f);
+    fclose(f);
+    free(path1);
+    free(path2);
+  }
+}
 
-    int fd = mpz_get_si(i);
-    off_t l = mpz_get_si(len);
+SortK hook_IO_log(SortString path, SortString msg) {
+  char *p = getTerminatedString(path);
+  char *m = getTerminatedString(msg);
 
-    struct flock lockp = {0};
-    lockp.l_type = F_UNLCK; lockp.l_whence = SEEK_CUR; lockp.l_start = 0; lockp.l_len = l;
-    int ret = fcntl(fd, F_SETLKW, &lockp);
-
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    return dotK;
+  static bool flushRegistered = false;
+  if (!flushRegistered) {
+    atexit(&flush_IO_logs);
+    flushRegistered = true;
   }
 
-  SortK hook_IO_remove(SortString path) {
-    char * p = getTerminatedString(path);
+  logFiles[p].append(m);
 
-    int ret = unlink(p);
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
+  return dotK;
+}
 
-    return dotK;
+block *hook_KREFLECTION_parseKAST(string *kast) {
+  throw std::invalid_argument("not implemented: KREFLECTION.parseKast");
+}
+
+block *hook_KREFLECTION_configuration() {
+  throw std::invalid_argument("not implemented: KREFLECTION.configuration");
+}
+
+string *hook_KREFLECTION_getenv(string *str) {
+  throw std::invalid_argument("not implemented: KREFLECTION.getenv");
+}
+
+string *hook_KREFLECTION_sort(block *K) {
+  throw std::invalid_argument("not implemented: KREFLECTION.sort");
+}
+
+block *hook_KREFLECTION_getKLabel(block *K) {
+  throw std::invalid_argument("not implemented: KREFLECTION.getKLabel");
+}
+
+block *hook_KREFLECTION_fresh(string *str) {
+  throw std::invalid_argument("not implemented: KREFLECTION.fresh");
+}
+
+string *hook_KREFLECTION_kompiledDir(void) {
+  auto str_ptr = &kompiled_directory;
+  auto len = strlen(str_ptr);
+  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  memcpy(ret->data, str_ptr, len);
+  set_len(ret, len);
+  return ret;
+}
+
+int llvm_backend_argc = 0;
+char const **llvm_backend_argv = nullptr;
+
+list hook_KREFLECTION_argv() {
+  if (!llvm_backend_argv)
+    throw std::invalid_argument("KREFLECTION.argv: no arguments given");
+
+  list l{};
+
+  for (int i = 0; i < llvm_backend_argc; i++) {
+    stringbuffer *buf = hook_BUFFER_empty();
+    buf = hook_BUFFER_concat_raw(
+        buf, llvm_backend_argv[i], strlen(llvm_backend_argv[i]));
+    SortString str = hook_BUFFER_toString(buf);
+    block *b = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(str)));
+    b->h = getBlockHeaderForSymbol(
+        (uint64_t)getTagForSymbolName("inj{SortString{}, SortKItem{}}"));
+    memcpy(b->children, &str, sizeof(str));
+    l = l.push_back(KElem(b));
   }
 
-  SortIOInt hook_IO_accept(SortInt sock) {
-    if (!mpz_fits_sint_p(sock)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  return l;
+}
 
-    int fd = mpz_get_si(sock);
-    int clientsock = accept(fd, NULL, NULL);
+SortIOFile hook_IO_mkstemp(SortString filename) {
+  char *temp = getTerminatedString(filename);
+  int ret = mkstemp(temp);
 
-    if (clientsock == -1) {
-      return getInjErrorBlock();
-    }
-
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr)));
-    retBlock->h = header_int();
-
-    mpz_t result;
-    mpz_init_set_si(result, clientsock);
-    mpz_ptr p = move_int(result);
-    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
-    return retBlock;
+  if (ret == -1) {
+    return getInjErrorBlock();
   }
 
-  SortK hook_IO_shutdownWrite(SortInt sock) {
-    if (!mpz_fits_sint_p(sock)) {
-      throw std::invalid_argument("Arg too large");
-    }
+  block *retBlock = static_cast<block *>(
+      koreAlloc(sizeof(block) + sizeof(string *) + sizeof(mpz_ptr)));
 
-    int fd = mpz_get_si(sock);
-    int ret = shutdown(fd, SHUT_WR);
+  mpz_t result;
+  mpz_init_set_si(result, ret);
+  mpz_ptr p = move_int(result);
+  size_t length = len(filename);
+  string *retString = static_cast<string *>(
+      koreAllocToken(sizeof(string) + sizeof(char) * length));
+  memcpy(retString->data, temp, sizeof(char) * length);
+  set_len(retString, length);
+  memcpy(retBlock->children, &retString, sizeof(string *));
+  memcpy(retBlock->children + 1, &p, sizeof(mpz_ptr));
+  retBlock->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName(GETTAG(tempFile)));
 
-    if (ret == -1) {
-      return getKSeqErrorBlock();
-    }
+  return retBlock;
+}
 
-    return dotK;
+SortKItem hook_IO_system(SortString cmd) {
+  pid_t pid;
+  int ret = 0, out[2], err[2];
+  stringbuffer *outBuffer = hook_BUFFER_empty();
+  stringbuffer *errBuffer = hook_BUFFER_empty();
+  char buf[IOBUFSIZE];
+
+  if (pipe(out) == -1 || pipe(err) == -1 || (pid = fork()) == -1) {
+    return getKSeqErrorBlock();
   }
 
-  void flush_IO_logs() {
-    std::string pid = std::to_string(getpid());
-    for (auto const& log : logFiles) {
-      std::string pathStr = log.first;
-      std::string msg = log.second;
-      size_t length = pathStr.length();
-      char * path1 = (char *) malloc(sizeof(char) * (length + 1));
-      strcpy(path1, pathStr.c_str());
-      char * path2 = (char *) malloc(sizeof(char) * (length + 1));
-      strcpy(path2, pathStr.c_str());
-      char * dir = dirname(path1);
-      if ( getenv("K_LOG_DIR") ) {
-        dir = getenv("K_LOG_DIR");
-      }
-      char fulldir[PATH_MAX];
-      if (!realpath(dir, fulldir)) {
-        abort();
-      }
-      char * base = basename(path2);
-      std::string prefix = "";
-      if ( getenv("K_LOG_PREFIX") ) {
-        prefix = getenv("K_LOG_PREFIX");
-      }
-      std::string fullPath = std::string(fulldir) + "/" + prefix + pid + "_" + std::string(base);
-      FILE* f = fopen(fullPath.c_str(), "a+");
-      fwrite(msg.c_str(), sizeof(char), msg.length(), f);
-      fclose(f);
-      free(path1);
-      free(path2);
-    }
-  }
-
-  SortK hook_IO_log(SortString path, SortString msg) {
-    char * p = getTerminatedString(path);
-    char * m = getTerminatedString(msg);
-
-    static bool flushRegistered = false;
-    if (!flushRegistered) {
-      atexit(&flush_IO_logs);
-      flushRegistered = true;
-    }
-
-    logFiles[p].append(m);
-
-    return dotK;
-  }
-
-  block * hook_KREFLECTION_parseKAST(string *kast) {
-    throw std::invalid_argument("not implemented: KREFLECTION.parseKast");
-  }
-
-  block * hook_KREFLECTION_configuration() {
-    throw std::invalid_argument("not implemented: KREFLECTION.configuration");
-  }
-
-  string * hook_KREFLECTION_getenv(string * str) {
-    throw std::invalid_argument("not implemented: KREFLECTION.getenv");
-  }
-
-  string * hook_KREFLECTION_sort(block * K) {
-    throw std::invalid_argument("not implemented: KREFLECTION.sort");
-  }
-
-  block * hook_KREFLECTION_getKLabel(block * K) {
-    throw std::invalid_argument("not implemented: KREFLECTION.getKLabel");
-  }
-
-  block * hook_KREFLECTION_fresh(string * str) {
-    throw std::invalid_argument("not implemented: KREFLECTION.fresh");
-  }
-
-  string * hook_KREFLECTION_kompiledDir(void) {
-    auto str_ptr = &kompiled_directory;
-    auto len = strlen(str_ptr);
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
-    memcpy(ret->data, str_ptr, len);
-    set_len(ret, len);
-    return ret;
-  }
-
-  int llvm_backend_argc = 0;
-  char const ** llvm_backend_argv = nullptr;
-
-  list hook_KREFLECTION_argv() {
-    if (!llvm_backend_argv)
-      throw std::invalid_argument("KREFLECTION.argv: no arguments given");
-
-    list l{};
-
-    for (int i = 0; i < llvm_backend_argc; i++) {
-      stringbuffer * buf = hook_BUFFER_empty();
-      buf = hook_BUFFER_concat_raw(buf, llvm_backend_argv[i], strlen(llvm_backend_argv[i]));
-      SortString str = hook_BUFFER_toString(buf);
-      block * b = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(str)));
-      b->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortString{}, SortKItem{}}"));
-      memcpy(b->children, &str, sizeof(str));
-      l = l.push_back(KElem(b));
-    }
-
-    return l;
-  }
-
-  SortIOFile hook_IO_mkstemp(SortString filename) {
-    char * temp = getTerminatedString(filename);
-    int ret = mkstemp(temp);
-
-    if (ret == -1) {
-      return getInjErrorBlock();
-    }
-
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *) + sizeof(mpz_ptr)));
-
-    mpz_t result;
-    mpz_init_set_si(result, ret);
-    mpz_ptr p = move_int(result);
-    size_t length = len(filename);
-    string * retString = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(char) * length));
-    memcpy(retString->data, temp, sizeof(char) * length);
-    set_len(retString, length);
-    memcpy(retBlock->children, &retString, sizeof(string *));
-    memcpy(retBlock->children + 1, &p, sizeof(mpz_ptr));
-    retBlock->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(GETTAG(tempFile)));
-
-    return retBlock;
-  }
-
-  SortKItem hook_IO_system(SortString cmd) {
-    pid_t pid;
-    int ret = 0, out[2], err[2];
-    stringbuffer *outBuffer = hook_BUFFER_empty();
-    stringbuffer *errBuffer = hook_BUFFER_empty();
-    char buf[IOBUFSIZE];
-
-    if (pipe(out) == -1 || pipe(err) == -1 || (pid = fork()) == -1) {
-      return getKSeqErrorBlock();
-    }
-
-    if (pid == 0) {
-      dup2(out[1], STDOUT_FILENO);
-      close(out[0]);
-      close(out[1]);
-      dup2(err[1], STDERR_FILENO);
-      close(err[0]);
-      close(err[1]);
-
-      if (len(cmd) > 0) {
-        char * command = getTerminatedString(cmd);
-        ret = execl("/bin/sh", "/bin/sh", "-c", command, NULL);
-        ret == -1 ? exit(127) : exit(0);
-      } else {
-        ret = system(NULL);
-        exit(ret);
-      }
-    }
-
+  if (pid == 0) {
+    dup2(out[1], STDOUT_FILENO);
+    close(out[0]);
     close(out[1]);
+    dup2(err[1], STDERR_FILENO);
+    close(err[0]);
     close(err[1]);
 
-    fd_set read_fds, ready_fds;
-    FD_ZERO(&read_fds);
-    FD_SET(out[0], &read_fds);
-    FD_SET(err[0], &read_fds);
+    if (len(cmd) > 0) {
+      char *command = getTerminatedString(cmd);
+      ret = execl("/bin/sh", "/bin/sh", "-c", command, NULL);
+      ret == -1 ? exit(127) : exit(0);
+    } else {
+      ret = system(NULL);
+      exit(ret);
+    }
+  }
 
-    int done = 0;
+  close(out[1]);
+  close(err[1]);
 
-    while(done < 2) {
-      ready_fds = read_fds;
-      if (select(FD_SETSIZE, &ready_fds, NULL, NULL, NULL) == -1) {
+  fd_set read_fds, ready_fds;
+  FD_ZERO(&read_fds);
+  FD_SET(out[0], &read_fds);
+  FD_SET(err[0], &read_fds);
+
+  int done = 0;
+
+  while (done < 2) {
+    ready_fds = read_fds;
+    if (select(FD_SETSIZE, &ready_fds, NULL, NULL, NULL) == -1) {
+      return getKSeqErrorBlock();
+    }
+    if (FD_ISSET(out[0], &ready_fds)) {
+      int nread = read(out[0], buf, IOBUFSIZE);
+      if (nread == -1) {
         return getKSeqErrorBlock();
-      }
-      if (FD_ISSET(out[0], &ready_fds)) {
-        int nread = read(out[0], buf, IOBUFSIZE);
-        if (nread == -1) {
-          return getKSeqErrorBlock();
-        } else if (nread == 0) {
-          FD_CLR(out[0], &read_fds);
-	  done++;
-        } else {
-          hook_BUFFER_concat_raw(outBuffer, buf, nread);
-        }
-      }
-      if (FD_ISSET(err[0], &ready_fds)) {
-        int nread = read(err[0], buf, IOBUFSIZE);
-        if (nread == -1) {
-          return getKSeqErrorBlock();
-        } else if (nread == 0) {
-          FD_CLR(err[0], &read_fds);
-          done++;
-        } else {
-          hook_BUFFER_concat_raw(errBuffer, buf, nread);
-        }
+      } else if (nread == 0) {
+        FD_CLR(out[0], &read_fds);
+        done++;
+      } else {
+        hook_BUFFER_concat_raw(outBuffer, buf, nread);
       }
     }
-
-    waitpid(pid, &ret, 0);
-    ret = WEXITSTATUS(ret);
-
-    block * retBlock = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(mpz_ptr) + sizeof(string *) + sizeof(string *)));
-
-    mpz_t result;
-    mpz_init_set_si(result, ret);
-    mpz_ptr p = move_int(result);
-    memcpy(retBlock->children, &p, sizeof(mpz_ptr));
-    
-    retBlock->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(GETTAG(systemResult)));
-    string *outStr, *errStr;
-    outStr = hook_BUFFER_toString(outBuffer);
-    errStr = hook_BUFFER_toString(errBuffer);
-    memcpy(retBlock->children + 1, &outStr, sizeof(string *));
-    memcpy(retBlock->children + 2, &errStr, sizeof(string *));
-
-    return retBlock;
+    if (FD_ISSET(err[0], &ready_fds)) {
+      int nread = read(err[0], buf, IOBUFSIZE);
+      if (nread == -1) {
+        return getKSeqErrorBlock();
+      } else if (nread == 0) {
+        FD_CLR(err[0], &read_fds);
+        done++;
+      } else {
+        hook_BUFFER_concat_raw(errBuffer, buf, nread);
+      }
+    }
   }
 
-  block * hook_IO_stat(string * path) {
-    throw std::invalid_argument("not implemented: IO.stat");
-  }
+  waitpid(pid, &ret, 0);
+  ret = WEXITSTATUS(ret);
 
-  block * hook_IO_lstat(string * path) {
-    throw std::invalid_argument("not implemented: IO.lstat");
-  }
+  block *retBlock = static_cast<block *>(koreAlloc(
+      sizeof(block) + sizeof(mpz_ptr) + sizeof(string *) + sizeof(string *)));
 
-  block * hook_IO_opendir(string * path) {
-    throw std::invalid_argument("not implemented: IO.opendir");
-  }
+  mpz_t result;
+  mpz_init_set_si(result, ret);
+  mpz_ptr p = move_int(result);
+  memcpy(retBlock->children, &p, sizeof(mpz_ptr));
 
-  SortInt hook_IO_time() {
-    mpz_t result;
-    mpz_init_set_si(result, time(NULL));
-    return move_int(result);
-  }
+  retBlock->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName(GETTAG(systemResult)));
+  string *outStr, *errStr;
+  outStr = hook_BUFFER_toString(outBuffer);
+  errStr = hook_BUFFER_toString(errBuffer);
+  memcpy(retBlock->children + 1, &outStr, sizeof(string *));
+  memcpy(retBlock->children + 2, &errStr, sizeof(string *));
+
+  return retBlock;
+}
+
+block *hook_IO_stat(string *path) {
+  throw std::invalid_argument("not implemented: IO.stat");
+}
+
+block *hook_IO_lstat(string *path) {
+  throw std::invalid_argument("not implemented: IO.lstat");
+}
+
+block *hook_IO_opendir(string *path) {
+  throw std::invalid_argument("not implemented: IO.opendir");
+}
+
+SortInt hook_IO_time() {
+  mpz_t result;
+  mpz_init_set_si(result, time(NULL));
+  return move_int(result);
+}
 }

--- a/runtime/io/logTerm.cpp
+++ b/runtime/io/logTerm.cpp
@@ -1,10 +1,10 @@
 #include "runtime/header.h"
 extern "C" {
-  block * hook_IO_log(string * path, string * msg);
+block *hook_IO_log(string *path, string *msg);
 
-  SortKItem hook_IO_logTerm(SortString path, SortKItem term) {
-    string *msg = printConfigurationToString(term);
-    hook_IO_log(path, msg);
-    return term;
-  }
+SortKItem hook_IO_logTerm(SortString path, SortKItem term) {
+  string *msg = printConfigurationToString(term);
+  hook_IO_log(path, msg);
+  return term;
+}
 }

--- a/runtime/io/parseKORE.cpp
+++ b/runtime/io/parseKORE.cpp
@@ -1,31 +1,31 @@
-#include <unistd.h>
 #include <cstdio>
+#include <unistd.h>
 
 #include "runtime/header.h"
 
 extern "C" {
-  static block * dotK = leaf_block(getTagForSymbolName("dotk{}"));
+static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));
 
-  block * hook_KREFLECTION_parseKORE(SortString kore) {
-    block * parsed = dotK;
-    char filename[17] = "parseKORE_XXXXXX";
+block *hook_KREFLECTION_parseKORE(SortString kore) {
+  block *parsed = dotK;
+  char filename[17] = "parseKORE_XXXXXX";
 
-    int fd = mkstemp(filename);
+  int fd = mkstemp(filename);
 
-    bool failed = write(fd, kore->data, len(kore)) == -1;
+  bool failed = write(fd, kore->data, len(kore)) == -1;
 
-    close(fd);
+  close(fd);
 
-    if (!failed) {
-      parsed = parseConfiguration(filename);
-    }
-
-    remove(filename);
-
-    return parsed;
+  if (!failed) {
+    parsed = parseConfiguration(filename);
   }
 
-  SortString hook_KREFLECTION_printKORE(block * subject) {
-    return printConfigurationToString(subject);
-  }
+  remove(filename);
+
+  return parsed;
+}
+
+SortString hook_KREFLECTION_printKORE(block *subject) {
+  return printConfigurationToString(subject);
+}
 }

--- a/runtime/main/search.cpp
+++ b/runtime/main/search.cpp
@@ -3,12 +3,14 @@
 #include "runtime/header.h"
 
 extern "C" {
-  void initStaticObjects(void);
-  uint64_t get_steps(void);
+void initStaticObjects(void);
+uint64_t get_steps(void);
 }
 
-std::unordered_set<block *, HashBlock, KEq> take_search_steps(int64_t depth, block *subject);
-void printConfigurations(const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
+std::unordered_set<block *, HashBlock, KEq>
+take_search_steps(int64_t depth, block *subject);
+void printConfigurations(
+    const char *filename, std::unordered_set<block *, HashBlock, KEq> results);
 
 int main(int argc, char **argv) {
   char *filename = argv[1];
@@ -19,7 +21,8 @@ int main(int argc, char **argv) {
   initStaticObjects();
 
   block *input = parseConfiguration(filename);
-  std::unordered_set<block *, HashBlock, KEq> results = take_search_steps(depth, input);
+  std::unordered_set<block *, HashBlock, KEq> results
+      = take_search_steps(depth, input);
   if (hasStatistics) {
     printStatistics(output, get_steps());
   }

--- a/runtime/meta/ffi.cpp
+++ b/runtime/meta/ffi.cpp
@@ -1,14 +1,14 @@
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 #include <cstring>
 #include <dlfcn.h>
 #include <ffi.h>
 #include <gmp.h>
-#include <stdexcept>
-#include <vector>
 #include <map>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <unordered_map>
+#include <vector>
 
 #include "runtime/alloc.h"
 #include "runtime/collect.h"
@@ -16,425 +16,444 @@
 
 extern "C" {
 
-  bool hook_KEQUAL_eq(block *, block *);
+bool hook_KEQUAL_eq(block *, block *);
 
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
 
-#define TAG_TYPE(NAME) static uint64_t tag_type_##NAME() {\
-  static uint64_t tag = -1; \
-  if (tag == -1) { \
-    tag = (uint64_t)leaf_block(getTagForSymbolName(TYPETAG(NAME))); \
-  } \
-  return tag; \
-}
+#define TAG_TYPE(NAME)                                                         \
+  static uint64_t tag_type_##NAME() {                                          \
+    static uint64_t tag = -1;                                                  \
+    if (tag == -1) {                                                           \
+      tag = (uint64_t)leaf_block(getTagForSymbolName(TYPETAG(NAME)));          \
+    }                                                                          \
+    return tag;                                                                \
+  }
 
-  static block * dotK = leaf_block(getTagForSymbolName("dotk{}"));
+static block *dotK = leaf_block(getTagForSymbolName("dotk{}"));
 
-  thread_local static std::vector<ffi_type *> structTypes;
+thread_local static std::vector<ffi_type *> structTypes;
 
-  static std::unordered_map<block *, string *, HashBlock, KEq> allocatedKItemPtrs;
-  static std::map<string *, block *> allocatedBytesRefs;
+static std::unordered_map<block *, string *, HashBlock, KEq> allocatedKItemPtrs;
+static std::map<string *, block *> allocatedBytesRefs;
 
-  TAG_TYPE(void)
-  TAG_TYPE(uint8)
-  TAG_TYPE(sint8)
-  TAG_TYPE(uint16)
-  TAG_TYPE(sint16)
-  TAG_TYPE(uint32)
-  TAG_TYPE(sint32)
-  TAG_TYPE(uint64)
-  TAG_TYPE(sint64)
-  TAG_TYPE(float)
-  TAG_TYPE(double)
-  TAG_TYPE(uchar)
-  TAG_TYPE(schar)
-  TAG_TYPE(ushort)
-  TAG_TYPE(sshort)
-  TAG_TYPE(uint)
-  TAG_TYPE(sint)
-  TAG_TYPE(ulong)
-  TAG_TYPE(slong)
-  TAG_TYPE(longdouble)
-  TAG_TYPE(pointer)
-  TAG_TYPE(complexfloat)
-  TAG_TYPE(complexdouble)
-  TAG_TYPE(complexlongdouble)
+TAG_TYPE(void)
+TAG_TYPE(uint8)
+TAG_TYPE(sint8)
+TAG_TYPE(uint16)
+TAG_TYPE(sint16)
+TAG_TYPE(uint32)
+TAG_TYPE(sint32)
+TAG_TYPE(uint64)
+TAG_TYPE(sint64)
+TAG_TYPE(float)
+TAG_TYPE(double)
+TAG_TYPE(uchar)
+TAG_TYPE(schar)
+TAG_TYPE(ushort)
+TAG_TYPE(sshort)
+TAG_TYPE(uint)
+TAG_TYPE(sint)
+TAG_TYPE(ulong)
+TAG_TYPE(slong)
+TAG_TYPE(longdouble)
+TAG_TYPE(pointer)
+TAG_TYPE(complexfloat)
+TAG_TYPE(complexdouble)
+TAG_TYPE(complexlongdouble)
 
-  mpz_ptr move_int(mpz_t);
-  char * getTerminatedString(string * str);
+mpz_ptr move_int(mpz_t);
+char *getTerminatedString(string *str);
 
-  size_t hook_LIST_size_long(list * l);
-  block * hook_LIST_get_long(list * l, ssize_t idx);
+size_t hook_LIST_size_long(list *l);
+block *hook_LIST_get_long(list *l, ssize_t idx);
 
-  static void * so_lib_handle() {
-    static void * handle = NULL;
+static void *so_lib_handle() {
+  static void *handle = NULL;
+
+  if (handle == NULL) {
+    handle = dlopen(NULL, RTLD_LAZY);
 
     if (handle == NULL) {
-      handle = dlopen(NULL, RTLD_LAZY);
-
-      if (handle == NULL) {
-        throw std::invalid_argument("dlopen returned NULL");
-      }
+      throw std::invalid_argument("dlopen returned NULL");
     }
-
-    return handle;
   }
 
-  static ffi_type * getTypeFromBlock(block * elem) {
-    if (is_leaf_block(elem)) {
-      uint64_t symbol = (uint64_t) elem;
-
-      if (symbol == tag_type_void()) {
-        return &ffi_type_void;
-      } else if (symbol == tag_type_uint8()) {
-        return &ffi_type_uint8;
-      } else if (symbol == tag_type_sint8()) {
-        return &ffi_type_sint8;
-      } else if (symbol == tag_type_uint16()) {
-        return &ffi_type_uint16;
-      } else if (symbol == tag_type_sint16()) {
-        return &ffi_type_sint16;
-      } else if (symbol == tag_type_uint32()) {
-        return &ffi_type_uint32;
-      } else if (symbol == tag_type_sint32()) {
-        return &ffi_type_sint32;
-      } else if (symbol == tag_type_uint64()) {
-        return &ffi_type_uint64;
-      } else if (symbol == tag_type_sint64()) {
-        return &ffi_type_sint64;
-      } else if (symbol == tag_type_float()) {
-        return &ffi_type_float;
-      } else if (symbol == tag_type_double()) {
-        return &ffi_type_double;
-      } else if (symbol == tag_type_uchar()) {
-        return &ffi_type_uchar;
-      } else if (symbol == tag_type_schar()) {
-        return &ffi_type_schar;
-      } else if (symbol == tag_type_ushort()) {
-        return &ffi_type_ushort;
-      } else if (symbol == tag_type_sshort()) {
-        return &ffi_type_sshort;
-      } else if (symbol == tag_type_uint()) {
-        return &ffi_type_uint;
-      } else if (symbol == tag_type_sint()) {
-        return &ffi_type_sint;
-      } else if (symbol == tag_type_ulong()) {
-        return &ffi_type_ulong;
-      } else if (symbol == tag_type_slong()) {
-        return &ffi_type_slong;
-      } else if (symbol == tag_type_longdouble()) {
-        return &ffi_type_longdouble;
-      } else if (symbol == tag_type_pointer()) {
-        return &ffi_type_pointer;
-      } else if (symbol == tag_type_complexfloat()) {
-        return &ffi_type_complex_float;
-      } else if (symbol == tag_type_complexdouble()) {
-        return &ffi_type_complex_double;
-      } else if (symbol == tag_type_complexlongdouble()) {
-        return &ffi_type_complex_longdouble;
-      }
-    } else if (tag_hdr(elem->h.hdr) == (uint64_t)getTagForSymbolName(TYPETAG(struct))){
-      list * elements = (list *) *elem->children;
-      size_t numFields = hook_LIST_size_long(elements);
-      block * structField;
-
-      ffi_type * structType = (ffi_type *) malloc(sizeof(ffi_type));
-      structType->size = 0;
-      structType->alignment = 0;
-      structType->type = FFI_TYPE_STRUCT;
-      structType->elements = (ffi_type **) malloc(sizeof(ffi_type *) * (numFields + 1));
-
-      for (int j = 0; j < numFields; j++) {
-        structField = hook_LIST_get_long(elements, j);
-
-        if (tag_hdr(structField->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
-          throw std::invalid_argument("Struct list contains invalid FFI type");
-        }
-
-        structType->elements[j]= getTypeFromBlock((block *) *(structField->children));
-      }
-
-      structType->elements[numFields] = NULL;
-
-      structTypes.push_back(structType);
-
-      return structType;
-    }
-
-    throw std::invalid_argument("Arg is not a supported type");
-  }
-
-  string * ffiCall(bool isVariadic, mpz_t addr, list * args, list * fixtypes, list * vartypes, block * ret) {
-    ffi_cif cif;
-    ffi_type ** argtypes, * rtype;
-    void (* address)(void);
-
-    if (!mpz_fits_ulong_p(addr)) {
-      throw std::invalid_argument("Addr is too large");
-    }
-
-    address = (void (*) (void))  mpz_get_ui(addr);
-
-    size_t nargs = hook_LIST_size_long(args);
-    size_t nfixtypes = hook_LIST_size_long(fixtypes);
-    size_t nvartypes = 0;
-
-    if (isVariadic) {
-      nvartypes = hook_LIST_size_long(vartypes);
-    }
-
-    if (nargs != (nfixtypes + nvartypes)) {
-      throw std::invalid_argument("Args size does not match types size");
-    }
-
-    argtypes = (ffi_type **) malloc(sizeof(ffi_type *) * nargs);
-
-    block * elem;
-    for (int i = 0; i < nfixtypes; i++) {
-        elem = hook_LIST_get_long(fixtypes, i);
-        if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
-          throw std::invalid_argument("Fix types list contains invalid FFI type");
-        }
-
-        argtypes[i] = getTypeFromBlock((block *) *elem->children);
-    }
-
-    for (int i = 0; i < nvartypes; i++) {
-        elem = hook_LIST_get_long(vartypes, i);
-        if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
-          throw std::invalid_argument("Var types list contains invalid FFI type");
-        }
-
-        argtypes[i + nfixtypes] = getTypeFromBlock((block *) *elem->children);
-    }
-
-    void ** avalues = (void **) malloc(sizeof(void *) * nargs);
-    for (int i = 0; i < nargs; i++) {
-        elem = hook_LIST_get_long(args, i);
-        if (tag_hdr(elem->h.hdr) != (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}")) {
-          throw std::invalid_argument("Args list contains non-bytes type");
-        }
-        avalues[i] = ((string *) *elem->children)->data;
-    }
-
-    rtype = getTypeFromBlock(ret);
-
-    ffi_status status;
-    if (isVariadic) {
-      status = ffi_prep_cif_var(&cif, FFI_DEFAULT_ABI, nfixtypes, nargs, rtype, argtypes);
-    } else {
-      status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, nargs, rtype, argtypes);
-    }
-
-    switch (status) {
-      case FFI_OK:
-        break;
-      case FFI_BAD_TYPEDEF:
-          throw std::invalid_argument("Types list contains invalid FFI type");
-        break;
-      case FFI_BAD_ABI:
-          throw std::invalid_argument("Invalid ABI mode");
-        break;
-    }
-
-    string * rvalue = static_cast<string *>(koreAllocToken(sizeof(string) + rtype->size));
-    ffi_call(&cif, address, (void *)(rvalue->data), avalues);
-
-    free(argtypes);
-    set_len(rvalue, rtype->size);
-    free(avalues);
-
-    for (auto &s : structTypes) {
-      free(s->elements);
-      free(s);
-    }
-
-    structTypes.clear();
-
-    return rvalue;
-  }
-
-  SortBytes hook_FFI_call(SortInt addr, SortList args, SortList types, SortFFIType ret) {
-    return ffiCall(false, addr, args, types, NULL, ret);
-  }
-
-  SortBytes hook_FFI_call_variadic(SortInt addr, SortList args, SortList fixtypes, SortList vartypes, SortFFIType ret) {
-    return ffiCall(true, addr, args, fixtypes, vartypes, ret);
-  }
-
-  static std::map<std::string, void *> getPrivateSymbols() {
-      std::map<std::string, void *> m;
-      m["atexit"] = (void *)atexit;
-#ifndef __APPLE__
-      m["at_quick_exit"] = (void *)at_quick_exit;
-      m["stat64"] = (void *)stat64;
-      m["fstat64"] = (void *)fstat64;
-      m["lstat64"] = (void *)lstat64;
-      m["fstatat64"] = (void *)fstatat64;
-      m["mknodat"] = (void *)mknodat;
-#endif
-      // Disabled: not present on Ubuntu Bionic
-      //m["pthread_atfork"] = (void *)pthread_atfork;
-      m["stat"] = (void *)stat;
-      m["fstat"] = (void *)fstat;
-      m["lstat"] = (void *)lstat;
-      m["fstatat"] = (void *)fstatat;
-      m["mknod"] = (void *)mknod;
-
-      return m;
-  }
-
-  SortInt hook_FFI_address(SortString fn) {
-    char * func = getTerminatedString(fn);
-
-    std::string funcStr = func;
-    static const std::map<std::string, void *> privateSymbols = getPrivateSymbols();
-
-    void *address;
-    if (auto it = privateSymbols.find(funcStr); it != privateSymbols.end()) {
-      address = it->second;
-    } else {
-      void * handle = so_lib_handle();
-      address = dlsym(handle, func);
-    }
-
-    mpz_t result;
-    mpz_init_set_ui(result, (uintptr_t)address);
-    return move_int(result);
-  }
-
-  static std::pair<std::vector<block **>::iterator, std::vector<block **>::iterator> firstBlockEnumerator() {
-    static std::vector<block **> blocks;
-
-    blocks.clear();
-
-    for (auto &keyVal : allocatedKItemPtrs) {
-      blocks.push_back(const_cast<block**>(&(keyVal.first)));
-    }
-
-    return std::make_pair(blocks.begin(), blocks.end());
-  }
-
-  static std::pair<std::vector<block **>::iterator, std::vector<block **>::iterator> secondBlockEnumerator() {
-    static std::vector<block **> blocks;
-
-    blocks.clear();
-
-    for (auto &keyVal : allocatedBytesRefs) {
-      blocks.push_back(const_cast<block**>(&(keyVal.second)));
-    }
-
-    return std::make_pair(blocks.begin(), blocks.end());
-  }
-
-  string * hook_FFI_alloc(block * kitem, mpz_t size, mpz_t align) {
-    static int registered = -1;
-
-    if (registered == -1) {
-      registerGCRootsEnumerator(firstBlockEnumerator);
-      registerGCRootsEnumerator(secondBlockEnumerator);
-      registered = 0;
-    }
-
-    if (!mpz_fits_ulong_p(size)) {
-      throw std::invalid_argument("Size is too large");
-    }
-    if (!mpz_fits_ulong_p(align)) {
-      throw std::invalid_argument("Alignment is too large");
-    }
-
-    size_t a = mpz_get_ui(align);
-
-    if (allocatedKItemPtrs.find(kitem) != allocatedKItemPtrs.end()) {
-      string *result = allocatedKItemPtrs[kitem];
-      if ((((uintptr_t)result) & (a-1)) != 0) {
-        throw std::invalid_argument("Memory is not aligned");
-      }
-      return allocatedKItemPtrs[kitem];
-    }
-
-    size_t s = mpz_get_ui(size);
-
-    string * ret;
-    int result = posix_memalign((void **)&ret, a < sizeof(void *) ? sizeof(void *) : a, sizeof(string *) + s);
-    if (result) {
-      throw std::invalid_argument("Could not allocate");
-    }
-    memset(ret, 0, sizeof(string *) + s);
-    set_len(ret, s);
-    ret->h.hdr |= NOT_YOUNG_OBJECT_BIT;
-
-    allocatedKItemPtrs[kitem] = ret;
-    allocatedBytesRefs[ret] = kitem;
-
-    return ret;
-  }
-
-  block * hook_FFI_free(block * kitem) {
-    auto ptrIter = allocatedKItemPtrs.find(kitem);
-    auto refIter = allocatedBytesRefs.find(ptrIter->second);
-
-    if (ptrIter != allocatedKItemPtrs.end()) {
-      free(allocatedKItemPtrs[kitem]);
-      allocatedKItemPtrs.erase(ptrIter);
-
-      if (refIter != allocatedBytesRefs.end()) {
-        allocatedBytesRefs.erase(refIter);
-      } else {
-        throw std::runtime_error("Internal memory map is out of sync");
-      }
-    }
-
-    return dotK;
-  }
-
-  block *hook_FFI_freeAll(void) {
-    for (auto iter = allocatedKItemPtrs.begin(); iter != allocatedKItemPtrs.end(); ++iter) {
-      hook_FFI_free(iter->first);
-    }
-
-    return dotK;
-  }
-
-  block * hook_FFI_bytes_ref(string * bytes) {
-    auto refIter = allocatedBytesRefs.find(bytes);
-
-    if (refIter == allocatedBytesRefs.end()) {
-      throw std::invalid_argument("Bytes have no reference");
-    }
-
-    return allocatedBytesRefs[bytes];
-  }
-
-  mpz_ptr hook_FFI_bytes_address(string * bytes) {
-    mpz_t addr;
-    mpz_init_set_ui(addr, (uintptr_t)bytes->data);
-    return move_int(addr);
-  }
-
-  bool hook_FFI_allocated(block * kitem) {
-    return allocatedKItemPtrs.find(kitem) != allocatedKItemPtrs.end();
-  }
-
-  SortK hook_FFI_read(SortInt addr, SortBytes mem) {
-    unsigned long l = mpz_get_ui(addr);
-    uintptr_t intptr = (uintptr_t)l;
-    char *ptr = (char *)intptr;
-    memcpy(mem->data, ptr, len(mem));
-    return dotK;
-  }
-
-  SortK hook_FFI_write(SortInt addr, SortBytes mem) {
-    unsigned long l = mpz_get_ui(addr);
-    uintptr_t intptr = (uintptr_t)l;
-    char *ptr = (char *)intptr;
-    for (size_t i = 0; i < len(mem); ++i) {
-      if (ptr[i] != mem->data[i]) {
-        ptr[i] = mem->data[i];
-      }
-    }
-    return dotK;
-  }
+  return handle;
 }
 
+static ffi_type *getTypeFromBlock(block *elem) {
+  if (is_leaf_block(elem)) {
+    uint64_t symbol = (uint64_t)elem;
+
+    if (symbol == tag_type_void()) {
+      return &ffi_type_void;
+    } else if (symbol == tag_type_uint8()) {
+      return &ffi_type_uint8;
+    } else if (symbol == tag_type_sint8()) {
+      return &ffi_type_sint8;
+    } else if (symbol == tag_type_uint16()) {
+      return &ffi_type_uint16;
+    } else if (symbol == tag_type_sint16()) {
+      return &ffi_type_sint16;
+    } else if (symbol == tag_type_uint32()) {
+      return &ffi_type_uint32;
+    } else if (symbol == tag_type_sint32()) {
+      return &ffi_type_sint32;
+    } else if (symbol == tag_type_uint64()) {
+      return &ffi_type_uint64;
+    } else if (symbol == tag_type_sint64()) {
+      return &ffi_type_sint64;
+    } else if (symbol == tag_type_float()) {
+      return &ffi_type_float;
+    } else if (symbol == tag_type_double()) {
+      return &ffi_type_double;
+    } else if (symbol == tag_type_uchar()) {
+      return &ffi_type_uchar;
+    } else if (symbol == tag_type_schar()) {
+      return &ffi_type_schar;
+    } else if (symbol == tag_type_ushort()) {
+      return &ffi_type_ushort;
+    } else if (symbol == tag_type_sshort()) {
+      return &ffi_type_sshort;
+    } else if (symbol == tag_type_uint()) {
+      return &ffi_type_uint;
+    } else if (symbol == tag_type_sint()) {
+      return &ffi_type_sint;
+    } else if (symbol == tag_type_ulong()) {
+      return &ffi_type_ulong;
+    } else if (symbol == tag_type_slong()) {
+      return &ffi_type_slong;
+    } else if (symbol == tag_type_longdouble()) {
+      return &ffi_type_longdouble;
+    } else if (symbol == tag_type_pointer()) {
+      return &ffi_type_pointer;
+    } else if (symbol == tag_type_complexfloat()) {
+      return &ffi_type_complex_float;
+    } else if (symbol == tag_type_complexdouble()) {
+      return &ffi_type_complex_double;
+    } else if (symbol == tag_type_complexlongdouble()) {
+      return &ffi_type_complex_longdouble;
+    }
+  } else if (
+      tag_hdr(elem->h.hdr) == (uint64_t)getTagForSymbolName(TYPETAG(struct))) {
+    list *elements = (list *)*elem->children;
+    size_t numFields = hook_LIST_size_long(elements);
+    block *structField;
+
+    ffi_type *structType = (ffi_type *)malloc(sizeof(ffi_type));
+    structType->size = 0;
+    structType->alignment = 0;
+    structType->type = FFI_TYPE_STRUCT;
+    structType->elements
+        = (ffi_type **)malloc(sizeof(ffi_type *) * (numFields + 1));
+
+    for (int j = 0; j < numFields; j++) {
+      structField = hook_LIST_get_long(elements, j);
+
+      if (tag_hdr(structField->h.hdr)
+          != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
+        throw std::invalid_argument("Struct list contains invalid FFI type");
+      }
+
+      structType->elements[j]
+          = getTypeFromBlock((block *)*(structField->children));
+    }
+
+    structType->elements[numFields] = NULL;
+
+    structTypes.push_back(structType);
+
+    return structType;
+  }
+
+  throw std::invalid_argument("Arg is not a supported type");
+}
+
+string *ffiCall(
+    bool isVariadic, mpz_t addr, list *args, list *fixtypes, list *vartypes,
+    block *ret) {
+  ffi_cif cif;
+  ffi_type **argtypes, *rtype;
+  void (*address)(void);
+
+  if (!mpz_fits_ulong_p(addr)) {
+    throw std::invalid_argument("Addr is too large");
+  }
+
+  address = (void (*)(void))mpz_get_ui(addr);
+
+  size_t nargs = hook_LIST_size_long(args);
+  size_t nfixtypes = hook_LIST_size_long(fixtypes);
+  size_t nvartypes = 0;
+
+  if (isVariadic) {
+    nvartypes = hook_LIST_size_long(vartypes);
+  }
+
+  if (nargs != (nfixtypes + nvartypes)) {
+    throw std::invalid_argument("Args size does not match types size");
+  }
+
+  argtypes = (ffi_type **)malloc(sizeof(ffi_type *) * nargs);
+
+  block *elem;
+  for (int i = 0; i < nfixtypes; i++) {
+    elem = hook_LIST_get_long(fixtypes, i);
+    if (tag_hdr(elem->h.hdr)
+        != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
+      throw std::invalid_argument("Fix types list contains invalid FFI type");
+    }
+
+    argtypes[i] = getTypeFromBlock((block *)*elem->children);
+  }
+
+  for (int i = 0; i < nvartypes; i++) {
+    elem = hook_LIST_get_long(vartypes, i);
+    if (tag_hdr(elem->h.hdr)
+        != (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}")) {
+      throw std::invalid_argument("Var types list contains invalid FFI type");
+    }
+
+    argtypes[i + nfixtypes] = getTypeFromBlock((block *)*elem->children);
+  }
+
+  void **avalues = (void **)malloc(sizeof(void *) * nargs);
+  for (int i = 0; i < nargs; i++) {
+    elem = hook_LIST_get_long(args, i);
+    if (tag_hdr(elem->h.hdr)
+        != (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}")) {
+      throw std::invalid_argument("Args list contains non-bytes type");
+    }
+    avalues[i] = ((string *)*elem->children)->data;
+  }
+
+  rtype = getTypeFromBlock(ret);
+
+  ffi_status status;
+  if (isVariadic) {
+    status = ffi_prep_cif_var(
+        &cif, FFI_DEFAULT_ABI, nfixtypes, nargs, rtype, argtypes);
+  } else {
+    status = ffi_prep_cif(&cif, FFI_DEFAULT_ABI, nargs, rtype, argtypes);
+  }
+
+  switch (status) {
+  case FFI_OK: break;
+  case FFI_BAD_TYPEDEF:
+    throw std::invalid_argument("Types list contains invalid FFI type");
+    break;
+  case FFI_BAD_ABI: throw std::invalid_argument("Invalid ABI mode"); break;
+  }
+
+  string *rvalue
+      = static_cast<string *>(koreAllocToken(sizeof(string) + rtype->size));
+  ffi_call(&cif, address, (void *)(rvalue->data), avalues);
+
+  free(argtypes);
+  set_len(rvalue, rtype->size);
+  free(avalues);
+
+  for (auto &s : structTypes) {
+    free(s->elements);
+    free(s);
+  }
+
+  structTypes.clear();
+
+  return rvalue;
+}
+
+SortBytes
+hook_FFI_call(SortInt addr, SortList args, SortList types, SortFFIType ret) {
+  return ffiCall(false, addr, args, types, NULL, ret);
+}
+
+SortBytes hook_FFI_call_variadic(
+    SortInt addr, SortList args, SortList fixtypes, SortList vartypes,
+    SortFFIType ret) {
+  return ffiCall(true, addr, args, fixtypes, vartypes, ret);
+}
+
+static std::map<std::string, void *> getPrivateSymbols() {
+  std::map<std::string, void *> m;
+  m["atexit"] = (void *)atexit;
+#ifndef __APPLE__
+  m["at_quick_exit"] = (void *)at_quick_exit;
+  m["stat64"] = (void *)stat64;
+  m["fstat64"] = (void *)fstat64;
+  m["lstat64"] = (void *)lstat64;
+  m["fstatat64"] = (void *)fstatat64;
+  m["mknodat"] = (void *)mknodat;
+#endif
+  // Disabled: not present on Ubuntu Bionic
+  // m["pthread_atfork"] = (void *)pthread_atfork;
+  m["stat"] = (void *)stat;
+  m["fstat"] = (void *)fstat;
+  m["lstat"] = (void *)lstat;
+  m["fstatat"] = (void *)fstatat;
+  m["mknod"] = (void *)mknod;
+
+  return m;
+}
+
+SortInt hook_FFI_address(SortString fn) {
+  char *func = getTerminatedString(fn);
+
+  std::string funcStr = func;
+  static const std::map<std::string, void *> privateSymbols
+      = getPrivateSymbols();
+
+  void *address;
+  if (auto it = privateSymbols.find(funcStr); it != privateSymbols.end()) {
+    address = it->second;
+  } else {
+    void *handle = so_lib_handle();
+    address = dlsym(handle, func);
+  }
+
+  mpz_t result;
+  mpz_init_set_ui(result, (uintptr_t)address);
+  return move_int(result);
+}
+
+static std::pair<
+    std::vector<block **>::iterator, std::vector<block **>::iterator>
+firstBlockEnumerator() {
+  static std::vector<block **> blocks;
+
+  blocks.clear();
+
+  for (auto &keyVal : allocatedKItemPtrs) {
+    blocks.push_back(const_cast<block **>(&(keyVal.first)));
+  }
+
+  return std::make_pair(blocks.begin(), blocks.end());
+}
+
+static std::pair<
+    std::vector<block **>::iterator, std::vector<block **>::iterator>
+secondBlockEnumerator() {
+  static std::vector<block **> blocks;
+
+  blocks.clear();
+
+  for (auto &keyVal : allocatedBytesRefs) {
+    blocks.push_back(const_cast<block **>(&(keyVal.second)));
+  }
+
+  return std::make_pair(blocks.begin(), blocks.end());
+}
+
+string *hook_FFI_alloc(block *kitem, mpz_t size, mpz_t align) {
+  static int registered = -1;
+
+  if (registered == -1) {
+    registerGCRootsEnumerator(firstBlockEnumerator);
+    registerGCRootsEnumerator(secondBlockEnumerator);
+    registered = 0;
+  }
+
+  if (!mpz_fits_ulong_p(size)) {
+    throw std::invalid_argument("Size is too large");
+  }
+  if (!mpz_fits_ulong_p(align)) {
+    throw std::invalid_argument("Alignment is too large");
+  }
+
+  size_t a = mpz_get_ui(align);
+
+  if (allocatedKItemPtrs.find(kitem) != allocatedKItemPtrs.end()) {
+    string *result = allocatedKItemPtrs[kitem];
+    if ((((uintptr_t)result) & (a - 1)) != 0) {
+      throw std::invalid_argument("Memory is not aligned");
+    }
+    return allocatedKItemPtrs[kitem];
+  }
+
+  size_t s = mpz_get_ui(size);
+
+  string *ret;
+  int result = posix_memalign(
+      (void **)&ret, a < sizeof(void *) ? sizeof(void *) : a,
+      sizeof(string *) + s);
+  if (result) {
+    throw std::invalid_argument("Could not allocate");
+  }
+  memset(ret, 0, sizeof(string *) + s);
+  set_len(ret, s);
+  ret->h.hdr |= NOT_YOUNG_OBJECT_BIT;
+
+  allocatedKItemPtrs[kitem] = ret;
+  allocatedBytesRefs[ret] = kitem;
+
+  return ret;
+}
+
+block *hook_FFI_free(block *kitem) {
+  auto ptrIter = allocatedKItemPtrs.find(kitem);
+  auto refIter = allocatedBytesRefs.find(ptrIter->second);
+
+  if (ptrIter != allocatedKItemPtrs.end()) {
+    free(allocatedKItemPtrs[kitem]);
+    allocatedKItemPtrs.erase(ptrIter);
+
+    if (refIter != allocatedBytesRefs.end()) {
+      allocatedBytesRefs.erase(refIter);
+    } else {
+      throw std::runtime_error("Internal memory map is out of sync");
+    }
+  }
+
+  return dotK;
+}
+
+block *hook_FFI_freeAll(void) {
+  for (auto iter = allocatedKItemPtrs.begin(); iter != allocatedKItemPtrs.end();
+       ++iter) {
+    hook_FFI_free(iter->first);
+  }
+
+  return dotK;
+}
+
+block *hook_FFI_bytes_ref(string *bytes) {
+  auto refIter = allocatedBytesRefs.find(bytes);
+
+  if (refIter == allocatedBytesRefs.end()) {
+    throw std::invalid_argument("Bytes have no reference");
+  }
+
+  return allocatedBytesRefs[bytes];
+}
+
+mpz_ptr hook_FFI_bytes_address(string *bytes) {
+  mpz_t addr;
+  mpz_init_set_ui(addr, (uintptr_t)bytes->data);
+  return move_int(addr);
+}
+
+bool hook_FFI_allocated(block *kitem) {
+  return allocatedKItemPtrs.find(kitem) != allocatedKItemPtrs.end();
+}
+
+SortK hook_FFI_read(SortInt addr, SortBytes mem) {
+  unsigned long l = mpz_get_ui(addr);
+  uintptr_t intptr = (uintptr_t)l;
+  char *ptr = (char *)intptr;
+  memcpy(mem->data, ptr, len(mem));
+  return dotK;
+}
+
+SortK hook_FFI_write(SortInt addr, SortBytes mem) {
+  unsigned long l = mpz_get_ui(addr);
+  uintptr_t intptr = (uintptr_t)l;
+  char *ptr = (char *)intptr;
+  for (size_t i = 0; i < len(mem); ++i) {
+    if (ptr[i] != mem->data[i]) {
+      ptr[i] = mem->data[i];
+    }
+  }
+  return dotK;
+}
+}

--- a/runtime/strings/bytes.cpp
+++ b/runtime/strings/bytes.cpp
@@ -1,8 +1,8 @@
-#include <gmp.h>
+#include <algorithm>
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
-#include <cstdint>
-#include <algorithm>
+#include <gmp.h>
 #include <stdexcept>
 
 #include "runtime/alloc.h"
@@ -12,208 +12,212 @@ extern "C" {
 
 #define KCHAR char
 
-  mpz_ptr move_int(mpz_t);
+mpz_ptr move_int(mpz_t);
 
-  SortBytes hook_BYTES_empty() {
-    static string empty;
-    empty.h.hdr = NOT_YOUNG_OBJECT_BIT;
-    return &empty;
+SortBytes hook_BYTES_empty() {
+  static string empty;
+  empty.h.hdr = NOT_YOUNG_OBJECT_BIT;
+  return &empty;
+}
+
+uint32_t getTagForSymbolName(const char *);
+
+// bytes2int and int2bytes expect constructors of sort Endianness, which become
+// a uint64_t constant value in the K term representation
+uint64_t tag_big_endian() {
+  static uint64_t tag = (uint64_t)-1;
+  if (tag == -1) {
+    tag = (uint64_t)leaf_block(getTagForSymbolName("LblbigEndianBytes{}"));
   }
+  return tag;
+}
 
-  uint32_t getTagForSymbolName(const char *);
+// bytes2int expects constructors of sort Signedness, which become a uint64_t
+// constant value in the K term representation
+uint64_t tag_unsigned() {
+  static uint64_t tag = (uint64_t)-1;
+  if (tag == -1) {
+    tag = (uint64_t)leaf_block(getTagForSymbolName("LblunsignedBytes{}"));
+  }
+  return tag;
+}
 
-  // bytes2int and int2bytes expect constructors of sort Endianness, which become a uint64_t
-  // constant value in the K term representation
-  uint64_t tag_big_endian() {
-    static uint64_t tag = (uint64_t)-1;
-    if (tag == -1) {
-      tag = (uint64_t)leaf_block(getTagForSymbolName("LblbigEndianBytes{}"));
+// syntax Int ::= Bytes2Int(Bytes, Endianness, Signedness)
+SortInt hook_BYTES_bytes2int(
+    SortBytes b, SortEndianness endianness_ptr, SortSignedness signedness_ptr) {
+  uint64_t endianness = (uint64_t)endianness_ptr;
+  uint64_t signedness = (uint64_t)signedness_ptr;
+  mpz_t result;
+  mpz_init(result);
+  int order = endianness == tag_big_endian() ? 1 : -1;
+  mpz_import(result, len(b), order, 1, 0, 0, b->data);
+  if (signedness != tag_unsigned() && len(b) != 0) {
+    bool msb;
+    if (endianness == tag_big_endian()) {
+      msb = b->data[0] & 0x80;
+    } else {
+      msb = b->data[len(b) - 1] & 0x80;
     }
-    return tag;
-  }
-
-  // bytes2int expects constructors of sort Signedness, which become a uint64_t
-  // constant value in the K term representation
-  uint64_t tag_unsigned() {
-    static uint64_t tag = (uint64_t)-1;
-    if (tag == -1) {
-      tag = (uint64_t)leaf_block(getTagForSymbolName("LblunsignedBytes{}"));
+    if (msb) {
+      mpz_t max;
+      mpz_init_set_ui(max, 1);
+      mpz_mul_2exp(max, max, len(b) * 8);
+      mpz_sub(result, result, max);
+      mpz_clear(max);
     }
-    return tag;
   }
+  return move_int(result);
+}
 
-  // syntax Int ::= Bytes2Int(Bytes, Endianness, Signedness)
-  SortInt hook_BYTES_bytes2int(SortBytes b, SortEndianness endianness_ptr, SortSignedness signedness_ptr) {
-    uint64_t endianness = (uint64_t)endianness_ptr;
-    uint64_t signedness = (uint64_t)signedness_ptr;
-    mpz_t result;
-    mpz_init(result);
-    int order = endianness == tag_big_endian() ? 1 : -1;
-    mpz_import(result, len(b), order, 1, 0, 0, b->data);
-    if (signedness != tag_unsigned() && len(b) != 0) {
-      bool msb;
-      if (endianness == tag_big_endian()) {
-        msb = b->data[0] & 0x80;
-      } else {
-        msb = b->data[len(b) - 1] & 0x80;
-      }
-      if (msb) {
-        mpz_t max;
-        mpz_init_set_ui(max, 1);
-        mpz_mul_2exp(max, max, len(b)*8);
-        mpz_sub(result, result, max);
-        mpz_clear(max);
-      }
-    }
-    return move_int(result);
+unsigned long get_ui(mpz_t i) {
+  if (!mpz_fits_ulong_p(i)) {
+    throw std::invalid_argument("Integer overflow");
   }
+  return mpz_get_ui(i);
+}
 
-  unsigned long get_ui(mpz_t i) {
-    if (!mpz_fits_ulong_p(i)) {
-      throw std::invalid_argument("Integer overflow");
-    }
-    return mpz_get_ui(i);
+void extract(mpz_t, mpz_t, size_t, size_t);
+
+// syntax Bytes ::= Int2Bytes(Int, Int, Endianness)
+SortBytes
+hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
+  uint64_t endianness = (uint64_t)endianness_ptr;
+  unsigned long len_long = mpz_get_ui(len);
+  if (len_long == 0) {
+    return hook_BYTES_empty();
   }
+  bool neg = mpz_sgn(i) < 0;
+  string *result
+      = static_cast<string *>(koreAllocToken(sizeof(string) + len_long));
+  set_len(result, len_long);
+  memset(result->data, neg ? 0xff : 0x00, len_long);
+  int order = endianness == tag_big_endian() ? 1 : -1;
+  mpz_t twos;
+  mpz_init(twos);
+  extract(twos, i, 0, len_long * 8);
+  size_t sizeInBytes = (mpz_sizeinbase(twos, 2) + 7) / 8;
+  void *start = result->data
+                + (endianness == tag_big_endian() ? len_long - sizeInBytes : 0);
+  mpz_export(start, nullptr, order, 1, 0, 0, twos);
+  mpz_clear(twos);
+  return result;
+}
 
-  void extract(mpz_t, mpz_t, size_t, size_t);
+string *bytes2string(string *b, size_t len) {
+  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  memcpy(result->data, b->data, len);
+  set_len(result, len);
+  return result;
+}
 
-  // syntax Bytes ::= Int2Bytes(Int, Int, Endianness)
-  SortBytes hook_BYTES_int2bytes(SortInt len, SortInt i, SortEndianness endianness_ptr) {
-    uint64_t endianness = (uint64_t)endianness_ptr;
-    unsigned long len_long = mpz_get_ui(len);
-    if (len_long == 0) {
-      return hook_BYTES_empty();
-    }
-    bool neg = mpz_sgn(i) < 0;
-    string *result = static_cast<string *>(koreAllocToken(sizeof(string) + len_long));
-    set_len(result, len_long);
-    memset(result->data, neg ? 0xff : 0x00, len_long);
-    int order = endianness == tag_big_endian() ? 1 : -1;
-    mpz_t twos;
-    mpz_init(twos);
-    extract(twos, i, 0, len_long*8);
-    size_t sizeInBytes = (mpz_sizeinbase(twos, 2) + 7) / 8;
-    void *start = result->data + (endianness == tag_big_endian() ? len_long - sizeInBytes : 0);
-    mpz_export(start, nullptr, order, 1, 0, 0, twos);
-    mpz_clear(twos);
-    return result;
+SortString hook_BYTES_bytes2string(SortBytes b) {
+  return bytes2string(b, len(b));
+}
+
+SortBytes hook_BYTES_string2bytes(SortString s) {
+  return hook_BYTES_bytes2string(s);
+}
+
+SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {
+  uint64_t ustart = get_ui(start);
+  uint64_t uend = get_ui(end);
+  if (uend < ustart) {
+    throw std::invalid_argument("Invalid string slice");
   }
-
-  string *bytes2string(string *b, size_t len) {
-    string *result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
-    memcpy(result->data, b->data, len);
-    set_len(result, len);
-    return result;
+  if (uend > len(input)) {
+    throw std::invalid_argument("Invalid string slice");
   }
+  uint64_t len = uend - ustart;
+  auto ret = static_cast<string *>(
+      koreAllocToken(sizeof(string) + sizeof(KCHAR) * len));
+  set_len(ret, len);
+  memcpy(&(ret->data), &(input->data[ustart]), len * sizeof(KCHAR));
+  return ret;
+}
 
-  SortString hook_BYTES_bytes2string(SortBytes b) {
-    return bytes2string(b, len(b));
+SortInt hook_BYTES_get(SortBytes b, SortInt off) {
+  unsigned long off_long = get_ui(off);
+  if (off_long >= len(b)) {
+    throw std::invalid_argument("Buffer overflow on get");
   }
+  mpz_t result;
+  mpz_init_set_ui(result, (unsigned char)b->data[off_long]);
+  return move_int(result);
+}
 
-  SortBytes hook_BYTES_string2bytes(SortString s) {
-    return hook_BYTES_bytes2string(s);
+SortBytes hook_BYTES_update(SortBytes b, SortInt off, SortInt val) {
+  unsigned long off_long = get_ui(off);
+  if (off_long >= len(b)) {
+    throw std::invalid_argument("Buffer overflow on update");
   }
-
-  SortBytes hook_BYTES_substr(SortBytes input, SortInt start, SortInt end) {
-    uint64_t ustart = get_ui(start);
-    uint64_t uend = get_ui(end);
-    if (uend < ustart) {
-      throw std::invalid_argument("Invalid string slice");
-    }
-    if (uend > len(input)) {
-      throw std::invalid_argument("Invalid string slice");
-    }
-    uint64_t len = uend - ustart;
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR) * len));
-    set_len(ret, len);
-    memcpy(&(ret->data), &(input->data[ustart]), len * sizeof(KCHAR));
-    return ret;
+  unsigned long val_long = get_ui(val);
+  if (val_long >= 256) {
+    throw std::invalid_argument("Not a valid value for a byte in update");
   }
+  b->data[off_long] = (unsigned char)val_long;
+  return b;
+}
 
-  SortInt hook_BYTES_get(SortBytes b, SortInt off) {
-    unsigned long off_long = get_ui(off);
-    if (off_long >= len(b)) {
-      throw std::invalid_argument("Buffer overflow on get");
-    }
-    mpz_t result;
-    mpz_init_set_ui(result, (unsigned char)b->data[off_long]);
-    return move_int(result);
+SortBytes hook_BYTES_replaceAt(SortBytes b, SortInt start, SortBytes b2) {
+  unsigned long start_long = get_ui(start);
+  if (start_long + len(b2) > len(b)) {
+    throw std::invalid_argument("Buffer overflow on replaceAt");
   }
+  memcpy(b->data + start_long, b2->data, len(b2));
+  return b;
+}
 
-  SortBytes hook_BYTES_update(SortBytes b, SortInt off, SortInt val) {
-    unsigned long off_long = get_ui(off);
-    if (off_long >= len(b)) {
-      throw std::invalid_argument("Buffer overflow on update");
-    }
-    unsigned long val_long = get_ui(val);
-    if (val_long >= 256) {
-      throw std::invalid_argument("Not a valid value for a byte in update");
-    }
-    b->data[off_long] = (unsigned char)val_long;
+SortInt hook_BYTES_length(SortBytes a) {
+  mpz_t result;
+  mpz_init_set_ui(result, len(a));
+  return move_int(result);
+}
+
+SortBytes hook_BYTES_padRight(SortBytes b, SortInt len, SortInt v) {
+  unsigned long ulen = get_ui(len);
+  if (ulen <= len(b)) {
     return b;
   }
+  unsigned long uv = get_ui(v);
+  if (uv > 255) {
+    throw std::invalid_argument("Integer overflow on value");
+  }
+  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
+  set_len(result, ulen);
+  memcpy(result->data, b->data, len(b));
+  memset(result->data + len(b), uv, ulen - len(b));
+  return result;
+}
 
-  SortBytes hook_BYTES_replaceAt(SortBytes b, SortInt start, SortBytes b2) {
-    unsigned long start_long = get_ui(start);
-    if (start_long + len(b2) > len(b)) {
-      throw std::invalid_argument("Buffer overflow on replaceAt");
-    }
-    memcpy(b->data + start_long, b2->data, len(b2));
+SortBytes hook_BYTES_padLeft(SortBytes b, SortInt len, SortInt v) {
+  unsigned long ulen = get_ui(len);
+  if (ulen <= len(b)) {
     return b;
   }
-
-  SortInt hook_BYTES_length(SortBytes a) {
-    mpz_t result;
-    mpz_init_set_ui(result, len(a));
-    return move_int(result);
+  unsigned long uv = get_ui(v);
+  if (uv > 255) {
+    throw std::invalid_argument("Integer overflow on value");
   }
+  string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
+  set_len(result, ulen);
+  memset(result->data, uv, ulen - len(b));
+  memcpy(result->data + ulen - len(b), b->data, len(b));
+  return result;
+}
 
-  SortBytes hook_BYTES_padRight(SortBytes b, SortInt len, SortInt v) {
-    unsigned long ulen = get_ui(len);
-    if (ulen <= len(b)) {
-      return b;
-    }
-    unsigned long uv = get_ui(v);
-    if (uv > 255) {
-      throw std::invalid_argument("Integer overflow on value");
-    }
-    string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
-    set_len(result, ulen);
-    memcpy(result->data, b->data, len(b));
-    memset(result->data + len(b), uv, ulen - len(b));
-    return result;
-  }
+SortBytes hook_BYTES_reverse(SortBytes b) {
+  std::reverse(b->data, b->data + len(b));
+  return b;
+}
 
-  SortBytes hook_BYTES_padLeft(SortBytes b, SortInt len, SortInt v) {
-    unsigned long ulen = get_ui(len);
-    if (ulen <= len(b)) {
-      return b;
-    }
-    unsigned long uv = get_ui(v);
-    if (uv > 255) {
-      throw std::invalid_argument("Integer overflow on value");
-    }
-    string *result = static_cast<string *>(koreAllocToken(sizeof(string) + ulen));
-    set_len(result, ulen);
-    memset(result->data, uv, ulen - len(b));
-    memcpy(result->data + ulen - len(b), b->data, len(b));
-    return result;
-  }
-
-  SortBytes hook_BYTES_reverse(SortBytes b) {
-    std::reverse(b->data, b->data + len(b));
-    return b;
-  }
-
-  SortBytes hook_BYTES_concat(SortBytes a, SortBytes b) {
-    auto len_a = len(a);
-    auto len_b = len(b);
-    auto newlen = len_a  + len_b;
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + newlen));
-    set_len(ret, newlen);
-    memcpy(&(ret->data), &(a->data), len(a) * sizeof(KCHAR));
-    memcpy(&(ret->data[len(a)]), &(b->data), len(b) * sizeof(KCHAR));
-    return ret;
-  }
-
+SortBytes hook_BYTES_concat(SortBytes a, SortBytes b) {
+  auto len_a = len(a);
+  auto len_b = len(b);
+  auto newlen = len_a + len_b;
+  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + newlen));
+  set_len(ret, newlen);
+  memcpy(&(ret->data), &(a->data), len(a) * sizeof(KCHAR));
+  memcpy(&(ret->data[len(a)]), &(b->data), len(b) * sizeof(KCHAR));
+  return ret;
+}
 }

--- a/runtime/strings/strings.cpp
+++ b/runtime/strings/strings.cpp
@@ -1,16 +1,16 @@
-#include<gmp.h>
-#include<mpfr.h>
-#include<iconv.h>
-#include<algorithm>
-#include<cassert>
-#include<cinttypes>
-#include<cstdlib>
-#include<cstdint>
-#include<cstring>
-#include<iomanip>
-#include<string>
-#include<sstream>
-#include<stdexcept>
+#include <algorithm>
+#include <cassert>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <gmp.h>
+#include <iconv.h>
+#include <iomanip>
+#include <mpfr.h>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 
 #include "runtime/alloc.h"
 #include "runtime/header.h"
@@ -19,389 +19,417 @@ extern "C" {
 
 #define KCHAR char
 
-  mpz_ptr move_int(mpz_t);
-  floating *move_float(floating *);
+mpz_ptr move_int(mpz_t);
+floating *move_float(floating *);
 
-  string *bytes2string(string *, size_t);
-  string *hook_BYTES_concat(string *a, string *b);
-  mpz_ptr hook_BYTES_length(string *a);
-  string *hook_BYTES_substr(string *a, mpz_t start, mpz_t end);
-  char *getTerminatedString(string *str);
+string *bytes2string(string *, size_t);
+string *hook_BYTES_concat(string *a, string *b);
+mpz_ptr hook_BYTES_length(string *a);
+string *hook_BYTES_substr(string *a, mpz_t start, mpz_t end);
+char *getTerminatedString(string *str);
 
-  bool hook_STRING_gt(SortString a, SortString b) {
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return res > 0 || (res == 0 && len(a) > len(b));
+bool hook_STRING_gt(SortString a, SortString b) {
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return res > 0 || (res == 0 && len(a) > len(b));
+}
+
+bool hook_STRING_ge(SortString a, SortString b) {
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return (res > 0 || (res == 0 && len(a) >= len(b)));
+}
+
+bool hook_STRING_lt(SortString a, SortString b) {
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return res < 0 || (res == 0 && len(a) < len(b));
+}
+
+bool hook_STRING_le(SortString a, SortString b) {
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return (res < 0 || (res == 0 && len(a) <= len(b)));
+}
+
+bool hook_STRING_eq(SortString a, SortString b) {
+  if (is_variable_block(a) || is_variable_block(b)) {
+    return a == b;
   }
-
-  bool hook_STRING_ge(SortString a, SortString b) {
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return (res > 0 || (res == 0 && len(a) >= len(b)));
+  if (a->h.hdr & VARIABLE_BIT || b->h.hdr & VARIABLE_BIT) {
+    return a == b;
   }
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return (res == 0 && len(a) == len(b));
+}
 
-  bool hook_STRING_lt(SortString a, SortString b) {
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return res < 0 || (res == 0 && len(a) < len(b));
+bool hook_STRING_ne(SortString a, SortString b) {
+  auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
+  return (res != 0 || len(a) != len(b));
+}
+
+SortString hook_STRING_concat(SortString a, SortString b) {
+  return hook_BYTES_concat(a, b);
+}
+
+SortInt hook_STRING_length(SortString a) {
+  return hook_BYTES_length(a);
+}
+
+static inline uint64_t gs(mpz_t i) {
+  if (!mpz_fits_ulong_p(i)) {
+    throw std::invalid_argument("Arg too large for int64_t");
   }
+  return mpz_get_ui(i);
+}
 
-  bool hook_STRING_le(SortString a, SortString b) {
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return (res < 0 || (res == 0 && len(a) <= len(b)));
+SortString hook_STRING_chr(SortInt ord) {
+  uint64_t uord = gs(ord);
+  if (uord > 255) {
+    throw std::invalid_argument("Ord must be <= 255");
   }
+  auto ret
+      = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR)));
+  set_len(ret, 1);
+  ret->data[0] = static_cast<KCHAR>(uord);
+  return ret;
+}
 
-  bool hook_STRING_eq(SortString a, SortString b) {
-    if (is_variable_block(a) || is_variable_block(b)) {
-      return a == b;
-    }
-    if (a->h.hdr & VARIABLE_BIT || b->h.hdr & VARIABLE_BIT) {
-      return a == b;
-    }
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return (res == 0 && len(a) == len(b));
+SortInt hook_STRING_ord(SortString input) {
+  mpz_t result;
+  if (len(input) != 1) {
+    throw std::invalid_argument("Input must a string of length 1");
   }
+  mpz_init_set_ui(result, static_cast<unsigned char>(input->data[0]));
+  return move_int(result);
+}
 
-  bool hook_STRING_ne(SortString a, SortString b) {
-    auto res = memcmp(a->data, b->data, std::min(len(a), len(b)));
-    return (res != 0 || len(a) != len(b));
-  }
+SortString hook_STRING_substr(SortString input, SortInt start, SortInt end) {
+  return hook_BYTES_substr(input, start, end);
+}
 
-  SortString hook_STRING_concat(SortString a, SortString b) {
-    return hook_BYTES_concat(a, b);
-  }
-
-  SortInt hook_STRING_length(SortString a) {
-    return hook_BYTES_length(a);
-  }
-
-  static inline uint64_t gs(mpz_t i) {
-    if (!mpz_fits_ulong_p(i)) {
-      throw std::invalid_argument("Arg too large for int64_t");
-    }
-    return mpz_get_ui(i);
-  }
-
-  SortString hook_STRING_chr(SortInt ord) {
-    uint64_t uord = gs(ord);
-    if (uord > 255) {
-      throw std::invalid_argument("Ord must be <= 255");
-    }
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + sizeof(KCHAR)));
-    set_len(ret, 1);
-    ret->data[0] = static_cast<KCHAR>(uord);
-    return ret;
-  }
-
-  SortInt hook_STRING_ord(SortString input) {
-    mpz_t result;
-    if (len(input) != 1) {
-      throw std::invalid_argument("Input must a string of length 1");
-    }
-    mpz_init_set_ui(result, static_cast<unsigned char>(input->data[0]));
+SortInt hook_STRING_find(SortString haystack, SortString needle, SortInt pos) {
+  mpz_t result;
+  uint64_t upos = gs(pos);
+  if (upos >= len(haystack)) {
+    mpz_init_set_si(result, -1);
     return move_int(result);
   }
+  auto out = std::search(
+      haystack->data + upos * sizeof(KCHAR),
+      haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
+      needle->data + len(needle) * sizeof(KCHAR));
+  int64_t ret = (out - haystack->data) / sizeof(KCHAR);
+  // search returns the end of the range if it is not found, but we want -1 in
+  // such a case.
+  auto res = (ret < len(haystack)) ? ret : -1;
+  mpz_init_set_si(result, res);
+  return move_int(result);
+}
 
-  SortString hook_STRING_substr(SortString input, SortInt start, SortInt end) {
-    return hook_BYTES_substr(input, start, end);
+SortInt hook_STRING_rfind(SortString haystack, SortString needle, SortInt pos) {
+  // The semantics of rfind uposition are strange, it is the last position at
+  // which the match can _start_, which means the end of the haystack needs to
+  // be upos + len(needle), or the end of the haystack, if that's less.
+  mpz_t result;
+  uint64_t upos = gs(pos);
+  upos += len(needle);
+  auto end = (upos < len(haystack)) ? upos : len(haystack);
+  auto out = std::find_end(
+      &haystack->data[0], &haystack->data[end], &needle->data[0],
+      &needle->data[len(needle)]);
+  auto ret = &*out - &haystack->data[0];
+  auto res = (ret < end) ? ret : -1;
+  mpz_init_set_si(result, res);
+  return move_int(result);
+}
+
+SortInt
+hook_STRING_findChar(SortString haystack, SortString needle, SortInt pos) {
+  mpz_t result;
+  uint64_t upos = gs(pos);
+  if (upos >= len(haystack)) {
+    mpz_init_set_si(result, -1);
+    return move_int(result);
+  }
+  auto out = std::find_first_of(
+      haystack->data + upos * sizeof(KCHAR),
+      haystack->data + len(haystack) * sizeof(KCHAR), needle->data,
+      needle->data + len(needle) * sizeof(KCHAR));
+  int64_t ret = (out - haystack->data) / sizeof(KCHAR);
+  // search returns the end of the range if it is not found, but we want -1 in
+  // such a case.
+  auto res = (ret < len(haystack)) ? ret : -1;
+  mpz_init_set_si(result, res);
+  return move_int(result);
+}
+
+SortInt
+hook_STRING_rfindChar(SortString haystack, SortString needle, SortInt pos) {
+  // The semantics of rfind uposition are strange, it is the last position at
+  // which the match can _start_, which means the end of the haystack needs to
+  // be upos + len(needle), or the end of the haystack, if that's less.
+  mpz_t result;
+  uint64_t upos = gs(pos);
+  upos += 1;
+  auto end = (upos < len(haystack)) ? upos : len(haystack);
+  auto out = std::find_first_of(
+      std::reverse_iterator<const char *>(&haystack->data[end]),
+      std::reverse_iterator<const char *>(&haystack->data[0]), &needle->data[0],
+      &needle->data[len(needle)]);
+  auto ret = &*out - &haystack->data[0];
+  auto res = (ret < end) ? ret : -1;
+  mpz_init_set_si(result, res);
+  return move_int(result);
+}
+
+string *makeString(const KCHAR *input, ssize_t len = -1) {
+  if (len == -1) {
+    len = strlen(input);
+  }
+  auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  memcpy(ret->data, input, len);
+  set_len(ret, len);
+  return ret;
+}
+
+char *getTerminatedString(string *str) {
+  int length = len(str);
+  string *buf
+      = static_cast<string *>(koreAllocToken(sizeof(string) + (length + 1)));
+  memcpy(buf->data, str->data, length);
+  set_len(buf, length + 1);
+  buf->data[length] = '\0';
+  return buf->data;
+}
+
+SortString hook_STRING_base2string_long(SortInt input, uint64_t base) {
+  size_t len = mpz_sizeinbase(input, base) + 2;
+  // +1 for null terminator needed by mpz_get_str, +1 for minus sign
+  auto result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
+  mpz_get_str(result->data, base, input);
+  set_len(result, strlen(result->data));
+  return static_cast<string *>(koreResizeLastAlloc(
+      result, sizeof(string) + len(result), sizeof(string) + len));
+}
+
+SortInt hook_STRING_string2base_long(SortString input, uint64_t base) {
+  mpz_t result;
+  size_t length;
+  const char *dataStart;
+
+  if (*(input->data) == '+') {
+    length = len(input) - 1;
+    dataStart = input->data + 1;
+  } else {
+    length = len(input);
+    dataStart = input->data;
   }
 
-  SortInt hook_STRING_find(SortString haystack, SortString needle, SortInt pos) {
-    mpz_t result;
-    uint64_t upos = gs(pos);
-    if (upos >= len(haystack)) {
-      mpz_init_set_si(result, -1);
-      return move_int(result);
+  auto copy = static_cast<char *>(koreAllocToken(length + 1));
+  memcpy(copy, dataStart, length);
+  copy[length] = 0;
+  if (mpz_init_set_str(result, copy, base)) {
+    throw std::invalid_argument("Not a valid integer");
+  }
+  return move_int(result);
+}
+
+SortString hook_STRING_int2string(SortInt input) {
+  return hook_STRING_base2string_long(input, 10);
+}
+
+SortInt hook_STRING_string2int(SortString input) {
+  return hook_STRING_string2base_long(input, 10);
+}
+
+SortInt hook_STRING_string2base(SortString input, SortInt base) {
+  uint64_t ubase = gs(base);
+  return hook_STRING_string2base_long(input, ubase);
+}
+
+SortString hook_STRING_base2string(SortInt input, SortInt base) {
+  uint64_t ubase = gs(base);
+  return hook_STRING_base2string_long(input, ubase);
+}
+
+SortString hook_STRING_float2string(SortFloat input) {
+  std::string result = floatToString(input);
+  return makeString(result.c_str());
+}
+
+SortFloat hook_STRING_string2float(SortString input) {
+  floating result[1];
+  init_float2(result, std::string(input->data, len(input)));
+  return move_float(result);
+}
+
+string *hook_STRING_string2token(SortString input) {
+  return input;
+}
+
+SortString hook_STRING_token2string(string *input) {
+  if (layout(input) != 0) {
+    throw std::invalid_argument("token2string: input is not a string token");
+  }
+  return input;
+}
+
+inline SortString hook_STRING_replace(
+    SortString haystack, SortString needle, SortString replacer,
+    SortInt occurences) {
+  uint64_t uoccurences = gs(occurences);
+  auto start = &haystack->data[0];
+  auto pos = start;
+  auto end = &haystack->data[len(haystack)];
+  size_t matches[len(haystack)];
+  int i = 0;
+  while (i < uoccurences) {
+    pos = std::search(pos, end, &needle->data[0], &needle->data[len(needle)]);
+    if (pos == end) {
+      break;
     }
-    auto out = std::search(haystack->data + upos * sizeof(KCHAR), haystack->data + len(haystack) * sizeof(KCHAR),
-        needle->data,   needle->data   + len(needle) * sizeof(KCHAR));
-    int64_t ret = (out - haystack->data) / sizeof(KCHAR);
-    // search returns the end of the range if it is not found, but we want -1 in such a case.
-    auto res = (ret < len(haystack))?ret:-1;
-    mpz_init_set_si(result, res);
-    return move_int(result);
+    matches[i] = (pos - start);
+    ++pos;
+    ++i;
   }
-
-  SortInt hook_STRING_rfind(SortString haystack, SortString needle, SortInt pos) {
-    // The semantics of rfind uposition are strange, it is the last position at which
-    // the match can _start_, which means the end of the haystack needs to be upos + len(needle),
-    // or the end of the haystack, if that's less.
-    mpz_t result;
-    uint64_t upos = gs(pos);
-    upos += len(needle);
-    auto end = (upos < len(haystack))?upos:len(haystack);
-    auto out = std::find_end(&haystack->data[0], &haystack->data[end],
-        &needle->data[0], &needle->data[len(needle)]);
-    auto ret = &*out - &haystack->data[0];
-    auto res = (ret < end)?ret:-1;
-    mpz_init_set_si(result, res);
-    return move_int(result);
+  if (i == 0) {
+    return haystack;
   }
-
-  SortInt hook_STRING_findChar(SortString haystack, SortString needle, SortInt pos) {
-    mpz_t result;
-    uint64_t upos = gs(pos);
-    if (upos >= len(haystack)) {
-      mpz_init_set_si(result, -1);
-      return move_int(result);
-    }
-    auto out = std::find_first_of(haystack->data + upos * sizeof(KCHAR), haystack->data + len(haystack) * sizeof(KCHAR),
-        needle->data,   needle->data   + len(needle) * sizeof(KCHAR));
-    int64_t ret = (out - haystack->data) / sizeof(KCHAR);
-    // search returns the end of the range if it is not found, but we want -1 in such a case.
-    auto res = (ret < len(haystack))?ret:-1;
-    mpz_init_set_si(result, res);
-    return move_int(result);
-  }
-
-  SortInt hook_STRING_rfindChar(SortString haystack, SortString needle, SortInt pos) {
-    // The semantics of rfind uposition are strange, it is the last position at which
-    // the match can _start_, which means the end of the haystack needs to be upos + len(needle),
-    // or the end of the haystack, if that's less.
-    mpz_t result;
-    uint64_t upos = gs(pos);
-    upos += 1;
-    auto end = (upos < len(haystack))?upos:len(haystack);
-    auto out = std::find_first_of(std::reverse_iterator<const char *>(&haystack->data[end]), std::reverse_iterator<const char *>(&haystack->data[0]),
-        &needle->data[0], &needle->data[len(needle)]);
-    auto ret = &*out - &haystack->data[0];
-    auto res = (ret < end)?ret:-1;
-    mpz_init_set_si(result, res);
-    return move_int(result);
-  }
-
-  string * makeString(const KCHAR * input, ssize_t len = -1) {
-    if (len == -1) {
-      len = strlen(input);
-    }
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + len));
-    memcpy(ret->data, input, len);
-    set_len(ret, len);
-    return ret;
-  }
-
-  char * getTerminatedString(string * str) {
-    int length = len(str);
-    string * buf = static_cast<string *>(koreAllocToken(sizeof(string) + (length + 1)));
-    memcpy(buf->data, str->data, length);
-    set_len(buf, length + 1);
-    buf->data[length] = '\0';
-    return buf->data;
-  }
-
-  SortString hook_STRING_base2string_long(SortInt input, uint64_t base) {
-    size_t len = mpz_sizeinbase(input, base) + 2;
-    // +1 for null terminator needed by mpz_get_str, +1 for minus sign
-    auto result = static_cast<string *>(koreAllocToken(sizeof(string) + len));
-    mpz_get_str(result->data, base, input);
-    set_len(result, strlen(result->data));
-    return static_cast<string *>(koreResizeLastAlloc(result, sizeof(string) + len(result), sizeof(string) + len));
-  }
-
-  SortInt hook_STRING_string2base_long(SortString input, uint64_t base) {
-    mpz_t result;
-    size_t length;
-    const char * dataStart;
-
-    if (*(input->data) == '+') {
-      length = len(input) - 1;
-      dataStart = input->data + 1;
+  auto diff = len(needle) - len(replacer);
+  size_t new_len = len(haystack) - i * diff;
+  auto ret = static_cast<string *>(
+      koreAllocToken(sizeof(string) + new_len * sizeof(KCHAR)));
+  set_len(ret, new_len);
+  int m = 0;
+  for (size_t r = 0, h = 0; r < new_len;) {
+    if (m >= i) {
+      memcpy(ret->data + r, haystack->data + h, new_len - r);
+      break;
+    } else if (r < matches[m] - diff * m) {
+      auto size = matches[m] - diff * m - r;
+      memcpy(ret->data + r, haystack->data + h, size);
+      r += size;
+      h += size;
     } else {
-      length = len(input);
-      dataStart = input->data;
+      ++m;
+      memcpy(&ret->data[r], replacer->data, len(replacer));
+      r += len(replacer);
+      h += len(needle);
     }
+  }
+  return ret;
+}
 
-    auto copy = static_cast<char *>(koreAllocToken(length + 1));
-    memcpy(copy, dataStart, length);
-    copy[length] = 0;
-    if (mpz_init_set_str(result, copy, base)) {
-      throw std::invalid_argument("Not a valid integer");
+SortString hook_STRING_replaceAll(
+    SortString haystack, SortString needle, SortString replacer) {
+  // It's guaranteed that there can be no more replacements than the length of
+  // the haystack, so this gives us the functionality of replaceAll.
+  mpz_t arg;
+  mpz_init_set_si(arg, len(haystack));
+  return hook_STRING_replace(haystack, needle, replacer, arg);
+}
+
+SortString hook_STRING_replaceFirst(
+    SortString haystack, SortString needle, SortString replacer) {
+  mpz_t arg;
+  mpz_init_set_si(arg, 1);
+  return hook_STRING_replace(haystack, needle, replacer, arg);
+}
+
+SortInt
+hook_STRING_countAllOccurrences(SortString haystack, SortString needle) {
+  auto pos = &haystack->data[0];
+  auto end = &haystack->data[len(haystack)];
+  int i = 0;
+  while (true) {
+    pos = std::search(pos, end, &needle->data[0], &needle->data[len(needle)]);
+    if (pos == end) {
+      break;
     }
-    return move_int(result);
+    ++pos;
+    ++i;
   }
+  mpz_t result;
+  mpz_init_set_ui(result, i);
+  return move_int(result);
+}
 
-  SortString hook_STRING_int2string(SortInt input) {
-    return hook_STRING_base2string_long(input, 10);
+SortString hook_STRING_transcode(
+    SortString input, SortString inputCharset, SortString outputCharset) {
+  iconv_t converter = iconv_open(
+      getTerminatedString(outputCharset), getTerminatedString(inputCharset));
+  char *inbuf = input->data;
+  size_t inbytesleft = len(input);
+  size_t outbytesleft = inbytesleft * 4;
+  char *buf = (char *)malloc(outbytesleft);
+  char *outbuf = buf;
+  size_t result
+      = iconv(converter, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
+  if (result < 0) {
+    throw std::invalid_argument("transcoding failed: STRING.transcode");
   }
+  *outbuf = 0;
+  return makeString(buf, len(input) * 4 - outbytesleft);
+}
 
-  SortInt hook_STRING_string2int(SortString input) {
-    return hook_STRING_string2base_long(input, 10);
-  }
+string *hook_STRING_uuid() {
+  throw std::invalid_argument("not implemented: STRING.uuid");
+}
 
-  SortInt hook_STRING_string2base(SortString input, SortInt base) {
-    uint64_t ubase = gs(base);
-    return hook_STRING_string2base_long(input, ubase);
-  }
+string *hook_STRING_category(string *str) {
+  throw std::invalid_argument("not implemented: STRING.category");
+}
 
-  SortString hook_STRING_base2string(SortInt input, SortInt base) {
-    uint64_t ubase = gs(base);
-    return hook_STRING_base2string_long(input, ubase);
-  }
+string *hook_STRING_directionality(string *str) {
+  throw std::invalid_argument("not implemented: STRING.directionality");
+}
 
-  SortString hook_STRING_float2string(SortFloat input) {
-    std::string result = floatToString(input);
-    return makeString(result.c_str());
-  }
+string *hook_STRING_floatFormat(string *str, string *fmt) {
+  throw std::invalid_argument("not implemented: STRING.floatFormat");
+}
 
-  SortFloat hook_STRING_string2float(SortString input) {
-    floating result[1];
-    init_float2(result, std::string(input->data, len(input)));
-    return move_float(result);
-  }
+SortStringBuffer hook_BUFFER_empty() {
+  auto result = static_cast<stringbuffer *>(koreAlloc(sizeof(stringbuffer)));
+  set_len(result, sizeof(stringbuffer) - sizeof(blockheader));
+  result->strlen = 0;
+  auto str = static_cast<string *>(koreAllocToken(sizeof(string) + 16));
+  set_len(str, 16);
+  result->contents = str;
+  return result;
+}
 
-  string * hook_STRING_string2token(SortString input) {
-    return input;
-  }
+SortStringBuffer hook_BUFFER_concat(SortStringBuffer buf, SortString s) {
+  return hook_BUFFER_concat_raw(buf, s->data, len(s));
+}
 
-  SortString hook_STRING_token2string(string * input) {
-    if (layout(input) != 0) {
-      throw std::invalid_argument("token2string: input is not a string token");
-    }
-    return input;
-  }
-
-  inline SortString hook_STRING_replace(SortString haystack, SortString needle, SortString replacer, SortInt occurences) {
-    uint64_t uoccurences = gs(occurences);
-    auto start = &haystack->data[0];
-    auto pos = start;
-    auto end = &haystack->data[len(haystack)];
-    size_t matches[len(haystack)];
-    int i = 0;
-    while (i < uoccurences) {
-      pos = std::search(pos, end, &needle->data[0], &needle->data[len(needle)]);
-      if (pos == end) {
-        break;
-      }
-      matches[i] = (pos - start);
-      ++pos; ++i;
-    }
-    if ( i == 0 ) {
-      return haystack;
-    }
-    auto diff = len(needle) - len(replacer);
-    size_t new_len = len(haystack) - i * diff;
-    auto ret = static_cast<string *>(koreAllocToken(sizeof(string) + new_len * sizeof(KCHAR)));
-    set_len(ret, new_len);
-    int m = 0;
-    for (size_t r = 0, h = 0; r < new_len;) {
-      if (m >= i) {
-        memcpy(ret->data+r, haystack->data+h, new_len - r);
-        break;
-      } else if (r < matches[m] - diff * m) {
-        auto size = matches[m] - diff * m - r;
-        memcpy(ret->data+r, haystack->data+h, size);
-        r += size;
-        h += size;
-      } else {
-        ++m;
-        memcpy(&ret->data[r], replacer->data, len(replacer));
-        r += len(replacer);
-        h += len(needle);
-      }
-    }
-    return ret;
-  }
-
-  SortString hook_STRING_replaceAll(SortString haystack, SortString needle, SortString replacer) {
-    // It's guaranteed that there can be no more replacements than the length of the haystack, so this
-    // gives us the functionality of replaceAll.
-    mpz_t arg;
-    mpz_init_set_si(arg, len(haystack));
-    return hook_STRING_replace(haystack, needle, replacer, arg);
-  }
-
-  SortString hook_STRING_replaceFirst(SortString haystack, SortString needle, SortString replacer) {
-    mpz_t arg;
-    mpz_init_set_si(arg, 1);
-    return hook_STRING_replace(haystack, needle, replacer, arg);
-  }
-
-  SortInt hook_STRING_countAllOccurrences(SortString haystack, SortString needle) {
-    auto pos = &haystack->data[0];
-    auto end = &haystack->data[len(haystack)];
-    int i = 0;
-    while (true) {
-      pos = std::search(pos, end, &needle->data[0], &needle->data[len(needle)]);
-      if (pos == end) {
-        break;
-      }
-      ++pos; ++i;
-    }
-    mpz_t result;
-    mpz_init_set_ui(result, i);
-    return move_int(result);
-  }
-
-  SortString hook_STRING_transcode(SortString input, SortString inputCharset, SortString outputCharset) {
-    iconv_t converter = iconv_open(getTerminatedString(outputCharset), getTerminatedString(inputCharset));
-    char *inbuf = input->data;
-    size_t inbytesleft = len(input);
-    size_t outbytesleft = inbytesleft * 4;
-    char *buf = (char *)malloc(outbytesleft);
-    char *outbuf = buf;
-    size_t result = iconv(converter, &inbuf, &inbytesleft, &outbuf, &outbytesleft);
-    if (result < 0) {
-        throw std::invalid_argument("transcoding failed: STRING.transcode");
-    }
-    *outbuf = 0;
-    return makeString(buf, len(input) * 4 - outbytesleft);
-  }
-
-  string *hook_STRING_uuid() {
-    throw std::invalid_argument("not implemented: STRING.uuid");
-  }
-
-  string *hook_STRING_category(string * str) {
-    throw std::invalid_argument("not implemented: STRING.category");
-  }
-
-  string *hook_STRING_directionality(string * str) {
-    throw std::invalid_argument("not implemented: STRING.directionality");
-  }
-
-  string *hook_STRING_floatFormat(string * str, string * fmt) {
-    throw std::invalid_argument("not implemented: STRING.floatFormat");
-  }
-
-  SortStringBuffer hook_BUFFER_empty() {
-    auto result = static_cast<stringbuffer *>(koreAlloc(sizeof(stringbuffer)));
-    set_len(result, sizeof(stringbuffer) - sizeof(blockheader));
-    result->strlen = 0;
-    auto str = static_cast<string *>(koreAllocToken(sizeof(string) + 16));
-    set_len(str, 16);
-    result->contents = str;
-    return result;
-  }
-
-  SortStringBuffer hook_BUFFER_concat(SortStringBuffer buf, SortString s) {
-    return hook_BUFFER_concat_raw(buf, s->data, len(s));
-  }
-
-  stringbuffer *hook_BUFFER_concat_raw(stringbuffer *buf, char const *data, uint64_t n) {
-    uint64_t newCapacity = len(buf->contents);
-    uint64_t minCapacity = buf->strlen + n;
-    uint64_t notYoungObjectBit = buf->h.hdr & NOT_YOUNG_OBJECT_BIT;
+stringbuffer *
+hook_BUFFER_concat_raw(stringbuffer *buf, char const *data, uint64_t n) {
+  uint64_t newCapacity = len(buf->contents);
+  uint64_t minCapacity = buf->strlen + n;
+  uint64_t notYoungObjectBit = buf->h.hdr & NOT_YOUNG_OBJECT_BIT;
+  if (newCapacity < minCapacity) {
+    newCapacity = len(buf->contents) * 2 + 2;
     if (newCapacity < minCapacity) {
-      newCapacity = len(buf->contents) * 2 + 2;
-      if (newCapacity < minCapacity) {
-        newCapacity = minCapacity;
-      }
-      string* new_contents;
-      if (notYoungObjectBit) {
-        assert(buf->h.hdr & AGE_MASK);
-        new_contents = static_cast<string *>(koreAllocTokenOld(sizeof(string) + newCapacity));
-      } else {
-        new_contents = static_cast<string *>(koreAllocToken(sizeof(string) + newCapacity));
-      }
-      memcpy(new_contents->data, buf->contents->data, buf->strlen);
-      buf->contents = new_contents;
+      newCapacity = minCapacity;
     }
-    memcpy(buf->contents->data + buf->strlen, data, n);
-    buf->strlen += n;
-    set_len(buf->contents, newCapacity);
-    return buf;
+    string *new_contents;
+    if (notYoungObjectBit) {
+      assert(buf->h.hdr & AGE_MASK);
+      new_contents = static_cast<string *>(
+          koreAllocTokenOld(sizeof(string) + newCapacity));
+    } else {
+      new_contents
+          = static_cast<string *>(koreAllocToken(sizeof(string) + newCapacity));
+    }
+    memcpy(new_contents->data, buf->contents->data, buf->strlen);
+    buf->contents = new_contents;
   }
+  memcpy(buf->contents->data + buf->strlen, data, n);
+  buf->strlen += n;
+  set_len(buf->contents, newCapacity);
+  return buf;
+}
 
-  SortString hook_BUFFER_toString(SortStringBuffer buf) {
-    return bytes2string(buf->contents, buf->strlen);
-  }
+SortString hook_BUFFER_toString(SortStringBuffer buf) {
+  return bytes2string(buf->contents, buf->strlen);
+}
 }
 
 void init_float2(floating *result, std::string contents) {
@@ -413,12 +441,12 @@ void init_float2(floating *result, std::string contents) {
   } else {
     size_t has_prec = contents.find_first_of("pP");
     if (has_prec == std::string::npos) {
-       prec = 53;
-       exp = 11;
+      prec = 53;
+      exp = 11;
     } else {
       size_t exp_idx = contents.find_first_of("xX");
-      std::string prec_str = contents.substr(has_prec+1, exp_idx-has_prec);
-      std::string exp_str = contents.substr(exp_idx+1);
+      std::string prec_str = contents.substr(has_prec + 1, exp_idx - has_prec);
+      std::string exp_str = contents.substr(exp_idx + 1);
       prec = atoll(prec_str.c_str());
       exp = atoll(exp_str.c_str());
     }
@@ -426,7 +454,8 @@ void init_float2(floating *result, std::string contents) {
   result->exp = exp;
   mpfr_init2(result->f, prec);
   int retValue;
-  if (contents == "+Infinity" || contents == "-Infinity" || contents == "Infinity") {
+  if (contents == "+Infinity" || contents == "-Infinity"
+      || contents == "Infinity") {
     retValue = mpfr_set_str(result->f, contents.c_str(), 10, MPFR_RNDN);
   } else {
     size_t last = contents.find_last_of("fFdDpP");
@@ -459,9 +488,10 @@ std::string floatToString(const floating *f, const char *suffix) {
       idx = 1;
     }
     newstr->data[idx] = '0';
-    newstr->data[idx+1] = '.';
+    newstr->data[idx + 1] = '.';
     strcpy(newstr->data + idx + 2, str + idx);
-    return std::string(newstr->data) + "e" + std::to_string(printed_exp) + suffix;
+    return std::string(newstr->data) + "e" + std::to_string(printed_exp)
+           + suffix;
   }
 }
 

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -3,12 +3,13 @@
 #include <list>
 #include <unordered_set>
 
-#include "runtime/header.h"
 #include "runtime/collect.h"
+#include "runtime/header.h"
 
 extern "C" {
 
-void addSearchResult(block *result, block ***bufPtr, uint64_t *count, uint64_t *capacity) {
+void addSearchResult(
+    block *result, block ***bufPtr, uint64_t *count, uint64_t *capacity) {
   if (*count == *capacity) {
     size_t len = *count * sizeof(block *) * 2;
     block **newBuf = (block **)koreAllocAlwaysGC(len);
@@ -20,27 +21,29 @@ void addSearchResult(block *result, block ***bufPtr, uint64_t *count, uint64_t *
   (*count)++;
 }
 
-block** take_search_step(block *, uint64_t *);
-
+block **take_search_step(block *, uint64_t *);
 }
 
 static std::list<block *> states;
 static block *state;
 
-static std::pair<std::vector<block **>::iterator, std::vector<block **>::iterator> blockEnumerator() {
+static std::pair<
+    std::vector<block **>::iterator, std::vector<block **>::iterator>
+blockEnumerator() {
   static std::vector<block **> blocks;
 
   blocks.clear();
 
   for (auto &keyVal : states) {
-    blocks.push_back(const_cast<block**>(&(keyVal)));
+    blocks.push_back(const_cast<block **>(&(keyVal)));
   }
   blocks.push_back(&state);
 
   return std::make_pair(blocks.begin(), blocks.end());
 }
 
-std::unordered_set<block *, HashBlock, KEq> take_search_steps(int64_t depth, block *subject) {
+std::unordered_set<block *, HashBlock, KEq>
+take_search_steps(int64_t depth, block *subject) {
   static int registered = -1;
   if (registered == -1) {
     registerGCRootsEnumerator(blockEnumerator);
@@ -51,11 +54,12 @@ std::unordered_set<block *, HashBlock, KEq> take_search_steps(int64_t depth, blo
   states.clear();
   states_set.insert(subject);
   states.push_back(subject);
-  while(!states.empty() && depth != 0) {
+  while (!states.empty() && depth != 0) {
     state = states.front();
     states.pop_front();
     states_set.erase(state);
-    if (depth > 0) depth--;
+    if (depth > 0)
+      depth--;
     uint64_t count;
     block **stepResults = take_search_step(state, &count);
     if (count == 0) {

--- a/tools/kore-expand-macros/main.cpp
+++ b/tools/kore-expand-macros/main.cpp
@@ -1,14 +1,15 @@
-#include "kllvm/parser/KOREScanner.h"
 #include "kllvm/parser/KOREParser.h"
+#include "kllvm/parser/KOREScanner.h"
 
 #include <iostream>
 
 using namespace kllvm;
 using namespace kllvm::parser;
 
-int main (int argc, char **argv) {
+int main(int argc, char **argv) {
   if (argc != 3) {
-    std::cerr << "usage: " << argv[0] << " <kompiled-dir> <pattern.kore>" << std::endl;
+    std::cerr << "usage: " << argv[0] << " <kompiled-dir> <pattern.kore>"
+              << std::endl;
     return 1;
   }
 
@@ -21,14 +22,20 @@ int main (int argc, char **argv) {
   for (auto axiom : def->getAxioms()) {
     if (axiom->getAttributes().count("subsort")) {
       KORECompositePattern *att = axiom->getAttributes().at("subsort").get();
-      KORESort *innerSort = att->getConstructor()->getFormalArguments()[0].get();
-      KORESort *outerSort = att->getConstructor()->getFormalArguments()[1].get();
+      KORESort *innerSort
+          = att->getConstructor()->getFormalArguments()[0].get();
+      KORESort *outerSort
+          = att->getConstructor()->getFormalArguments()[1].get();
       subsorts[innerSort].insert(outerSort);
     }
     if (axiom->getAttributes().count("overload")) {
       KORECompositePattern *att = axiom->getAttributes().at("overload").get();
-      KORESymbol *innerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())->getConstructor();
-      KORESymbol *outerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())->getConstructor();
+      KORESymbol *innerSymbol
+          = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())
+                ->getConstructor();
+      KORESymbol *outerSymbol
+          = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())
+                ->getConstructor();
       overloads[innerSymbol].insert(outerSymbol);
     }
   }
@@ -38,13 +45,15 @@ int main (int argc, char **argv) {
 
   KOREParser parser2(argv[1] + std::string("/macros.kore"));
   std::vector<ptr<KOREDeclaration>> axioms = parser2.declarations();
-  std::sort(axioms.begin(), axioms.end(), [](const ptr<KOREDeclaration> &l, const ptr<KOREDeclaration> &r) {
-      std::string lStr = l->getStringAttribute("priority");
-      std::string rStr = r->getStringAttribute("priority");
-      int lInt = std::stoi(lStr);
-      int rInt = std::stoi(rStr);
-      return lInt < rInt;
-  });
+  std::sort(
+      axioms.begin(), axioms.end(),
+      [](const ptr<KOREDeclaration> &l, const ptr<KOREDeclaration> &r) {
+        std::string lStr = l->getStringAttribute("priority");
+        std::string rStr = r->getStringAttribute("priority");
+        int lInt = std::stoi(lStr);
+        int rInt = std::stoi(rStr);
+        return lInt < rInt;
+      });
 
   KOREParser parser3(argv[2]);
   sptr<KOREPattern> config = parser3.pattern();
@@ -64,7 +73,8 @@ int main (int argc, char **argv) {
     }
   }
 
-  sptr<KOREPattern> expanded = config->expandMacros(subsorts, overloads, axioms, false);
+  sptr<KOREPattern> expanded
+      = config->expandMacros(subsorts, overloads, axioms, false);
   expanded->print(std::cout);
   std::cout << std::endl;
 

--- a/tools/kprint/addBrackets.cpp
+++ b/tools/kprint/addBrackets.cpp
@@ -4,12 +4,7 @@
 
 using namespace kllvm;
 
-enum Fixity {
-  EMPTY = 0,
-  BARE_LEFT = 1,
-  BARE_RIGHT = 2,
-  BARE_BOTH = 3
-};
+enum Fixity { EMPTY = 0, BARE_LEFT = 1, BARE_RIGHT = 2, BARE_BOTH = 3 };
 
 /**
  * Get the index of the Nth nonterminal within the list of all terminals and
@@ -39,7 +34,7 @@ int getNTPositionInProd(std::string terminals, int position) {
   return terminalPos;
 }
 
-/** 
+/**
  * Get whether a production has a terminal at a particular index.
  *
  * Out of bounds errors do not occur with this function: if the index is out of
@@ -64,21 +59,22 @@ bool hasTerminalAtIdx(std::string terminals, int position) {
  * data: pretty printing metadata
  *
  * returns: EMPTY if there are terminals on both sides of this nonterminal
- *          BARE_LEFT if there is a terminal only on the right of this nonterminal
- *          BARE_RIGHT if there is a terminal only on the left of this nonterminal
- *          BARE_BOTH if there are not terminals on either side of this nonterminal
+ *          BARE_LEFT if there is a terminal only on the right of this
+ * nonterminal BARE_RIGHT if there is a terminal only on the left of this
+ * nonterminal BARE_BOTH if there are not terminals on either side of this
+ * nonterminal
  */
-Fixity getFixity(int position, KORESymbol *sym, PrettyPrintData const& data) {
+Fixity getFixity(int position, KORESymbol *sym, PrettyPrintData const &data) {
   int result = EMPTY;
   std::string terminals = data.terminals.at(sym->getName());
   int terminalPos = getNTPositionInProd(terminals, position);
-  if (!hasTerminalAtIdx(terminals, terminalPos+1)) {
+  if (!hasTerminalAtIdx(terminals, terminalPos + 1)) {
     result |= BARE_RIGHT;
   }
-  if (!hasTerminalAtIdx(terminals, terminalPos-1)) {
+  if (!hasTerminalAtIdx(terminals, terminalPos - 1)) {
     result |= BARE_LEFT;
   }
-  return (Fixity) result;
+  return (Fixity)result;
 }
 
 /**
@@ -90,17 +86,18 @@ Fixity getFixity(int position, KORESymbol *sym, PrettyPrintData const& data) {
  * data: pretty printing metadata
  *
  * returns: EMPTY if there are terminals on both edges of this production.
- *          BARE_LEFT if there is a terminal only on the right edge of this production
- *          BARE_RIGHT if there is a terminal only on the left edge of this production
- *          BARE_BOTH if there are not terminals on either edge of this production
+ *          BARE_LEFT if there is a terminal only on the right edge of this
+ * production BARE_RIGHT if there is a terminal only on the left edge of this
+ * production BARE_BOTH if there are not terminals on either edge of this
+ * production
  */
-Fixity getFixity(KORESymbol *sym, PrettyPrintData const& data) {
+Fixity getFixity(KORESymbol *sym, PrettyPrintData const &data) {
   std::string name = sym->getName();
   int result = EMPTY;
   if (data.terminals.at(name)[0] == '0') {
     result = result | BARE_LEFT;
   }
-  if (data.terminals.at(name)[data.terminals.at(name).size()-1] == '0') {
+  if (data.terminals.at(name)[data.terminals.at(name).size() - 1] == '0') {
     result = result | BARE_RIGHT;
   }
   return (Fixity)result;
@@ -127,8 +124,10 @@ Fixity getFixity(KORESymbol *sym, PrettyPrintData const& data) {
  * data: pretty printing metadata
  *
  * returns: the left capture of the term, or NULL if no such term exists
- */ 
-KORECompositePattern *getLeftCapture(KORECompositePattern *previousLeftCapture, KORECompositePattern *outer, int position, PrettyPrintData const& data) {
+ */
+KORECompositePattern *getLeftCapture(
+    KORECompositePattern *previousLeftCapture, KORECompositePattern *outer,
+    int position, PrettyPrintData const &data) {
   Fixity fixity = getFixity(outer->getConstructor(), data);
   if (position == 0 && (fixity & BARE_LEFT)) {
     return previousLeftCapture;
@@ -158,9 +157,11 @@ KORECompositePattern *getLeftCapture(KORECompositePattern *previousLeftCapture, 
  * data: pretty printing metadata
  *
  * returns: the right capture of the term, or NULL if no such term exists
- */ 
+ */
 
-KORECompositePattern *getRightCapture(KORECompositePattern *previousRightCapture, KORECompositePattern *outer, int position, PrettyPrintData const& data) {
+KORECompositePattern *getRightCapture(
+    KORECompositePattern *previousRightCapture, KORECompositePattern *outer,
+    int position, PrettyPrintData const &data) {
   Fixity fixity = getFixity(outer->getConstructor(), data);
   if (position == outer->getArguments().size() - 1 && (fixity & BARE_RIGHT)) {
     return previousRightCapture;
@@ -181,35 +182,32 @@ KORECompositePattern *getRightCapture(KORECompositePattern *previousRightCapture
  *
  * returns: s1 <= s2
  */
-bool lessThanEq(PrettyPrintData const& data, KORESort *s1, KORESort *s2) {
-  return *s1 == *s2 || (data.subsorts.count(s1) && data.subsorts.at(s1).count(s2));
+bool lessThanEq(PrettyPrintData const &data, KORESort *s1, KORESort *s2) {
+  return *s1 == *s2
+         || (data.subsorts.count(s1) && data.subsorts.at(s1).count(s2));
 }
 
-sptr<KORESort> getArgSort(KORESymbol *symbol, int position, sptr<KORESort> firstArgSort) {
+sptr<KORESort>
+getArgSort(KORESymbol *symbol, int position, sptr<KORESort> firstArgSort) {
   if (!symbol->isBuiltin()) {
     return symbol->getArguments()[position];
-  } else if (symbol->getName() == "\\and" ||
-      symbol->getName() == "\\not" ||
-      symbol->getName() == "\\or" ||
-      symbol->getName() == "\\implies" ||
-      symbol->getName() == "\\iff" ||
-      symbol->getName() == "\\ceil" ||
-      symbol->getName() == "\\floor" ||
-      symbol->getName() == "\\equals" ||
-      symbol->getName() == "\\in" ||
-      symbol->getName() == "\\next" ||
-      symbol->getName() == "\\rewrites") {
+  } else if (
+      symbol->getName() == "\\and" || symbol->getName() == "\\not"
+      || symbol->getName() == "\\or" || symbol->getName() == "\\implies"
+      || symbol->getName() == "\\iff" || symbol->getName() == "\\ceil"
+      || symbol->getName() == "\\floor" || symbol->getName() == "\\equals"
+      || symbol->getName() == "\\in" || symbol->getName() == "\\next"
+      || symbol->getName() == "\\rewrites") {
     return symbol->getFormalArguments()[0];
-  } else if (symbol->getName() == "\\forall" ||
-      symbol->getName() == "\\exists") {
+  } else if (
+      symbol->getName() == "\\forall" || symbol->getName() == "\\exists") {
     if (position == 0) {
       assert(firstArgSort != nullptr);
       return firstArgSort;
     } else {
       return symbol->getFormalArguments()[0];
     }
-  } else if (symbol->getName() == "\\mu" ||
-      symbol->getName() == "\\nu") {
+  } else if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
     assert(firstArgSort != nullptr);
     return firstArgSort;
   } else {
@@ -222,25 +220,19 @@ sptr<KORESort> getReturnSort(KOREPattern *pat) {
     auto symbol = composite->getConstructor();
     if (!symbol->isBuiltin()) {
       return pat->getSort();
-    } else if (symbol->getName() == "\\top" ||
-        symbol->getName() == "\\bottom" ||
-        symbol->getName() == "\\and" ||
-        symbol->getName() == "\\not" ||
-        symbol->getName() == "\\or" ||
-        symbol->getName() == "\\implies" ||
-        symbol->getName() == "\\iff" ||
-        symbol->getName() == "\\exists" ||
-        symbol->getName() == "\\forall" ||
-        symbol->getName() == "\\next" ||
-        symbol->getName() == "\\rewrites") {
+    } else if (
+        symbol->getName() == "\\top" || symbol->getName() == "\\bottom"
+        || symbol->getName() == "\\and" || symbol->getName() == "\\not"
+        || symbol->getName() == "\\or" || symbol->getName() == "\\implies"
+        || symbol->getName() == "\\iff" || symbol->getName() == "\\exists"
+        || symbol->getName() == "\\forall" || symbol->getName() == "\\next"
+        || symbol->getName() == "\\rewrites") {
       return symbol->getFormalArguments()[0];
-    } else if (symbol->getName() == "\\ceil" ||
-        symbol->getName() == "\\floor" ||
-        symbol->getName() == "\\equals" ||
-        symbol->getName() == "\\in") {
+    } else if (
+        symbol->getName() == "\\ceil" || symbol->getName() == "\\floor"
+        || symbol->getName() == "\\equals" || symbol->getName() == "\\in") {
       return symbol->getFormalArguments()[1];
-    } else if (symbol->getName() == "\\mu" ||
-        symbol->getName() == "\\nu") {
+    } else if (symbol->getName() == "\\mu" || symbol->getName() == "\\nu") {
       return composite->getArguments()[0]->getSort();
     } else {
       abort();
@@ -267,23 +259,32 @@ sptr<KORESort> getReturnSort(KOREPattern *pat) {
  * returns: true if priority forbids `inner` to appear inside `outer` at that
  * position.
  */
-bool isPriorityWrong(KORECompositePattern *outer, KORECompositePattern *inner, int position, PrettyPrintData const& data) {
+bool isPriorityWrong(
+    KORECompositePattern *outer, KORECompositePattern *inner, int position,
+    PrettyPrintData const &data) {
   std::string outerName = outer->getConstructor()->getName();
   std::string innerName = inner->getConstructor()->getName();
   KORESort *innerSort = getReturnSort(inner).get();
-  KORESort *outerSort = getArgSort(outer->getConstructor(), position, outer->getArguments()[0]->getSort()).get();
+  KORESort *outerSort = getArgSort(
+                            outer->getConstructor(), position,
+                            outer->getArguments()[0]->getSort())
+                            .get();
   if (!lessThanEq(data, innerSort, outerSort)) {
     return true;
   }
-  if (data.priorities.count(outerName) && data.priorities.at(outerName).count(innerName)) {
+  if (data.priorities.count(outerName)
+      && data.priorities.at(outerName).count(innerName)) {
     return true;
   }
   std::string terminals = data.terminals.at(outerName);
   int terminalPos = getNTPositionInProd(terminals, position);
-  if (data.leftAssoc.count(outerName) && data.leftAssoc.at(outerName).count(innerName) && terminalPos == terminals.size() - 1) {
+  if (data.leftAssoc.count(outerName)
+      && data.leftAssoc.at(outerName).count(innerName)
+      && terminalPos == terminals.size() - 1) {
     return true;
   }
-  if (data.rightAssoc.count(outerName) && data.rightAssoc.at(outerName).count(innerName) && terminalPos == 0) {
+  if (data.rightAssoc.count(outerName)
+      && data.rightAssoc.at(outerName).count(innerName) && terminalPos == 0) {
     return true;
   }
   return false;
@@ -313,11 +314,11 @@ bool isPriorityWrong(KORECompositePattern *outer, KORECompositePattern *inner, i
  * or right capture, respectively, and its left or right capture does not
  * end or begin, respectively, with a terminal.
  *
- * Warning: this algorithm is *unsound*. There is no guarantee that after 
+ * Warning: this algorithm is *unsound*. There is no guarantee that after
  * it completes, the resulting term can be unparsed into a string that will
  * parse unambiguously as the original AST. Indeed, the problem of inserting
- * brackets into an AST in order to ensure this property is NP-hard, and 
- * grammars can be constructed such that solving the unparsing problem is 
+ * brackets into an AST in order to ensure this property is NP-hard, and
+ * grammars can be constructed such that solving the unparsing problem is
  * equivalent to boolean satisfiability. This algorithm is merely a linear-time
  * approximation of the general problem which performs very well in most
  * real-world grammars, especially the common expression-grammar category of
@@ -330,7 +331,10 @@ bool isPriorityWrong(KORECompositePattern *outer, KORECompositePattern *inner, i
  * The terms `(1 ++) 1` and `1 (++ 1)` will not have brackets inserted
  * into them by this algorithm, even though they are required.
  */
-bool requiresBracketWithSimpleAlgorithm(KORECompositePattern *outer, KORECompositePattern *leftCapture, KORECompositePattern *rightCapture, KOREPattern *inner, int position, PrettyPrintData const& data) {
+bool requiresBracketWithSimpleAlgorithm(
+    KORECompositePattern *outer, KORECompositePattern *leftCapture,
+    KORECompositePattern *rightCapture, KOREPattern *inner, int position,
+    PrettyPrintData const &data) {
   if (auto innerComposite = dynamic_cast<KORECompositePattern *>(inner)) {
     std::string innerName = innerComposite->getConstructor()->getName();
     if (innerName == outer->getConstructor()->getName()) {
@@ -354,14 +358,18 @@ bool requiresBracketWithSimpleAlgorithm(KORECompositePattern *outer, KOREComposi
     }
     Fixity innerFixity = getFixity(innerComposite->getConstructor(), data);
     if ((innerFixity & BARE_RIGHT) && rightCapture != nullptr) {
-      bool inversePriority = isPriorityWrong(innerComposite, rightCapture, innerComposite->getArguments().size() - 1, data);
-      Fixity rightCaptureFixity = getFixity(rightCapture->getConstructor(), data);
+      bool inversePriority = isPriorityWrong(
+          innerComposite, rightCapture,
+          innerComposite->getArguments().size() - 1, data);
+      Fixity rightCaptureFixity
+          = getFixity(rightCapture->getConstructor(), data);
       if (!inversePriority && (rightCaptureFixity & BARE_LEFT)) {
         return true;
       }
     }
     if ((innerFixity & BARE_LEFT) && leftCapture != nullptr) {
-      bool inversePriority = isPriorityWrong(innerComposite, leftCapture, 0, data);
+      bool inversePriority
+          = isPriorityWrong(innerComposite, leftCapture, 0, data);
       Fixity leftCaptureFixity = getFixity(leftCapture->getConstructor(), data);
       if (!inversePriority && (leftCaptureFixity & BARE_RIGHT)) {
         return true;
@@ -373,20 +381,28 @@ bool requiresBracketWithSimpleAlgorithm(KORECompositePattern *outer, KOREComposi
   }
 }
 
-sptr<KOREPattern> addBrackets(sptr<KOREPattern> inner, KORECompositePattern *outer, KORECompositePattern *leftCapture, KORECompositePattern *rightCapture, int position, PrettyPrintData const& data) {
+sptr<KOREPattern> addBrackets(
+    sptr<KOREPattern> inner, KORECompositePattern *outer,
+    KORECompositePattern *leftCapture, KORECompositePattern *rightCapture,
+    int position, PrettyPrintData const &data) {
   if (auto innerComposite = dynamic_cast<KORECompositePattern *>(inner.get())) {
     if (innerComposite->getConstructor()->getName() == "inj") {
-      return addBrackets(innerComposite->getArguments()[0], outer, leftCapture, rightCapture, position, data);
+      return addBrackets(
+          innerComposite->getArguments()[0], outer, leftCapture, rightCapture,
+          position, data);
     }
   }
-  if (requiresBracketWithSimpleAlgorithm(outer, leftCapture, rightCapture, inner.get(), position, data)) {
-    sptr<KORESort> outerSort = getArgSort(outer->getConstructor(), position, outer->getArguments()[0]->getSort());
+  if (requiresBracketWithSimpleAlgorithm(
+          outer, leftCapture, rightCapture, inner.get(), position, data)) {
+    sptr<KORESort> outerSort = getArgSort(
+        outer->getConstructor(), position, outer->getArguments()[0]->getSort());
     sptr<KORESort> innerSort = getReturnSort(inner.get());
     for (auto &entry : data.brackets) {
       bool isCorrectOuterSort = lessThanEq(data, entry.first, outerSort.get());
       if (isCorrectOuterSort) {
         for (KORESymbol *s : entry.second) {
-          bool isCorrectInnerSort = lessThanEq(data, innerSort.get(), getArgSort(s, 0, nullptr).get());
+          bool isCorrectInnerSort = lessThanEq(
+              data, innerSort.get(), getArgSort(s, 0, nullptr).get());
           if (isCorrectInnerSort) {
             sptr<KORECompositePattern> result = KORECompositePattern::Create(s);
             result->addArgument(inner);
@@ -403,19 +419,25 @@ sptr<KOREPattern> addBrackets(sptr<KOREPattern> inner, KORECompositePattern *out
   return inner;
 }
 
-sptr<KOREPattern> addBrackets(sptr<KOREPattern> t, KORECompositePattern *previousLeftCapture, KORECompositePattern *previousRightCapture, PrettyPrintData const& data) {
+sptr<KOREPattern> addBrackets(
+    sptr<KOREPattern> t, KORECompositePattern *previousLeftCapture,
+    KORECompositePattern *previousRightCapture, PrettyPrintData const &data) {
   if (auto outer = dynamic_cast<KORECompositePattern *>(t.get())) {
     if (outer->getConstructor()->getName() == "\\dv") {
       return t;
     }
     std::vector<sptr<KOREPattern>> newItems;
 
-    sptr<KORECompositePattern> result = KORECompositePattern::Create(outer->getConstructor());
+    sptr<KORECompositePattern> result
+        = KORECompositePattern::Create(outer->getConstructor());
     int position = 0;
     for (auto &inner : outer->getArguments()) {
-      KORECompositePattern *leftCapture = getLeftCapture(previousLeftCapture, outer, position, data);
-      KORECompositePattern *rightCapture = getRightCapture(previousRightCapture, outer, position, data);
-      sptr<KOREPattern> newInner = addBrackets(inner, outer, leftCapture, rightCapture, position, data);
+      KORECompositePattern *leftCapture
+          = getLeftCapture(previousLeftCapture, outer, position, data);
+      KORECompositePattern *rightCapture
+          = getRightCapture(previousRightCapture, outer, position, data);
+      sptr<KOREPattern> newInner = addBrackets(
+          inner, outer, leftCapture, rightCapture, position, data);
       newInner = addBrackets(newInner, leftCapture, rightCapture, data);
       result->addArgument(newInner);
       position++;
@@ -426,6 +448,7 @@ sptr<KOREPattern> addBrackets(sptr<KOREPattern> t, KORECompositePattern *previou
   }
 }
 
-sptr<KOREPattern> addBrackets(sptr<KOREPattern> t, PrettyPrintData const& data) {
+sptr<KOREPattern>
+addBrackets(sptr<KOREPattern> t, PrettyPrintData const &data) {
   return addBrackets(t, nullptr, nullptr, data);
 }

--- a/tools/kprint/main.cpp
+++ b/tools/kprint/main.cpp
@@ -1,34 +1,35 @@
-#include "kllvm/parser/KOREScanner.h"
 #include "kllvm/parser/KOREParser.h"
+#include "kllvm/parser/KOREScanner.h"
 
 #include <iostream>
 
 using namespace kllvm;
 using namespace kllvm::parser;
 
-sptr<KOREPattern> addBrackets(sptr<KOREPattern>, PrettyPrintData const&);
+sptr<KOREPattern> addBrackets(sptr<KOREPattern>, PrettyPrintData const &);
 
 const std::string WHITESPACE = " \n\r\t\f\v";
 
-static std::string ltrim(const std::string &s)
-{
-    size_t start = s.find_first_not_of(WHITESPACE);
-    return (start == std::string::npos) ? "" : s.substr(start);
+static std::string ltrim(const std::string &s) {
+  size_t start = s.find_first_not_of(WHITESPACE);
+  return (start == std::string::npos) ? "" : s.substr(start);
 }
 
-static std::string rtrim(const std::string &s)
-{
-    size_t end = s.find_last_not_of(WHITESPACE);
-    return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+static std::string rtrim(const std::string &s) {
+  size_t end = s.find_last_not_of(WHITESPACE);
+  return (end == std::string::npos) ? "" : s.substr(0, end + 1);
 }
 
 static std::string trim(const std::string &s) {
-    return rtrim(ltrim(s));
+  return rtrim(ltrim(s));
 }
 
-int main (int argc, char **argv) {
+int main(int argc, char **argv) {
   if (argc != 3 && argc != 4 && argc != 5) {
-    std::cerr << "usage: " << argv[0] << " <definition.kore> <pattern.kore> [true|false|auto] [true|false]" << std::endl;
+    std::cerr
+        << "usage: " << argv[0]
+        << " <definition.kore> <pattern.kore> [true|false|auto] [true|false]"
+        << std::endl;
   }
 
   bool hasColor, filterSubst;
@@ -99,7 +100,8 @@ int main (int argc, char **argv) {
   comms.insert("\\or");
   std::map<std::string, std::vector<std::string>> colors;
 
-  std::map<std::string, std::set<std::string>> priorities, leftAssoc, rightAssoc;
+  std::map<std::string, std::set<std::string>> priorities, leftAssoc,
+      rightAssoc;
   leftAssoc["kseq"].insert("kseq");
   leftAssoc["append"].insert("append");
   leftAssoc["\\and"].insert("\\and");
@@ -181,7 +183,7 @@ int main (int argc, char **argv) {
             color.push_back(trim(colorAtt.substr(idx)));
             break;
           } else {
-            color.push_back(trim(colorAtt.substr(idx, pos-idx)));
+            color.push_back(trim(colorAtt.substr(idx, pos - idx)));
             idx = pos + 1;
           }
         } while (true);
@@ -189,7 +191,8 @@ int main (int argc, char **argv) {
       }
 
       if (entry.second->getAttributes().count("bracket")) {
-        brackets[entry.second->getSymbol()->getSort().get()].push_back(entry.second->getSymbol());
+        brackets[entry.second->getSymbol()->getSort().get()].push_back(
+            entry.second->getSymbol());
       }
 
       readMultimap(name, entry.second, leftAssoc, "left");
@@ -208,14 +211,20 @@ int main (int argc, char **argv) {
   for (auto axiom : def->getAxioms()) {
     if (axiom->getAttributes().count("subsort")) {
       KORECompositePattern *att = axiom->getAttributes().at("subsort").get();
-      KORESort *innerSort = att->getConstructor()->getFormalArguments()[0].get();
-      KORESort *outerSort = att->getConstructor()->getFormalArguments()[1].get();
+      KORESort *innerSort
+          = att->getConstructor()->getFormalArguments()[0].get();
+      KORESort *outerSort
+          = att->getConstructor()->getFormalArguments()[1].get();
       subsorts[innerSort].insert(outerSort);
     }
     if (axiom->getAttributes().count("overload")) {
       KORECompositePattern *att = axiom->getAttributes().at("overload").get();
-      KORESymbol *innerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())->getConstructor();
-      KORESymbol *outerSymbol = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())->getConstructor();
+      KORESymbol *innerSymbol
+          = dynamic_cast<KORECompositePattern *>(att->getArguments()[1].get())
+                ->getConstructor();
+      KORESymbol *outerSymbol
+          = dynamic_cast<KORECompositePattern *>(att->getArguments()[0].get())
+                ->getConstructor();
       overloads[innerSymbol].insert(outerSymbol);
     }
   }
@@ -244,9 +253,12 @@ int main (int argc, char **argv) {
     }
   }
 
-  PrettyPrintData data = {formats, colors, terminals, priorities, leftAssoc, rightAssoc, hooks, brackets, assocs, comms, subsorts, hasColor};
+  PrettyPrintData data
+      = {formats, colors,   terminals, priorities, leftAssoc, rightAssoc,
+         hooks,   brackets, assocs,    comms,      subsorts,  hasColor};
 
-  sptr<KOREPattern> expanded = config->expandMacros(subsorts, overloads, axioms, true);
+  sptr<KOREPattern> expanded
+      = config->expandMacros(subsorts, overloads, axioms, true);
   sptr<KOREPattern> sorted = expanded->sortCollections(data);
   sptr<KOREPattern> filtered;
   if (filterSubst) {

--- a/tools/llvm-kompile-codegen/main.cpp
+++ b/tools/llvm-kompile-codegen/main.cpp
@@ -1,10 +1,10 @@
 #include "kllvm/codegen/CreateTerm.h"
-#include "kllvm/codegen/Decision.h"
 #include "kllvm/codegen/Debug.h"
+#include "kllvm/codegen/Decision.h"
 #include "kllvm/codegen/DecisionParser.h"
 #include "kllvm/codegen/EmitConfigParser.h"
-#include "kllvm/parser/KOREScanner.h"
 #include "kllvm/parser/KOREParser.h"
+#include "kllvm/parser/KOREScanner.h"
 
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/LLVMContext.h"
@@ -14,19 +14,22 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 using namespace kllvm;
 using namespace kllvm::parser;
 
-std::string getFilename(std::map<std::string, std::string> index, char **argv, KORESymbolDeclaration *decl) {
+std::string getFilename(
+    std::map<std::string, std::string> index, char **argv,
+    KORESymbolDeclaration *decl) {
   return argv[3] + std::string("/") + index.at(decl->getSymbol()->getName());
 }
 
-int main (int argc, char **argv) {
+int main(int argc, char **argv) {
   if (argc < 5) {
-    std::cerr << "Usage: llvm-kompile-codegen <def.kore> <dt.yaml> <dir> [1|0]\n";
+    std::cerr
+        << "Usage: llvm-kompile-codegen <def.kore> <dt.yaml> <dir> [1|0]\n";
     exit(1);
   }
 
@@ -45,7 +48,7 @@ int main (int argc, char **argv) {
   if (CODEGEN_DEBUG) {
     initDebugInfo(mod.get(), argv[1]);
   }
-  
+
   addKompiledDirSymbol(Context, dirname(realPath), mod.get(), CODEGEN_DEBUG);
 
   for (auto axiom : definition->getAxioms()) {
@@ -53,18 +56,25 @@ int main (int argc, char **argv) {
     if (!axiom->isTopAxiom()) {
       makeApplyRuleFunction(axiom, definition.get(), mod.get());
     } else {
-      std::string filename = argv[3] + std::string("/") + "dt_" + std::to_string(axiom->getOrdinal()) + ".yaml";
+      std::string filename = argv[3] + std::string("/") + "dt_"
+                             + std::to_string(axiom->getOrdinal()) + ".yaml";
       struct stat buf;
       if (stat(filename.c_str(), &buf) == 0) {
-        auto residuals = parseYamlSpecialDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
-        makeApplyRuleFunction(axiom, definition.get(), mod.get(), residuals.residuals);
+        auto residuals = parseYamlSpecialDecisionTree(
+            mod.get(), filename, definition->getAllSymbols(),
+            definition->getHookedSorts());
+        makeApplyRuleFunction(
+            axiom, definition.get(), mod.get(), residuals.residuals);
         makeStepFunction(axiom, definition.get(), mod.get(), residuals);
       } else {
         makeApplyRuleFunction(axiom, definition.get(), mod.get(), true);
       }
-      filename = argv[3] + std::string("/") + "match_" + std::to_string(axiom->getOrdinal()) + ".yaml";
+      filename = argv[3] + std::string("/") + "match_"
+                 + std::to_string(axiom->getOrdinal()) + ".yaml";
       if (stat(filename.c_str(), &buf) == 0) {
-        auto dt = parseYamlDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
+        auto dt = parseYamlDecisionTree(
+            mod.get(), filename, definition->getAllSymbols(),
+            definition->getHookedSorts());
         makeMatchReasonFunction(definition.get(), mod.get(), axiom, dt);
       }
     }
@@ -72,9 +82,13 @@ int main (int argc, char **argv) {
 
   emitConfigParserFunctions(definition.get(), mod.get());
 
-  auto dt = parseYamlDecisionTree(mod.get(), argv[2], definition->getAllSymbols(), definition->getHookedSorts());
+  auto dt = parseYamlDecisionTree(
+      mod.get(), argv[2], definition->getAllSymbols(),
+      definition->getHookedSorts());
   makeStepFunction(definition.get(), mod.get(), dt, false);
-  auto dtSearch = parseYamlDecisionTree(mod.get(), argv[3] + std::string("/") + "dt-search.yaml", definition->getAllSymbols(), definition->getHookedSorts());
+  auto dtSearch = parseYamlDecisionTree(
+      mod.get(), argv[3] + std::string("/") + "dt-search.yaml",
+      definition->getAllSymbols(), definition->getHookedSorts());
   makeStepFunction(definition.get(), mod.get(), dtSearch, true);
 
   std::map<std::string, std::string> index;
@@ -82,9 +96,9 @@ int main (int argc, char **argv) {
   std::ifstream in(argv[3] + std::string("/index.txt"));
 
   std::string line;
-  while(std::getline(in, line)) {
+  while (std::getline(in, line)) {
     size_t delim = line.find('\t');
-    index[line.substr(0, delim)] = line.substr(delim+1);
+    index[line.substr(0, delim)] = line.substr(delim + 1);
   }
 
   in.close();
@@ -94,14 +108,20 @@ int main (int argc, char **argv) {
     auto decl = definition->getSymbolDeclarations().at(symbol->getName());
     if ((decl->getAttributes().count("function") && !decl->isHooked())) {
       std::string filename = getFilename(index, argv, decl);
-      auto funcDt = parseYamlDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
+      auto funcDt = parseYamlDecisionTree(
+          mod.get(), filename, definition->getAllSymbols(),
+          definition->getHookedSorts());
       makeEvalFunction(decl->getSymbol(), definition.get(), mod.get(), funcDt);
     } else if (decl->isAnywhere()) {
       std::string filename = getFilename(index, argv, decl);
-      auto funcDt = parseYamlDecisionTree(mod.get(), filename, definition->getAllSymbols(), definition->getHookedSorts());
+      auto funcDt = parseYamlDecisionTree(
+          mod.get(), filename, definition->getAllSymbols(),
+          definition->getHookedSorts());
       std::ostringstream Out;
       decl->getSymbol()->print(Out);
-      makeAnywhereFunction(definition->getAllSymbols().at(Out.str()), definition.get(), mod.get(), funcDt);
+      makeAnywhereFunction(
+          definition->getAllSymbols().at(Out.str()), definition.get(),
+          mod.get(), funcDt);
     }
   }
 

--- a/tools/llvm-kompile-gc-stats/main.cpp
+++ b/tools/llvm-kompile-gc-stats/main.cpp
@@ -4,9 +4,9 @@
 #include <cstring>
 #include <gmp.h>
 
-int main (int argc, char **argv) {
+int main(int argc, char **argv) {
   const char *usage = "usage: %s [dump|analyze|generation|count] <file>"
-   " [<lower_bound> <upper_bound>]\n";
+                      " [<lower_bound> <upper_bound>]\n";
   if (argc < 3) {
     fprintf(stderr, usage, argv[0]);
     return 1;
@@ -46,7 +46,7 @@ int main (int argc, char **argv) {
     upperBound = atoi(argv[4]);
     mpz_init(size);
   }
-  while(true) {
+  while (true) {
     int ret = fread(frame, sizeof(size_t), 2049, f);
     // the frame contains 2049 integers:
     //
@@ -59,7 +59,8 @@ int main (int argc, char **argv) {
     //
     // frame[2048] contains the total number of bytes that survived
     // at least 2048 collection cycles that are alive at that point in time.
-    if (ret < 2049) break;
+    if (ret < 2049)
+      break;
     if (dump) {
       printf("Collection %zd\n", step);
       for (int i = 0; i < 2048; i++) {
@@ -70,8 +71,8 @@ int main (int argc, char **argv) {
       for (int i = 0; i < 2048; i++) {
         mpz_add_ui(total[i], total[i], frame[i]);
         if (i > 0) {
-          assert(mpz_cmp_ui(total[i-1], frame[i]) >= 0);
-          mpz_sub_ui(total[i-1], total[i-1], frame[i]);
+          assert(mpz_cmp_ui(total[i - 1], frame[i]) >= 0);
+          mpz_sub_ui(total[i - 1], total[i - 1], frame[i]);
         }
       }
     } else if (generation) {
@@ -94,7 +95,7 @@ int main (int argc, char **argv) {
     step++;
   }
   if (analyze) {
-    for (int i = 0; i < 2047; i++) { 
+    for (int i = 0; i < 2047; i++) {
       gmp_printf("%d: %Zd\n", i, total[i]);
     }
     gmp_printf("saturated: %Zd\n", total[2047]);
@@ -103,5 +104,3 @@ int main (int argc, char **argv) {
   }
   return 0;
 }
-
-

--- a/unittests/runtime-arithmetic/floattest.cpp
+++ b/unittests/runtime-arithmetic/floattest.cpp
@@ -1,61 +1,61 @@
 #include <boost/test/unit_test.hpp>
-#include <gmp.h>
-#include <mpfr.h>
 #include <cmath>
+#include <gmp.h>
 #include <limits>
+#include <mpfr.h>
 
 #include "runtime/header.h"
 
 extern "C" {
-  floating *hook_FLOAT_ceil(floating *);
-  floating *hook_FLOAT_floor(floating *);
-  floating *hook_FLOAT_trunc(floating *);
-  floating *hook_FLOAT_round(floating *, mpz_t, mpz_t);
-  mpz_ptr hook_FLOAT_float2int(floating *);
-  floating *hook_FLOAT_int2float(mpz_t, mpz_t, mpz_t);
-  floating *hook_FLOAT_sin(floating *);
-  floating *hook_FLOAT_cos(floating *);
-  floating *hook_FLOAT_tan(floating *);
-  floating *hook_FLOAT_sec(floating *);
-  floating *hook_FLOAT_csc(floating *);
-  floating *hook_FLOAT_cot(floating *);
-  floating *hook_FLOAT_asin(floating *);
-  floating *hook_FLOAT_acos(floating *);
-  floating *hook_FLOAT_atan(floating *);
-  floating *hook_FLOAT_atan2(floating *, floating *);
-  mpz_ptr hook_FLOAT_precision(floating *);
-  mpz_ptr hook_FLOAT_exponentBits(floating *);
-  mpz_ptr hook_FLOAT_exponent(floating *);
-  bool hook_FLOAT_isNaN(floating *);
-  floating *hook_FLOAT_maxValue(mpz_t, mpz_t);
-  floating *hook_FLOAT_minValue(mpz_t, mpz_t);
-  bool hook_FLOAT_gt(floating *, floating *);
-  bool hook_FLOAT_ge(floating *, floating *);
-  bool hook_FLOAT_lt(floating *, floating *);
-  bool hook_FLOAT_le(floating *, floating *);
-  bool hook_FLOAT_eq(floating *, floating *);
-  bool hook_FLOAT_ne(floating *, floating *);
-  floating *hook_FLOAT_abs(floating *);
-  floating *hook_FLOAT_neg(floating *);
-  floating *hook_FLOAT_min(floating *, floating *);
-  floating *hook_FLOAT_max(floating *, floating *);
-  floating *hook_FLOAT_add(floating *, floating *);
-  floating *hook_FLOAT_sub(floating *, floating *);
-  floating *hook_FLOAT_mul(floating *, floating *);
-  floating *hook_FLOAT_div(floating *, floating *);
-  floating *hook_FLOAT_rem(floating *, floating *);
-  floating *hook_FLOAT_pow(floating *, floating *);
-  floating *hook_FLOAT_root(floating *, mpz_t);
-  floating *hook_FLOAT_log(floating *);
-  floating *hook_FLOAT_exp(floating *);
-  floating *hook_FLOAT_rat2float(mpz_t, mpz_t, mpz_t, mpz_t);
-  bool hook_FLOAT_sign(floating *);
+floating *hook_FLOAT_ceil(floating *);
+floating *hook_FLOAT_floor(floating *);
+floating *hook_FLOAT_trunc(floating *);
+floating *hook_FLOAT_round(floating *, mpz_t, mpz_t);
+mpz_ptr hook_FLOAT_float2int(floating *);
+floating *hook_FLOAT_int2float(mpz_t, mpz_t, mpz_t);
+floating *hook_FLOAT_sin(floating *);
+floating *hook_FLOAT_cos(floating *);
+floating *hook_FLOAT_tan(floating *);
+floating *hook_FLOAT_sec(floating *);
+floating *hook_FLOAT_csc(floating *);
+floating *hook_FLOAT_cot(floating *);
+floating *hook_FLOAT_asin(floating *);
+floating *hook_FLOAT_acos(floating *);
+floating *hook_FLOAT_atan(floating *);
+floating *hook_FLOAT_atan2(floating *, floating *);
+mpz_ptr hook_FLOAT_precision(floating *);
+mpz_ptr hook_FLOAT_exponentBits(floating *);
+mpz_ptr hook_FLOAT_exponent(floating *);
+bool hook_FLOAT_isNaN(floating *);
+floating *hook_FLOAT_maxValue(mpz_t, mpz_t);
+floating *hook_FLOAT_minValue(mpz_t, mpz_t);
+bool hook_FLOAT_gt(floating *, floating *);
+bool hook_FLOAT_ge(floating *, floating *);
+bool hook_FLOAT_lt(floating *, floating *);
+bool hook_FLOAT_le(floating *, floating *);
+bool hook_FLOAT_eq(floating *, floating *);
+bool hook_FLOAT_ne(floating *, floating *);
+floating *hook_FLOAT_abs(floating *);
+floating *hook_FLOAT_neg(floating *);
+floating *hook_FLOAT_min(floating *, floating *);
+floating *hook_FLOAT_max(floating *, floating *);
+floating *hook_FLOAT_add(floating *, floating *);
+floating *hook_FLOAT_sub(floating *, floating *);
+floating *hook_FLOAT_mul(floating *, floating *);
+floating *hook_FLOAT_div(floating *, floating *);
+floating *hook_FLOAT_rem(floating *, floating *);
+floating *hook_FLOAT_pow(floating *, floating *);
+floating *hook_FLOAT_root(floating *, mpz_t);
+floating *hook_FLOAT_log(floating *);
+floating *hook_FLOAT_exp(floating *);
+floating *hook_FLOAT_rat2float(mpz_t, mpz_t, mpz_t, mpz_t);
+bool hook_FLOAT_sign(floating *);
 
-  floating *move_float(floating *i) {
-    floating *result = (floating *)malloc(sizeof(floating));
-    *result = *i;
-    return result;
-  }
+floating *move_float(floating *i) {
+  floating *result = (floating *)malloc(sizeof(floating));
+  *result = *i;
+  return result;
+}
 }
 
 static void set_float(floating *a, unsigned prec, unsigned exp, double val) {
@@ -166,9 +166,11 @@ BOOST_AUTO_TEST_CASE(trig) {
   result = hook_FLOAT_tan(a);
   BOOST_CHECK_CLOSE_FRACTION(mpfr_get_d(result->f, MPFR_RNDN), 1.0, e);
   result = hook_FLOAT_sec(a);
-  BOOST_CHECK_CLOSE_FRACTION(mpfr_get_d(result->f, MPFR_RNDN), 1.0/cos(M_PI_4), e);
+  BOOST_CHECK_CLOSE_FRACTION(
+      mpfr_get_d(result->f, MPFR_RNDN), 1.0 / cos(M_PI_4), e);
   result = hook_FLOAT_csc(a);
-  BOOST_CHECK_CLOSE_FRACTION(mpfr_get_d(result->f, MPFR_RNDN), 1.0/sin(M_PI_4), e);
+  BOOST_CHECK_CLOSE_FRACTION(
+      mpfr_get_d(result->f, MPFR_RNDN), 1.0 / sin(M_PI_4), e);
   result = hook_FLOAT_cot(a);
   BOOST_CHECK_CLOSE_FRACTION(mpfr_get_d(result->f, MPFR_RNDN), 1.0, e);
   set_float(a, 53, 11, 0.0);
@@ -225,10 +227,10 @@ BOOST_AUTO_TEST_CASE(exponent) {
   set_float(a, 24, 8, -0.0);
   result = hook_FLOAT_exponent(a);
   BOOST_CHECK_EQUAL(mpz_cmp_si(result, -127), 0);
-  set_float(a, 24, 8, 1.0/0.0);
+  set_float(a, 24, 8, 1.0 / 0.0);
   result = hook_FLOAT_exponent(a);
   BOOST_CHECK_EQUAL(mpz_cmp_si(result, 128), 0);
-  set_float(a, 24, 8, 0.0/0.0);
+  set_float(a, 24, 8, 0.0 / 0.0);
   result = hook_FLOAT_exponent(a);
   BOOST_CHECK_EQUAL(mpz_cmp_si(result, 128), 0);
   set_float(a, 24, 8, 4.0);
@@ -260,11 +262,13 @@ BOOST_AUTO_TEST_CASE(maxValue) {
   mpz_init_set_ui(b, 8);
   floating *result;
   result = hook_FLOAT_maxValue(a, b);
-  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, std::numeric_limits<float>::max()), 0);
+  BOOST_CHECK_EQUAL(
+      mpfr_cmp_d(result->f, std::numeric_limits<float>::max()), 0);
   mpz_init_set_ui(a, 53);
   mpz_init_set_ui(b, 11);
   result = hook_FLOAT_maxValue(a, b);
-  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, std::numeric_limits<double>::max()), 0);
+  BOOST_CHECK_EQUAL(
+      mpfr_cmp_d(result->f, std::numeric_limits<double>::max()), 0);
 }
 
 BOOST_AUTO_TEST_CASE(minValue) {
@@ -273,25 +277,27 @@ BOOST_AUTO_TEST_CASE(minValue) {
   mpz_init_set_ui(b, 8);
   floating *result;
   result = hook_FLOAT_minValue(a, b);
-  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, std::numeric_limits<float>::denorm_min()), 0);
+  BOOST_CHECK_EQUAL(
+      mpfr_cmp_d(result->f, std::numeric_limits<float>::denorm_min()), 0);
   mpz_init_set_ui(a, 53);
   mpz_init_set_ui(b, 11);
   result = hook_FLOAT_minValue(a, b);
-  BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, std::numeric_limits<double>::denorm_min()), 0);
+  BOOST_CHECK_EQUAL(
+      mpfr_cmp_d(result->f, std::numeric_limits<double>::denorm_min()), 0);
 }
 
 BOOST_AUTO_TEST_CASE(lt) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_lt(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_lt(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
       } else if (i < j) {
@@ -301,25 +307,25 @@ BOOST_AUTO_TEST_CASE(lt) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(!hook_FLOAT_lt(arr+i, nan));
-    BOOST_CHECK(!hook_FLOAT_lt(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(!hook_FLOAT_lt(arr + i, nan));
+    BOOST_CHECK(!hook_FLOAT_lt(nan, arr + i));
   }
   BOOST_CHECK(!hook_FLOAT_lt(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(le) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_le(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_le(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
       } else if (i <= j) {
@@ -329,25 +335,25 @@ BOOST_AUTO_TEST_CASE(le) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(!hook_FLOAT_le(arr+i, nan));
-    BOOST_CHECK(!hook_FLOAT_le(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(!hook_FLOAT_le(arr + i, nan));
+    BOOST_CHECK(!hook_FLOAT_le(nan, arr + i));
   }
   BOOST_CHECK(!hook_FLOAT_le(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(gt) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_gt(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_gt(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
       } else if (i > j) {
@@ -357,25 +363,25 @@ BOOST_AUTO_TEST_CASE(gt) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(!hook_FLOAT_gt(arr+i, nan));
-    BOOST_CHECK(!hook_FLOAT_gt(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(!hook_FLOAT_gt(arr + i, nan));
+    BOOST_CHECK(!hook_FLOAT_gt(nan, arr + i));
   }
   BOOST_CHECK(!hook_FLOAT_gt(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(ge) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_ge(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_ge(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
       } else if (i >= j) {
@@ -385,25 +391,25 @@ BOOST_AUTO_TEST_CASE(ge) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(!hook_FLOAT_ge(arr+i, nan));
-    BOOST_CHECK(!hook_FLOAT_ge(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(!hook_FLOAT_ge(arr + i, nan));
+    BOOST_CHECK(!hook_FLOAT_ge(nan, arr + i));
   }
   BOOST_CHECK(!hook_FLOAT_ge(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(eq) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_eq(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_eq(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(result);
       } else if (i == j) {
@@ -413,25 +419,25 @@ BOOST_AUTO_TEST_CASE(eq) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(!hook_FLOAT_eq(arr+i, nan));
-    BOOST_CHECK(!hook_FLOAT_eq(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(!hook_FLOAT_eq(arr + i, nan));
+    BOOST_CHECK(!hook_FLOAT_eq(nan, arr + i));
   }
   BOOST_CHECK(!hook_FLOAT_eq(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(ne) {
   floating arr[6], nan[1];
-  set_float(arr, 24, 8, -1.0/0.0);
-  set_float(arr+1, 24, 8, -1.0);
-  set_float(arr+2, 24, 8, -0.0);
-  set_float(arr+3, 24, 8, 0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, 1.0/0.0);
-  set_float(nan, 24, 8, 0.0/0.0);
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    for (int j = 0; j < sizeof(arr)/sizeof(arr[0]); j++) {
-      bool result = hook_FLOAT_ne(arr+i, arr+j);
+  set_float(arr, 24, 8, -1.0 / 0.0);
+  set_float(arr + 1, 24, 8, -1.0);
+  set_float(arr + 2, 24, 8, -0.0);
+  set_float(arr + 3, 24, 8, 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, 1.0 / 0.0);
+  set_float(nan, 24, 8, 0.0 / 0.0);
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    for (int j = 0; j < sizeof(arr) / sizeof(arr[0]); j++) {
+      bool result = hook_FLOAT_ne(arr + i, arr + j);
       if ((i == 2 && j == 3) || (i == 3 && j == 2)) {
         BOOST_CHECK(!result);
       } else if (i != j) {
@@ -441,38 +447,38 @@ BOOST_AUTO_TEST_CASE(ne) {
       }
     }
   }
-  for (int i = 0; i < sizeof(arr)/sizeof(arr[0]); i++) {
-    BOOST_CHECK(hook_FLOAT_ne(arr+i, nan));
-    BOOST_CHECK(hook_FLOAT_ne(nan, arr+i));
+  for (int i = 0; i < sizeof(arr) / sizeof(arr[0]); i++) {
+    BOOST_CHECK(hook_FLOAT_ne(arr + i, nan));
+    BOOST_CHECK(hook_FLOAT_ne(nan, arr + i));
   }
   BOOST_CHECK(hook_FLOAT_ne(nan, nan));
 }
 
 BOOST_AUTO_TEST_CASE(abs) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    floating *result = hook_FLOAT_abs(arr+i);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    floating *result = hook_FLOAT_abs(arr + i);
     float f = fabsf(ref[i]);
-    if (f!=f) {
+    if (f != f) {
       BOOST_CHECK(mpfr_nan_p(result->f));
     } else {
       BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -482,29 +488,29 @@ BOOST_AUTO_TEST_CASE(abs) {
 
 BOOST_AUTO_TEST_CASE(log) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    floating *result = hook_FLOAT_log(arr+i);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    floating *result = hook_FLOAT_log(arr + i);
     float f = logf(ref[i]);
-    if (f!=f) {
+    if (f != f) {
       BOOST_CHECK(mpfr_nan_p(result->f));
     } else {
       BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -514,29 +520,29 @@ BOOST_AUTO_TEST_CASE(log) {
 
 BOOST_AUTO_TEST_CASE(exp) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    floating *result = hook_FLOAT_exp(arr+i);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    floating *result = hook_FLOAT_exp(arr + i);
     float f = expf(ref[i]);
-    if (f!=f) {
+    if (f != f) {
       BOOST_CHECK(mpfr_nan_p(result->f));
     } else {
       BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -546,29 +552,29 @@ BOOST_AUTO_TEST_CASE(exp) {
 
 BOOST_AUTO_TEST_CASE(neg) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    floating *result = hook_FLOAT_neg(arr+i);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    floating *result = hook_FLOAT_neg(arr + i);
     float f = -ref[i];
-    if (f!=f) {
+    if (f != f) {
       BOOST_CHECK(mpfr_nan_p(result->f));
     } else {
       BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -578,30 +584,30 @@ BOOST_AUTO_TEST_CASE(neg) {
 
 BOOST_AUTO_TEST_CASE(min) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_min(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_min(arr + i, arr + j);
       float f = fminf(ref[i], ref[j]);
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -612,30 +618,30 @@ BOOST_AUTO_TEST_CASE(min) {
 
 BOOST_AUTO_TEST_CASE(max) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_max(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_max(arr + i, arr + j);
       float f = fmaxf(ref[i], ref[j]);
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -646,30 +652,30 @@ BOOST_AUTO_TEST_CASE(max) {
 
 BOOST_AUTO_TEST_CASE(add) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_add(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_add(arr + i, arr + j);
       float f = ref[i] + ref[j];
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -680,30 +686,30 @@ BOOST_AUTO_TEST_CASE(add) {
 
 BOOST_AUTO_TEST_CASE(sub) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_sub(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_sub(arr + i, arr + j);
       float f = ref[i] - ref[j];
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -714,30 +720,30 @@ BOOST_AUTO_TEST_CASE(sub) {
 
 BOOST_AUTO_TEST_CASE(mul) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_mul(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_mul(arr + i, arr + j);
       float f = ref[i] * ref[j];
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -748,30 +754,30 @@ BOOST_AUTO_TEST_CASE(mul) {
 
 BOOST_AUTO_TEST_CASE(div) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_div(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_div(arr + i, arr + j);
       float f = ref[i] / ref[j];
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -782,30 +788,30 @@ BOOST_AUTO_TEST_CASE(div) {
 
 BOOST_AUTO_TEST_CASE(rem) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_rem(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_rem(arr + i, arr + j);
       float f = fmodf(ref[i], ref[j]);
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -816,30 +822,30 @@ BOOST_AUTO_TEST_CASE(rem) {
 
 BOOST_AUTO_TEST_CASE(pow) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    for (int j = 0; j < sizeof(ref)/sizeof(ref[0]); j++) {
-      floating *result = hook_FLOAT_pow(arr+i, arr+j);
+  ref[8] = 0.0f / 0.0f;
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    for (int j = 0; j < sizeof(ref) / sizeof(ref[0]); j++) {
+      floating *result = hook_FLOAT_pow(arr + i, arr + j);
       float f = powf(ref[i], ref[j]);
-      if (f!=f) {
+      if (f != f) {
         BOOST_CHECK(mpfr_nan_p(result->f));
       } else {
         BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -850,31 +856,31 @@ BOOST_AUTO_TEST_CASE(pow) {
 
 BOOST_AUTO_TEST_CASE(root) {
   floating arr[9];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
   float ref[9];
   ref[0] = 0.0f;
   ref[1] = -0.0f;
-  ref[2] = 1.0f/0.0f;
-  ref[3] = -1.0f/0.0f;
+  ref[2] = 1.0f / 0.0f;
+  ref[3] = -1.0f / 0.0f;
   ref[4] = 1.0f;
   ref[5] = -1.0f;
   ref[6] = 3.0f;
   ref[7] = 0.5f;
-  ref[8] = 0.0f/0.0f;
+  ref[8] = 0.0f / 0.0f;
   mpz_t k;
   mpz_init_set_ui(k, 2);
-  for (int i = 0; i < sizeof(ref)/sizeof(ref[0]); i++) {
-    floating *result = hook_FLOAT_root(arr+i, k);
+  for (int i = 0; i < sizeof(ref) / sizeof(ref[0]); i++) {
+    floating *result = hook_FLOAT_root(arr + i, k);
     float f = sqrt(ref[i]);
-    if (f!=f) {
+    if (f != f) {
       BOOST_CHECK(mpfr_nan_p(result->f));
     } else {
       BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, f), 0);
@@ -884,24 +890,24 @@ BOOST_AUTO_TEST_CASE(root) {
 
 BOOST_AUTO_TEST_CASE(sign) {
   floating arr[10];
-  set_float(arr+0, 24, 8, 0.0);
-  set_float(arr+1, 24, 8, -0.0);
-  set_float(arr+2, 24, 8, 1.0/0.0);
-  set_float(arr+3, 24, 8, -1.0/0.0);
-  set_float(arr+4, 24, 8, 1.0);
-  set_float(arr+5, 24, 8, -1.0);
-  set_float(arr+6, 24, 8, 3.0);
-  set_float(arr+7, 24, 8, 0.5);
-  set_float(arr+8, 24, 8, 0.0/0.0);
-  BOOST_CHECK(!hook_FLOAT_sign(arr+0));
-  BOOST_CHECK(hook_FLOAT_sign(arr+1));
-  BOOST_CHECK(!hook_FLOAT_sign(arr+2));
-  BOOST_CHECK(hook_FLOAT_sign(arr+3));
-  BOOST_CHECK(!hook_FLOAT_sign(arr+4));
-  BOOST_CHECK(hook_FLOAT_sign(arr+5));
-  BOOST_CHECK(!hook_FLOAT_sign(arr+6));
-  BOOST_CHECK(!hook_FLOAT_sign(arr+7));
-  BOOST_CHECK(!hook_FLOAT_sign(arr+8));
+  set_float(arr + 0, 24, 8, 0.0);
+  set_float(arr + 1, 24, 8, -0.0);
+  set_float(arr + 2, 24, 8, 1.0 / 0.0);
+  set_float(arr + 3, 24, 8, -1.0 / 0.0);
+  set_float(arr + 4, 24, 8, 1.0);
+  set_float(arr + 5, 24, 8, -1.0);
+  set_float(arr + 6, 24, 8, 3.0);
+  set_float(arr + 7, 24, 8, 0.5);
+  set_float(arr + 8, 24, 8, 0.0 / 0.0);
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 0));
+  BOOST_CHECK(hook_FLOAT_sign(arr + 1));
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 2));
+  BOOST_CHECK(hook_FLOAT_sign(arr + 3));
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 4));
+  BOOST_CHECK(hook_FLOAT_sign(arr + 5));
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 6));
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 7));
+  BOOST_CHECK(!hook_FLOAT_sign(arr + 8));
 }
 
 BOOST_AUTO_TEST_CASE(rat2float) {

--- a/unittests/runtime-arithmetic/inttest.cpp
+++ b/unittests/runtime-arithmetic/inttest.cpp
@@ -4,51 +4,51 @@
 #include "runtime/header.h"
 
 extern "C" {
-  mpz_ptr hook_INT_tmod(mpz_t, mpz_t);
-  mpz_ptr hook_INT_emod(mpz_t, mpz_t);
-  mpz_ptr hook_INT_add(mpz_t, mpz_t);
-  mpz_ptr hook_INT_and(mpz_t, mpz_t);
-  mpz_ptr hook_INT_mul(mpz_t, mpz_t);
-  mpz_ptr hook_INT_sub(mpz_t, mpz_t);
-  mpz_ptr hook_INT_tdiv(mpz_t, mpz_t);
-  mpz_ptr hook_INT_ediv(mpz_t, mpz_t);
-  mpz_ptr hook_INT_shl(mpz_t, mpz_t);
-  mpz_ptr hook_INT_shr(mpz_t, mpz_t);
-  mpz_ptr hook_INT_pow(mpz_t, mpz_t);
-  mpz_ptr hook_INT_xor(mpz_t, mpz_t);
-  mpz_ptr hook_INT_or(mpz_t, mpz_t);
-  mpz_ptr hook_INT_max(mpz_t, mpz_t);
-  mpz_ptr hook_INT_min(mpz_t, mpz_t);
-  mpz_ptr hook_INT_powmod(mpz_t, mpz_t, mpz_t);
-  mpz_ptr hook_INT_bitRange(mpz_t, mpz_t, mpz_t);
-  mpz_ptr hook_INT_signExtendBitRange(mpz_t, mpz_t, mpz_t);
-  mpz_ptr hook_INT_not(mpz_t);
-  mpz_ptr hook_INT_abs(mpz_t);
-  mpz_ptr hook_INT_log2(mpz_t);
-  mpz_ptr hook_INT_rand(mpz_t);
-  bool hook_INT_le(mpz_t, mpz_t);
-  bool hook_INT_lt(mpz_t, mpz_t);
-  bool hook_INT_eq(mpz_t, mpz_t);
-  bool hook_INT_ne(mpz_t, mpz_t);
-  bool hook_INT_ge(mpz_t, mpz_t);
-  bool hook_INT_gt(mpz_t, mpz_t);
-  block *hook_INT_srand(mpz_t);
+mpz_ptr hook_INT_tmod(mpz_t, mpz_t);
+mpz_ptr hook_INT_emod(mpz_t, mpz_t);
+mpz_ptr hook_INT_add(mpz_t, mpz_t);
+mpz_ptr hook_INT_and(mpz_t, mpz_t);
+mpz_ptr hook_INT_mul(mpz_t, mpz_t);
+mpz_ptr hook_INT_sub(mpz_t, mpz_t);
+mpz_ptr hook_INT_tdiv(mpz_t, mpz_t);
+mpz_ptr hook_INT_ediv(mpz_t, mpz_t);
+mpz_ptr hook_INT_shl(mpz_t, mpz_t);
+mpz_ptr hook_INT_shr(mpz_t, mpz_t);
+mpz_ptr hook_INT_pow(mpz_t, mpz_t);
+mpz_ptr hook_INT_xor(mpz_t, mpz_t);
+mpz_ptr hook_INT_or(mpz_t, mpz_t);
+mpz_ptr hook_INT_max(mpz_t, mpz_t);
+mpz_ptr hook_INT_min(mpz_t, mpz_t);
+mpz_ptr hook_INT_powmod(mpz_t, mpz_t, mpz_t);
+mpz_ptr hook_INT_bitRange(mpz_t, mpz_t, mpz_t);
+mpz_ptr hook_INT_signExtendBitRange(mpz_t, mpz_t, mpz_t);
+mpz_ptr hook_INT_not(mpz_t);
+mpz_ptr hook_INT_abs(mpz_t);
+mpz_ptr hook_INT_log2(mpz_t);
+mpz_ptr hook_INT_rand(mpz_t);
+bool hook_INT_le(mpz_t, mpz_t);
+bool hook_INT_lt(mpz_t, mpz_t);
+bool hook_INT_eq(mpz_t, mpz_t);
+bool hook_INT_ne(mpz_t, mpz_t);
+bool hook_INT_ge(mpz_t, mpz_t);
+bool hook_INT_gt(mpz_t, mpz_t);
+block *hook_INT_srand(mpz_t);
 
-  mpz_ptr move_int(mpz_t i) {
-    mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
-    *result = *i;
-    return result;
-  }
-  
-  void add_hash64(void*, uint64_t) {}
+mpz_ptr move_int(mpz_t i) {
+  mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
+  *result = *i;
+  return result;
+}
 
-  uint32_t getTagForSymbolName(const char *) {
-    return 0;
-  }
+void add_hash64(void *, uint64_t) { }
 
-  void *koreAllocAlwaysGC(size_t size) {
-    return malloc(size);
-  }
+uint32_t getTagForSymbolName(const char *) {
+  return 0;
+}
+
+void *koreAllocAlwaysGC(size_t size) {
+  return malloc(size);
+}
 }
 
 BOOST_AUTO_TEST_SUITE(IntTest)
@@ -523,14 +523,24 @@ BOOST_AUTO_TEST_CASE(bitRange) {
   BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
   mpz_clear(result);
   free(result);
-  mpz_set_str(i, "-710567042938717889665411037832208781722350888143921263584927239275773573551204588944105336352942349727184887589413944684473529682801526123805453895275517072855048781056", 10);
+  mpz_set_str(
+      i,
+      "-71056704293871788966541103783220878172235088814392126358492723927577357"
+      "355120458894410533635294234972718488758941394468447352968280152612380545"
+      "3895275517072855048781056",
+      10);
   mpz_set_ui(off, 32);
   mpz_set_ui(len, 8);
   result = hook_INT_bitRange(i, off, len);
   BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 12), 0);
   mpz_clear(result);
   free(result);
-  mpz_set_str(i, "697754608693466068295273213726275558775348389513141500672185545754018175722916164768735179047222610843044264325669307777729891642448846794142000", 10);
+  mpz_set_str(
+      i,
+      "697754608693466068295273213726275558775348389513141500672185545754018175"
+      "72291616476873517904722261084304426432566930777772989164244884679414200"
+      "0",
+      10);
   mpz_set_ui(off, 64);
   mpz_set_ui(len, 8);
   result = hook_INT_bitRange(i, off, len);
@@ -588,10 +598,12 @@ BOOST_AUTO_TEST_CASE(signExtendBitRange) {
   mpz_clear(result);
   free(result);
   mpz_set_si(len, -1);
-  BOOST_CHECK_THROW(hook_INT_signExtendBitRange(i, off, len), std::invalid_argument);
+  BOOST_CHECK_THROW(
+      hook_INT_signExtendBitRange(i, off, len), std::invalid_argument);
   mpz_set_ui(len, 8);
   mpz_set_si(off, -1);
-  BOOST_CHECK_THROW(hook_INT_signExtendBitRange(i, off, len), std::invalid_argument);
+  BOOST_CHECK_THROW(
+      hook_INT_signExtendBitRange(i, off, len), std::invalid_argument);
   mpz_set_ui(off, 1);
   mpz_mul_2exp(off, off, 64);
   result = hook_INT_signExtendBitRange(i, off, len);

--- a/unittests/runtime-collections/lists.cpp
+++ b/unittests/runtime-collections/lists.cpp
@@ -1,286 +1,289 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
+#include <boost/test/unit_test.hpp>
+#include <gmp.h>
 
 #include "runtime/header.h"
 
 extern "C" {
-  list hook_LIST_unit();
-  list hook_LIST_element(block *);
-  list hook_LIST_concat(list *, list *);
-  list hook_LIST_range(list *, mpz_t, mpz_t);
-  list hook_LIST_range_long(list *, size_t, size_t);
-  list hook_LIST_make(mpz_t len, block * value);
-  list hook_LIST_update(list * list, mpz_t index, block * value);
-  list hook_LIST_updateAll(list * l1, mpz_t index, list * l2);
-  list hook_LIST_fill(list * l, mpz_t index, mpz_t len, block * val);
-  mpz_ptr hook_LIST_size(list *);
-  block * hook_LIST_get(list *, mpz_t);
-  bool hook_LIST_in(block *, list *);
-  bool hook_LIST_eq(list *, list *);
+list hook_LIST_unit();
+list hook_LIST_element(block *);
+list hook_LIST_concat(list *, list *);
+list hook_LIST_range(list *, mpz_t, mpz_t);
+list hook_LIST_range_long(list *, size_t, size_t);
+list hook_LIST_make(mpz_t len, block *value);
+list hook_LIST_update(list *list, mpz_t index, block *value);
+list hook_LIST_updateAll(list *l1, mpz_t index, list *l2);
+list hook_LIST_fill(list *l, mpz_t index, mpz_t len, block *val);
+mpz_ptr hook_LIST_size(list *);
+block *hook_LIST_get(list *, mpz_t);
+bool hook_LIST_in(block *, list *);
+bool hook_LIST_eq(list *, list *);
 
-  mpz_ptr move_int(mpz_t i) {
-    mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
-    *result = *i;
-    return result;
-  }
+mpz_ptr move_int(mpz_t i) {
+  mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
+  *result = *i;
+  return result;
+}
 
-  bool during_gc() {
-    return false;
-  }
+bool during_gc() {
+  return false;
+}
 
-  void *koreAllocToken(size_t requested) {
-    return malloc(requested);
-  }
-  const size_t BLOCK_SIZE = -1;
+void *koreAllocToken(size_t requested) {
+  return malloc(requested);
+}
+const size_t BLOCK_SIZE = -1;
 
-  void printConfigurationInternal(writer *file, block *subject, const char *sort, bool) {}
-  void sfprintf(writer *, const char *, ...) {}
+void printConfigurationInternal(
+    writer *file, block *subject, const char *sort, bool) { }
+void sfprintf(writer *, const char *, ...) { }
 
-  bool hook_KEQUAL_eq(block * b1, block * b2) {
-    return b1->h.hdr == b2->h.hdr;
-  }
+bool hook_KEQUAL_eq(block *b1, block *b2) {
+  return b1->h.hdr == b2->h.hdr;
+}
 
-  bool hash_enter(void) {
-    return true;
-  }
+bool hash_enter(void) {
+  return true;
+}
 
-  void hash_exit(void) {}
+void hash_exit(void) { }
 
-  void k_hash(block *, void *) {}
+void k_hash(block *, void *) { }
 
-  block D0 = {{0}};
-  block * DUMMY0 = &D0;
-  block D1 = {{1}};
-  block * DUMMY1 = &D1;
+block D0 = {{0}};
+block *DUMMY0 = &D0;
+block D1 = {{1}};
+block *DUMMY1 = &D1;
 }
 
 BOOST_AUTO_TEST_SUITE(ListTest)
 
-  BOOST_AUTO_TEST_CASE(element) {
-    list list = hook_LIST_element(DUMMY0);
-    mpz_t index;
-    mpz_init_set_ui(index, 0);
-    block * result = hook_LIST_get(&list, index);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+BOOST_AUTO_TEST_CASE(element) {
+  list list = hook_LIST_element(DUMMY0);
+  mpz_t index;
+  mpz_init_set_ui(index, 0);
+  block *result = hook_LIST_get(&list, index);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
 
-    mpz_t index2;
-    mpz_init_set_si(index2, -1);
-    result = hook_LIST_get(&list, index2);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
-  }
+  mpz_t index2;
+  mpz_init_set_si(index2, -1);
+  result = hook_LIST_get(&list, index2);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+}
 
-  BOOST_AUTO_TEST_CASE(unit) {
-    list list = hook_LIST_unit();
-    mpz_ptr result = hook_LIST_size(&list);
-    BOOST_CHECK_EQUAL(0, mpz_cmp_ui(result, 0));
-  }
+BOOST_AUTO_TEST_CASE(unit) {
+  list list = hook_LIST_unit();
+  mpz_ptr result = hook_LIST_size(&list);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_ui(result, 0));
+}
 
-  BOOST_AUTO_TEST_CASE(concat) {
-    list l1 = hook_LIST_element(DUMMY0);
-    list l2 = hook_LIST_element(DUMMY1);
-    list list = hook_LIST_concat(&l1, &l2);
+BOOST_AUTO_TEST_CASE(concat) {
+  list l1 = hook_LIST_element(DUMMY0);
+  list l2 = hook_LIST_element(DUMMY1);
+  list list = hook_LIST_concat(&l1, &l2);
 
-    mpz_t index;
-    mpz_init_set_ui(index, 0);
-    block * result = hook_LIST_get(&list, index);
+  mpz_t index;
+  mpz_init_set_ui(index, 0);
+  block *result = hook_LIST_get(&list, index);
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
 
-    mpz_set_ui(index, 1);
-    result = hook_LIST_get(&list, index);
+  mpz_set_ui(index, 1);
+  result = hook_LIST_get(&list, index);
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
-    mpz_ptr size = hook_LIST_size(&list);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
+  mpz_ptr size = hook_LIST_size(&list);
 
-    BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 2));
-  }
+  BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 2));
+}
 
-  BOOST_AUTO_TEST_CASE(in) {
-    list list = hook_LIST_element(DUMMY0);
-    bool result = hook_LIST_in(DUMMY0, &list);
-    BOOST_CHECK(result == true);
-    result = hook_LIST_in(DUMMY1, &list);
-    BOOST_CHECK(result == false);
-  }
+BOOST_AUTO_TEST_CASE(in) {
+  list list = hook_LIST_element(DUMMY0);
+  bool result = hook_LIST_in(DUMMY0, &list);
+  BOOST_CHECK(result == true);
+  result = hook_LIST_in(DUMMY1, &list);
+  BOOST_CHECK(result == false);
+}
 
-  BOOST_AUTO_TEST_CASE(get_negative) {
-    mpz_t index;
-    mpz_init_set_si(index, -2);
-    list list = hook_LIST_element(DUMMY0);
-    BOOST_CHECK_THROW(hook_LIST_get(&list, index), std::out_of_range);
-  }
+BOOST_AUTO_TEST_CASE(get_negative) {
+  mpz_t index;
+  mpz_init_set_si(index, -2);
+  list list = hook_LIST_element(DUMMY0);
+  BOOST_CHECK_THROW(hook_LIST_get(&list, index), std::out_of_range);
+}
 
-  BOOST_AUTO_TEST_CASE(get_out_of_range) {
-    mpz_t index;
-    mpz_init_set_si(index, 1);
-    list list = hook_LIST_element(DUMMY0);
+BOOST_AUTO_TEST_CASE(get_out_of_range) {
+  mpz_t index;
+  mpz_init_set_si(index, 1);
+  list list = hook_LIST_element(DUMMY0);
 
-    BOOST_CHECK_THROW(hook_LIST_get(&list, index), std::out_of_range);
-  }
+  BOOST_CHECK_THROW(hook_LIST_get(&list, index), std::out_of_range);
+}
 
+BOOST_AUTO_TEST_CASE(get_range_neg_idx) {
+  mpz_t neg, zero;
+  mpz_init_set_si(neg, -1);
+  mpz_init_set_si(zero, 0);
+  list list = hook_LIST_element(DUMMY0);
 
-  BOOST_AUTO_TEST_CASE(get_range_neg_idx) {
-    mpz_t neg, zero;
-    mpz_init_set_si(neg, -1);
-    mpz_init_set_si(zero, 0);
-    list list = hook_LIST_element(DUMMY0);
+  BOOST_CHECK_THROW(hook_LIST_range(&list, neg, zero), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_range(&list, neg, zero), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(range_neg_len) {
+  mpz_t neg, zero;
+  mpz_init_set_si(neg, -1);
+  mpz_init_set_si(zero, 0);
+  list list = hook_LIST_element(DUMMY0);
 
-  BOOST_AUTO_TEST_CASE(range_neg_len) {
-    mpz_t neg, zero;
-    mpz_init_set_si(neg, -1);
-    mpz_init_set_si(zero, 0);
-    list list = hook_LIST_element(DUMMY0);
+  BOOST_CHECK_THROW(hook_LIST_range(&list, zero, neg), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_range(&list, zero, neg), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(range) {
+  mpz_t zero, one;
+  mpz_init_set_ui(zero, 0);
+  mpz_init_set_ui(one, 1);
 
-  BOOST_AUTO_TEST_CASE(range) {
-    mpz_t zero, one;
-    mpz_init_set_ui(zero, 0);
-    mpz_init_set_ui(one, 1);
+  list l = hook_LIST_element(DUMMY0);
+  list result = hook_LIST_range(&l, zero, one);
 
-    list l = hook_LIST_element(DUMMY0);
-    list result = hook_LIST_range(&l, zero, one);
+  mpz_ptr size = hook_LIST_size(&result);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 0));
 
-    mpz_ptr size = hook_LIST_size(&result);
-    BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 0));
+  l = hook_LIST_concat(&l, &l);
+  result = hook_LIST_range(&l, one, zero);
 
-    l = hook_LIST_concat(&l, &l);
-    result = hook_LIST_range(&l, one, zero);
+  size = hook_LIST_size(&result);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 1));
+}
 
-    size = hook_LIST_size(&result);
-    BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 1));
-  }
+BOOST_AUTO_TEST_CASE(make_out_of_range) {
+  mpz_t neg;
+  mpz_init_set_si(neg, -1);
+  BOOST_CHECK_THROW(hook_LIST_make(neg, DUMMY0), std::invalid_argument);
+}
 
-  BOOST_AUTO_TEST_CASE(make_out_of_range) {
-    mpz_t neg;
-    mpz_init_set_si(neg, -1);
-    BOOST_CHECK_THROW(hook_LIST_make(neg, DUMMY0), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(make) {
+  mpz_t zero, ten;
+  mpz_init_set_ui(zero, 0);
+  mpz_init_set_ui(ten, 10);
+  list l = hook_LIST_make(ten, DUMMY0);
+  block *result = hook_LIST_get(&l, zero);
 
-  BOOST_AUTO_TEST_CASE(make) {
-    mpz_t zero, ten;
-    mpz_init_set_ui(zero, 0);
-    mpz_init_set_ui(ten, 10);
-    list l = hook_LIST_make(ten, DUMMY0);
-    block * result = hook_LIST_get(&l, zero);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+  mpz_ptr size = hook_LIST_size(&l);
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
-    mpz_ptr size = hook_LIST_size(&l);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 10));
+}
 
-    BOOST_CHECK_EQUAL(0, mpz_cmp_ui(size, 10));
-  }
+BOOST_AUTO_TEST_CASE(update_neg) {
+  list list = hook_LIST_element(DUMMY0);
+  mpz_t neg;
+  mpz_init_set_si(neg, -1);
 
-  BOOST_AUTO_TEST_CASE(update_neg) {
-    list list = hook_LIST_element(DUMMY0);
-    mpz_t neg;
-    mpz_init_set_si(neg, -1);
+  BOOST_CHECK_THROW(
+      hook_LIST_update(&list, neg, DUMMY1), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_update(&list, neg, DUMMY1), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(update_out_of_range) {
+  list list = hook_LIST_element(DUMMY0);
+  mpz_t one;
+  mpz_init_set_ui(one, 1);
 
-  BOOST_AUTO_TEST_CASE(update_out_of_range) {
-    list list = hook_LIST_element(DUMMY0);
-    mpz_t one;
-    mpz_init_set_ui(one, 1);
+  BOOST_CHECK_THROW(
+      hook_LIST_update(&list, one, DUMMY1), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_update(&list, one, DUMMY1), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(update) {
+  list list = hook_LIST_element(DUMMY0);
+  mpz_t index;
+  mpz_init_set_ui(index, 0);
+  list = hook_LIST_update(&list, index, DUMMY1);
+  block *result = hook_LIST_get(&list, index);
 
-  BOOST_AUTO_TEST_CASE(update) {
-    list list = hook_LIST_element(DUMMY0);
-    mpz_t index;
-    mpz_init_set_ui(index, 0);
-    list = hook_LIST_update(&list, index, DUMMY1);
-    block * result = hook_LIST_get(&list, index);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
+}
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
-  }
+BOOST_AUTO_TEST_CASE(update_all_neg) {
+  mpz_t neg;
+  mpz_init_set_si(neg, -1);
+  list l1 = hook_LIST_element(DUMMY0);
+  list l2 = hook_LIST_unit();
 
-  BOOST_AUTO_TEST_CASE(update_all_neg) {
-    mpz_t neg;
-    mpz_init_set_si(neg, -1);
-    list l1 = hook_LIST_element(DUMMY0);
-    list l2 = hook_LIST_unit();
+  BOOST_CHECK_THROW(hook_LIST_updateAll(&l1, neg, &l2), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_updateAll(&l1, neg, &l2), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(update_all) {
+  mpz_t zero, one;
+  mpz_init_set_ui(zero, 0);
+  mpz_init_set_ui(one, 1);
+  list l1 = hook_LIST_element(DUMMY0);
+  list l2 = hook_LIST_unit();
+  list list = hook_LIST_updateAll(&l1, one, &l2);
+  block *result = hook_LIST_get(&list, zero);
 
-  BOOST_AUTO_TEST_CASE(update_all) {
-    mpz_t zero, one;
-    mpz_init_set_ui(zero, 0);
-    mpz_init_set_ui(one, 1);
-    list l1 = hook_LIST_element(DUMMY0);
-    list l2 = hook_LIST_unit();
-    list list = hook_LIST_updateAll(&l1, one, &l2);
-    block * result = hook_LIST_get(&list, zero);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+  list = hook_LIST_updateAll(&l1, zero, &l2);
+  result = hook_LIST_get(&list, zero);
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
-    list = hook_LIST_updateAll(&l1, zero, &l2);
-    result = hook_LIST_get(&list, zero);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+  l2 = hook_LIST_element(DUMMY1);
+  list = hook_LIST_updateAll(&l1, zero, &l2);
+  result = hook_LIST_get(&list, zero);
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
-    l2 = hook_LIST_element(DUMMY1);
-    list = hook_LIST_updateAll(&l1, zero, &l2);
-    result = hook_LIST_get(&list, zero);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
+}
 
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
-  }
+BOOST_AUTO_TEST_CASE(update_all_out_of_range) {
+  mpz_t one;
+  mpz_init_set_ui(one, 1);
+  list l1 = hook_LIST_element(DUMMY0);
+  list l2 = hook_LIST_element(DUMMY1);
 
-  BOOST_AUTO_TEST_CASE(update_all_out_of_range) {
-    mpz_t one;
-    mpz_init_set_ui(one, 1);
-    list l1 = hook_LIST_element(DUMMY0);
-    list l2 = hook_LIST_element(DUMMY1);
+  BOOST_CHECK_THROW(hook_LIST_updateAll(&l1, one, &l2), std::invalid_argument);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_updateAll(&l1, one, &l2), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(fill_out_of_range) {
+  list list = hook_LIST_unit();
+  mpz_t index, len;
+  mpz_init_set_ui(index, 1);
+  mpz_init_set_ui(len, 2);
 
-  BOOST_AUTO_TEST_CASE(fill_out_of_range) {
-    list list = hook_LIST_unit();
-    mpz_t index, len;
-    mpz_init_set_ui(index, 1);
-    mpz_init_set_ui(len, 2);
+  BOOST_CHECK_THROW(
+      hook_LIST_fill(&list, index, len, DUMMY0), std::out_of_range);
+}
 
-    BOOST_CHECK_THROW(hook_LIST_fill(&list, index, len, DUMMY0), std::out_of_range);
-  }
+BOOST_AUTO_TEST_CASE(fill) {
+  mpz_t zero, one, two, three, four;
+  mpz_init_set_ui(zero, 0);
+  mpz_init_set_ui(one, 1);
+  mpz_init_set_ui(two, 2);
+  mpz_init_set_ui(three, 3);
+  mpz_init_set_ui(four, 4);
 
-  BOOST_AUTO_TEST_CASE(fill) {
-    mpz_t zero, one, two, three, four;
-    mpz_init_set_ui(zero, 0);
-    mpz_init_set_ui(one, 1);
-    mpz_init_set_ui(two, 2);
-    mpz_init_set_ui(three, 3);
-    mpz_init_set_ui(four, 4);
+  list l1 = hook_LIST_make(four, DUMMY0);
+  list l2 = hook_LIST_fill(&l1, one, two, DUMMY1);
 
-    list l1 = hook_LIST_make(four, DUMMY0);
-    list l2 = hook_LIST_fill(&l1, one, two, DUMMY1);
+  block *result = hook_LIST_get(&l2, zero);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
 
-    block * result = hook_LIST_get(&l2, zero);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+  result = hook_LIST_get(&l2, one);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
 
-    result = hook_LIST_get(&l2, one);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
+  result = hook_LIST_get(&l2, two);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
 
-    result = hook_LIST_get(&l2, two);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY1));
+  result = hook_LIST_get(&l2, three);
+  BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
+}
 
-    result = hook_LIST_get(&l2, three);
-    BOOST_CHECK_EQUAL(true, hook_KEQUAL_eq(result, DUMMY0));
-  }
+BOOST_AUTO_TEST_CASE(eq) {
+  list l1 = hook_LIST_element(DUMMY0);
+  list l2 = hook_LIST_unit();
+  bool result = hook_LIST_eq(&l1, &l2);
 
-  BOOST_AUTO_TEST_CASE(eq) {
-    list l1 = hook_LIST_element(DUMMY0);
-    list l2 = hook_LIST_unit();
-    bool result = hook_LIST_eq(&l1, &l2);
+  BOOST_CHECK(!result);
 
-    BOOST_CHECK(!result);
-
-    l2 = hook_LIST_element(DUMMY0);
-    result = hook_LIST_eq(&l1, &l2);
-    BOOST_CHECK(result);
-  }
+  l2 = hook_LIST_element(DUMMY0);
+  result = hook_LIST_eq(&l1, &l2);
+  BOOST_CHECK(result);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/runtime-collections/maps.cpp
+++ b/unittests/runtime-collections/maps.cpp
@@ -1,178 +1,178 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
+#include <boost/test/unit_test.hpp>
+#include <gmp.h>
 
 #include "runtime/header.h"
 
 extern "C" {
-  map hook_MAP_element(block *key, block *value);
-  map hook_MAP_concat(map *m1, map *m2);
-  map hook_MAP_unit(void);
-  block *hook_MAP_lookup(map *m, block *key);
-  block *hook_MAP_lookupOrDefault(map *m, block *key, block *_default);
-  map hook_MAP_update(map *m, block *key, block *value);
-  map hook_MAP_remove(map *m, block *key);
-  map hook_MAP_difference(map *m1, map *m2);
-  set hook_MAP_keys(map *m);
-  list hook_MAP_keys_list(map *m);
-  bool hook_MAP_in_keys(block *key, map *m);
-  list hook_MAP_values(map *m);
-  block *hook_MAP_choice(map *m);
-  size_t hook_MAP_size_long(map *m);
-  mpz_ptr hook_MAP_size(map *m);
-  bool hook_MAP_inclusion(map *m1, map *m2);
-  map hook_MAP_updateAll(map *m1, map *m2);
-  map hook_MAP_removeAll(map *map, set *set);
-  bool hook_MAP_eq(map *m1, map *m2);
+map hook_MAP_element(block *key, block *value);
+map hook_MAP_concat(map *m1, map *m2);
+map hook_MAP_unit(void);
+block *hook_MAP_lookup(map *m, block *key);
+block *hook_MAP_lookupOrDefault(map *m, block *key, block *_default);
+map hook_MAP_update(map *m, block *key, block *value);
+map hook_MAP_remove(map *m, block *key);
+map hook_MAP_difference(map *m1, map *m2);
+set hook_MAP_keys(map *m);
+list hook_MAP_keys_list(map *m);
+bool hook_MAP_in_keys(block *key, map *m);
+list hook_MAP_values(map *m);
+block *hook_MAP_choice(map *m);
+size_t hook_MAP_size_long(map *m);
+mpz_ptr hook_MAP_size(map *m);
+bool hook_MAP_inclusion(map *m1, map *m2);
+map hook_MAP_updateAll(map *m1, map *m2);
+map hook_MAP_removeAll(map *map, set *set);
+bool hook_MAP_eq(map *m1, map *m2);
 
-  bool hook_SET_in(block *, set *);
-  set hook_SET_element(block *);
-  block *hook_LIST_get_long(list *, size_t);
-  extern block *DUMMY0;
-  extern block *DUMMY1;
-  block D2 = {{1}};
-  block * DUMMY2 = &D2;
+bool hook_SET_in(block *, set *);
+set hook_SET_element(block *);
+block *hook_LIST_get_long(list *, size_t);
+extern block *DUMMY0;
+extern block *DUMMY1;
+block D2 = {{1}};
+block *DUMMY2 = &D2;
 
-  size_t hash_k(block * kitem) {
-    return (size_t) kitem;
-  }
+size_t hash_k(block *kitem) {
+  return (size_t)kitem;
+}
 }
 
 BOOST_AUTO_TEST_SUITE(MapTest)
 
-  BOOST_AUTO_TEST_CASE(element) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto result = hook_MAP_choice(&map);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-    result = hook_MAP_lookup(&map, DUMMY0);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-  }
+BOOST_AUTO_TEST_CASE(element) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto result = hook_MAP_choice(&map);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+  result = hook_MAP_lookup(&map, DUMMY0);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+}
 
-  BOOST_AUTO_TEST_CASE(unit) {
-    auto map = hook_MAP_unit();
-    auto result = hook_MAP_size_long(&map);
-    BOOST_CHECK_EQUAL(result, 0);
-  }
+BOOST_AUTO_TEST_CASE(unit) {
+  auto map = hook_MAP_unit();
+  auto result = hook_MAP_size_long(&map);
+  BOOST_CHECK_EQUAL(result, 0);
+}
 
-  BOOST_AUTO_TEST_CASE(concat_success) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY1);
-    auto m2 = hook_MAP_element(DUMMY1, DUMMY2);
-    auto map = hook_MAP_concat(&m1, &m2);
-    auto result = hook_MAP_size_long(&map);
-    BOOST_CHECK_EQUAL(result, 2);
-  }
+BOOST_AUTO_TEST_CASE(concat_success) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY1);
+  auto m2 = hook_MAP_element(DUMMY1, DUMMY2);
+  auto map = hook_MAP_concat(&m1, &m2);
+  auto result = hook_MAP_size_long(&map);
+  BOOST_CHECK_EQUAL(result, 2);
+}
 
-  BOOST_AUTO_TEST_CASE(concat_failure) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY1);
-    auto m2 = hook_MAP_element(DUMMY0, DUMMY2);
-    BOOST_CHECK_THROW(hook_MAP_concat(&m1, &m2), std::invalid_argument);
-  }
+BOOST_AUTO_TEST_CASE(concat_failure) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY1);
+  auto m2 = hook_MAP_element(DUMMY0, DUMMY2);
+  BOOST_CHECK_THROW(hook_MAP_concat(&m1, &m2), std::invalid_argument);
+}
 
-  BOOST_AUTO_TEST_CASE(lookup_or_default) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto result = hook_MAP_lookupOrDefault(&map, DUMMY0, DUMMY1);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-    result = hook_MAP_lookupOrDefault(&map, DUMMY1, DUMMY1);
-    BOOST_CHECK_EQUAL(result, DUMMY1);
-  }
+BOOST_AUTO_TEST_CASE(lookup_or_default) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto result = hook_MAP_lookupOrDefault(&map, DUMMY0, DUMMY1);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+  result = hook_MAP_lookupOrDefault(&map, DUMMY1, DUMMY1);
+  BOOST_CHECK_EQUAL(result, DUMMY1);
+}
 
-  BOOST_AUTO_TEST_CASE(update) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto result = hook_MAP_lookup(&map, DUMMY0);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-    auto map2 = hook_MAP_update(&map, DUMMY0, DUMMY1);
-    result = hook_MAP_lookup(&map, DUMMY0);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-    result = hook_MAP_lookup(&map2, DUMMY0);
-    BOOST_CHECK_EQUAL(result, DUMMY1);
-  }
+BOOST_AUTO_TEST_CASE(update) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto result = hook_MAP_lookup(&map, DUMMY0);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+  auto map2 = hook_MAP_update(&map, DUMMY0, DUMMY1);
+  result = hook_MAP_lookup(&map, DUMMY0);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+  result = hook_MAP_lookup(&map2, DUMMY0);
+  BOOST_CHECK_EQUAL(result, DUMMY1);
+}
 
-  BOOST_AUTO_TEST_CASE(remove) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto map2 = hook_MAP_remove(&map, DUMMY0);
-    auto result = hook_MAP_size(&map);
-    BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 1), 0);
-    result = hook_MAP_size(&map2);
-    BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
-  }
+BOOST_AUTO_TEST_CASE(remove) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto map2 = hook_MAP_remove(&map, DUMMY0);
+  auto result = hook_MAP_size(&map);
+  BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 1), 0);
+  result = hook_MAP_size(&map2);
+  BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(difference) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto m2 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto map = hook_MAP_difference(&m1, &m2);
-    auto result = hook_MAP_size(&map);
-    BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
-    m2 = hook_MAP_update(&m2, DUMMY0, DUMMY1);
-    map = hook_MAP_difference(&m1, &m2);
-    result = hook_MAP_size(&map);
-    BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 1), 0);
-  }
+BOOST_AUTO_TEST_CASE(difference) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto m2 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto map = hook_MAP_difference(&m1, &m2);
+  auto result = hook_MAP_size(&map);
+  BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
+  m2 = hook_MAP_update(&m2, DUMMY0, DUMMY1);
+  map = hook_MAP_difference(&m1, &m2);
+  result = hook_MAP_size(&map);
+  BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 1), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(keys) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto set = hook_MAP_keys(&map);
-    BOOST_CHECK(hook_SET_in(DUMMY0, &set));
-  }
+BOOST_AUTO_TEST_CASE(keys) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto set = hook_MAP_keys(&map);
+  BOOST_CHECK(hook_SET_in(DUMMY0, &set));
+}
 
-  BOOST_AUTO_TEST_CASE(keys_list) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto list = hook_MAP_keys_list(&map);
-    BOOST_CHECK_EQUAL(hook_LIST_get_long(&list, 0), DUMMY0);
-  }
+BOOST_AUTO_TEST_CASE(keys_list) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto list = hook_MAP_keys_list(&map);
+  BOOST_CHECK_EQUAL(hook_LIST_get_long(&list, 0), DUMMY0);
+}
 
-  BOOST_AUTO_TEST_CASE(in_keys) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto result = hook_MAP_in_keys(DUMMY0, &map);
-    BOOST_CHECK(result);
-    result = hook_MAP_in_keys(DUMMY1, &map);
-    BOOST_CHECK(!result);
-  }
+BOOST_AUTO_TEST_CASE(in_keys) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto result = hook_MAP_in_keys(DUMMY0, &map);
+  BOOST_CHECK(result);
+  result = hook_MAP_in_keys(DUMMY1, &map);
+  BOOST_CHECK(!result);
+}
 
-  BOOST_AUTO_TEST_CASE(values) {
-    auto map = hook_MAP_element(DUMMY0, DUMMY0);
-    auto list = hook_MAP_values(&map);
-    BOOST_CHECK_EQUAL(hook_LIST_get_long(&list, 0), DUMMY0);
-  }
+BOOST_AUTO_TEST_CASE(values) {
+  auto map = hook_MAP_element(DUMMY0, DUMMY0);
+  auto list = hook_MAP_values(&map);
+  BOOST_CHECK_EQUAL(hook_LIST_get_long(&list, 0), DUMMY0);
+}
 
-  BOOST_AUTO_TEST_CASE(inclusion) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
-    auto result = hook_MAP_inclusion(&m1, &m2);
-    BOOST_CHECK(!result);
-    m2 = hook_MAP_update(&m2, DUMMY0, DUMMY0);
-    result = hook_MAP_inclusion(&m1, &m2);
-    BOOST_CHECK(result);
-    m2 = hook_MAP_element(DUMMY0, DUMMY1);
-    result = hook_MAP_inclusion(&m1, &m2);
-    BOOST_CHECK(!result);
-  }
+BOOST_AUTO_TEST_CASE(inclusion) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
+  auto result = hook_MAP_inclusion(&m1, &m2);
+  BOOST_CHECK(!result);
+  m2 = hook_MAP_update(&m2, DUMMY0, DUMMY0);
+  result = hook_MAP_inclusion(&m1, &m2);
+  BOOST_CHECK(result);
+  m2 = hook_MAP_element(DUMMY0, DUMMY1);
+  result = hook_MAP_inclusion(&m1, &m2);
+  BOOST_CHECK(!result);
+}
 
-  BOOST_AUTO_TEST_CASE(update_all) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
-    m2 = hook_MAP_update(&m2, DUMMY0, DUMMY1);
-    auto map = hook_MAP_updateAll(&m1, &m2);
-    auto result = hook_MAP_lookup(&map, DUMMY0);
-    BOOST_CHECK_EQUAL(result, DUMMY1);
-    result = hook_MAP_lookup(&map, DUMMY1);
-    BOOST_CHECK_EQUAL(result, DUMMY1);
-  }
+BOOST_AUTO_TEST_CASE(update_all) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
+  m2 = hook_MAP_update(&m2, DUMMY0, DUMMY1);
+  auto map = hook_MAP_updateAll(&m1, &m2);
+  auto result = hook_MAP_lookup(&map, DUMMY0);
+  BOOST_CHECK_EQUAL(result, DUMMY1);
+  result = hook_MAP_lookup(&map, DUMMY1);
+  BOOST_CHECK_EQUAL(result, DUMMY1);
+}
 
-  BOOST_AUTO_TEST_CASE(remove_all) {
-    auto set = hook_SET_element(DUMMY0);
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto m2 = hook_MAP_removeAll(&m1, &set);
-    auto result = hook_MAP_size(&m2);
-    BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
-  }
+BOOST_AUTO_TEST_CASE(remove_all) {
+  auto set = hook_SET_element(DUMMY0);
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto m2 = hook_MAP_removeAll(&m1, &set);
+  auto result = hook_MAP_size(&m2);
+  BOOST_CHECK_EQUAL(mpz_cmp_ui(result, 0), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(eq) {
-    auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
-    auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
-    auto result = hook_MAP_eq(&m1, &m2);
-    BOOST_CHECK(!result);
-    m2 = hook_MAP_element(DUMMY0, DUMMY0);
-    result = hook_MAP_eq(&m1, &m2);
-    BOOST_CHECK(result);
-  }
+BOOST_AUTO_TEST_CASE(eq) {
+  auto m1 = hook_MAP_element(DUMMY0, DUMMY0);
+  auto m2 = hook_MAP_element(DUMMY1, DUMMY1);
+  auto result = hook_MAP_eq(&m1, &m2);
+  BOOST_CHECK(!result);
+  m2 = hook_MAP_element(DUMMY0, DUMMY0);
+  result = hook_MAP_eq(&m1, &m2);
+  BOOST_CHECK(result);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/runtime-collections/sets.cpp
+++ b/unittests/runtime-collections/sets.cpp
@@ -1,124 +1,124 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
+#include <boost/test/unit_test.hpp>
+#include <gmp.h>
 
 #include "runtime/header.h"
 
 extern "C" {
-  set hook_SET_element(block *elem);
-  set hook_SET_unit(void);
-  bool hook_SET_in(block *elem, set *set);
-  set hook_SET_concat(set *s1, set *s2);
-  set hook_SET_difference(set *s1, set *s2);
-  set hook_SET_remove(set *s, block *elem);
-  bool hook_SET_inclusion(set *s1, set *s2);
-  set hook_SET_intersection(set *s1, set *s2);
-  block *hook_SET_choice(set *s);
-  mpz_ptr hook_SET_size(set *s);
-  list hook_SET_set2list(set *s);
-  set hook_SET_list2set(list *l);
-  bool hook_SET_eq(set *s1, set *s2);
+set hook_SET_element(block *elem);
+set hook_SET_unit(void);
+bool hook_SET_in(block *elem, set *set);
+set hook_SET_concat(set *s1, set *s2);
+set hook_SET_difference(set *s1, set *s2);
+set hook_SET_remove(set *s, block *elem);
+bool hook_SET_inclusion(set *s1, set *s2);
+set hook_SET_intersection(set *s1, set *s2);
+block *hook_SET_choice(set *s);
+mpz_ptr hook_SET_size(set *s);
+list hook_SET_set2list(set *s);
+set hook_SET_list2set(list *l);
+bool hook_SET_eq(set *s1, set *s2);
 
-  extern block *DUMMY0, *DUMMY1, *DUMMY2;
+extern block *DUMMY0, *DUMMY1, *DUMMY2;
 }
 
 BOOST_AUTO_TEST_SUITE(SetTest)
 
-  BOOST_AUTO_TEST_CASE(element) {
-    auto set = hook_SET_element(DUMMY0);
-    auto result = hook_SET_choice(&set);
-    BOOST_CHECK_EQUAL(result, DUMMY0);
-    auto contains = hook_SET_in(DUMMY0, &set);
-    BOOST_CHECK(contains);
-  }
+BOOST_AUTO_TEST_CASE(element) {
+  auto set = hook_SET_element(DUMMY0);
+  auto result = hook_SET_choice(&set);
+  BOOST_CHECK_EQUAL(result, DUMMY0);
+  auto contains = hook_SET_in(DUMMY0, &set);
+  BOOST_CHECK(contains);
+}
 
-  BOOST_AUTO_TEST_CASE(unit) {
-    auto set = hook_SET_unit();
-    auto result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
-  }
+BOOST_AUTO_TEST_CASE(unit) {
+  auto set = hook_SET_unit();
+  auto result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(concat) {
-    auto s1 = hook_SET_element(DUMMY0);
-    auto s2 = hook_SET_element(DUMMY1);
-    auto set = hook_SET_concat(&s1, &s2);
-    auto result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 2), 0);
-  }
+BOOST_AUTO_TEST_CASE(concat) {
+  auto s1 = hook_SET_element(DUMMY0);
+  auto s2 = hook_SET_element(DUMMY1);
+  auto set = hook_SET_concat(&s1, &s2);
+  auto result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 2), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(difference) {
-    auto s1 = hook_SET_element(DUMMY0);
-    auto s2 = hook_SET_element(DUMMY0);
-    auto s3 = hook_SET_element(DUMMY1);
-    auto set = hook_SET_difference(&s1, &s2);
-    auto result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
-    s1 = hook_SET_concat(&s1, &s3);
-    set = hook_SET_difference(&s1, &s3);
-    result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
-  }
+BOOST_AUTO_TEST_CASE(difference) {
+  auto s1 = hook_SET_element(DUMMY0);
+  auto s2 = hook_SET_element(DUMMY0);
+  auto s3 = hook_SET_element(DUMMY1);
+  auto set = hook_SET_difference(&s1, &s2);
+  auto result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
+  s1 = hook_SET_concat(&s1, &s3);
+  set = hook_SET_difference(&s1, &s3);
+  result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(inclusion) {
-    auto s1 = hook_SET_element(DUMMY0);
-    auto s2 = hook_SET_element(DUMMY1);
-    auto result = hook_SET_inclusion(&s1, &s2);
-    BOOST_CHECK(!result);
-    s2 = hook_SET_concat(&s2, &s1);
-    result = hook_SET_inclusion(&s1, &s2);
-    BOOST_CHECK(result);
-  }
+BOOST_AUTO_TEST_CASE(inclusion) {
+  auto s1 = hook_SET_element(DUMMY0);
+  auto s2 = hook_SET_element(DUMMY1);
+  auto result = hook_SET_inclusion(&s1, &s2);
+  BOOST_CHECK(!result);
+  s2 = hook_SET_concat(&s2, &s1);
+  result = hook_SET_inclusion(&s1, &s2);
+  BOOST_CHECK(result);
+}
 
-  BOOST_AUTO_TEST_CASE(intersection) {
-    auto s1 = hook_SET_element(DUMMY0);
-    auto s2 = hook_SET_element(DUMMY1);
-    auto s3 = hook_SET_element(DUMMY2);
-    s3 = hook_SET_concat(&s3, &s1);
-    auto set = hook_SET_intersection(&s1, &s2);
-    auto result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
-    s1 = hook_SET_concat(&s1, &s2);
-    set = hook_SET_intersection(&s1, &s3);
-    result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
-    set = hook_SET_intersection(&s3, &s1);
-    result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
-    set = hook_SET_intersection(&s2, &s2);
-    result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
-  }
+BOOST_AUTO_TEST_CASE(intersection) {
+  auto s1 = hook_SET_element(DUMMY0);
+  auto s2 = hook_SET_element(DUMMY1);
+  auto s3 = hook_SET_element(DUMMY2);
+  s3 = hook_SET_concat(&s3, &s1);
+  auto set = hook_SET_intersection(&s1, &s2);
+  auto result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 0), 0);
+  s1 = hook_SET_concat(&s1, &s2);
+  set = hook_SET_intersection(&s1, &s3);
+  result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
+  set = hook_SET_intersection(&s3, &s1);
+  result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
+  set = hook_SET_intersection(&s2, &s2);
+  result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 1), 0);
+}
 
-  BOOST_AUTO_TEST_CASE(set2list) {
-    auto set = hook_SET_element(DUMMY0);
-    auto set2 = hook_SET_element(DUMMY1);
-    set = hook_SET_concat(&set, &set2);
-    set2 = hook_SET_element(DUMMY2);
-    set = hook_SET_concat(&set, &set2);
-    auto list = hook_SET_set2list(&set);
-    BOOST_CHECK_EQUAL(list.size(), 3);
-  }
+BOOST_AUTO_TEST_CASE(set2list) {
+  auto set = hook_SET_element(DUMMY0);
+  auto set2 = hook_SET_element(DUMMY1);
+  set = hook_SET_concat(&set, &set2);
+  set2 = hook_SET_element(DUMMY2);
+  set = hook_SET_concat(&set, &set2);
+  auto list = hook_SET_set2list(&set);
+  BOOST_CHECK_EQUAL(list.size(), 3);
+}
 
-  BOOST_AUTO_TEST_CASE(list2set) {
-    auto l = list{DUMMY0, DUMMY1, DUMMY2};
-    auto set = hook_SET_list2set(&l);
-    auto result = hook_SET_size(&set);
-    BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 3), 0);
-    auto contains = hook_SET_in(DUMMY0, &set);
-    BOOST_CHECK(contains);
-    contains = hook_SET_in(DUMMY1, &set);
-    BOOST_CHECK(contains);
-    contains = hook_SET_in(DUMMY2, &set);
-    BOOST_CHECK(contains);
-  }
+BOOST_AUTO_TEST_CASE(list2set) {
+  auto l = list{DUMMY0, DUMMY1, DUMMY2};
+  auto set = hook_SET_list2set(&l);
+  auto result = hook_SET_size(&set);
+  BOOST_CHECK_EQUAL(__gmpz_cmp_ui(result, 3), 0);
+  auto contains = hook_SET_in(DUMMY0, &set);
+  BOOST_CHECK(contains);
+  contains = hook_SET_in(DUMMY1, &set);
+  BOOST_CHECK(contains);
+  contains = hook_SET_in(DUMMY2, &set);
+  BOOST_CHECK(contains);
+}
 
-  BOOST_AUTO_TEST_CASE(eq) {
-    auto set = hook_SET_element(DUMMY0);
-    auto set2 = hook_SET_element(DUMMY1);
-    auto result = hook_SET_eq(&set, &set2);
-    BOOST_CHECK(!result);
-    set2 = hook_SET_element(DUMMY0);
-    result = hook_SET_eq(&set, &set2);
-    BOOST_CHECK(result);
-  }
+BOOST_AUTO_TEST_CASE(eq) {
+  auto set = hook_SET_element(DUMMY0);
+  auto set2 = hook_SET_element(DUMMY1);
+  auto result = hook_SET_eq(&set, &set2);
+  BOOST_CHECK(!result);
+  set2 = hook_SET_element(DUMMY0);
+  result = hook_SET_eq(&set, &set2);
+  BOOST_CHECK(result);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -1,119 +1,125 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
-#include<mpfr.h>
-#include<cstdint>
-#include<cstdio>
-#include<cstdlib>
-#include<cstring>
-#include<vector>
-#include<dlfcn.h>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <gmp.h>
+#include <mpfr.h>
+#include <vector>
 
-#include "runtime/header.h"
 #include "runtime/alloc.h"
+#include "runtime/header.h"
 
 #define KCHAR char
 #define TYPETAG(type) "Lbl'Hash'ffi'Unds'" #type "{}"
 extern "C" {
 
-  struct point {
-    int x;
-    int y;
-  };
+struct point {
+  int x;
+  int y;
+};
 
-  struct point2 {
-    struct point p;
-  };
+struct point2 {
+  struct point p;
+};
 
 #define NUM_SYMBOLS 6
-  const char * symbols[NUM_SYMBOLS] = {TYPETAG(struct), TYPETAG(uint), TYPETAG(sint), TYPETAG(pointer), "inj{SortBytes{}, SortKItem{}}", "inj{SortFFIType{}, SortKItem{}}"};
+const char *symbols[NUM_SYMBOLS]
+    = {TYPETAG(struct),
+       TYPETAG(uint),
+       TYPETAG(sint),
+       TYPETAG(pointer),
+       "inj{SortBytes{}, SortKItem{}}",
+       "inj{SortFFIType{}, SortKItem{}}"};
 
-  char * getTerminatedString(string * str);
+char *getTerminatedString(string *str);
 
-  uint32_t getTagForSymbolName(const char *s) {
-    for (int i = 0; i < NUM_SYMBOLS; i++) {
-      if (0 == strcmp(symbols[i], s)) {
-        return i + 1;
-      }
+uint32_t getTagForSymbolName(const char *s) {
+  for (int i = 0; i < NUM_SYMBOLS; i++) {
+    if (0 == strcmp(symbols[i], s)) {
+      return i + 1;
     }
-
-    return 0;
   }
 
-  struct blockheader getBlockHeaderForSymbol(uint32_t tag) {
-    return blockheader {tag};
-  }
+  return 0;
+}
 
-  void add_hash64(void*, uint64_t) {}
+struct blockheader getBlockHeaderForSymbol(uint32_t tag) {
+  return blockheader{tag};
+}
 
-  size_t hash_k(block * kitem) {
-    return (size_t) kitem;
-  }
+void add_hash64(void *, uint64_t) { }
 
-  bool hash_enter(void) {
-    return true;
-  }
+size_t hash_k(block *kitem) {
+  return (size_t)kitem;
+}
 
-  void hash_exit(void) {}
+bool hash_enter(void) {
+  return true;
+}
 
-  void k_hash(block *, void *) {}
+void hash_exit(void) { }
 
-  bool during_gc() {
-    return false;
-  }
+void k_hash(block *, void *) { }
 
-  void printConfigurationInternal(writer *file, block *subject, const char *sort, bool) {}
-  void sfprintf(writer *, const char *, ...) {}
+bool during_gc() {
+  return false;
+}
 
-  bool hook_KEQUAL_eq(block * lhs, block * rhs) {
-    return lhs->h.hdr == rhs->h.hdr;
-  }
+void printConfigurationInternal(
+    writer *file, block *subject, const char *sort, bool) { }
+void sfprintf(writer *, const char *, ...) { }
 
-  mpz_ptr hook_FFI_address(string * fn);
-  string * hook_FFI_call(mpz_t addr, list * args, list * types, block * ret);
-  string * hook_FFI_call_variadic(mpz_t addr, list * args, list * fixtypes, list * vartypes, block * ret);
+bool hook_KEQUAL_eq(block *lhs, block *rhs) {
+  return lhs->h.hdr == rhs->h.hdr;
+}
 
-  mpz_ptr hook_FFI_bytes_address(string * bytes);
-  block * hook_FFI_free(block * kitem);
-  block * hook_FFI_freeAll(void);
-  block * hook_FFI_bytes_ref(string * bytes);
-  string * hook_FFI_alloc(block * kitem, mpz_t size, mpz_t align);
-  bool hook_FFI_allocated(block * kitem);
+mpz_ptr hook_FFI_address(string *fn);
+string *hook_FFI_call(mpz_t addr, list *args, list *types, block *ret);
+string *hook_FFI_call_variadic(
+    mpz_t addr, list *args, list *fixtypes, list *vartypes, block *ret);
 
-  string * makeString(const KCHAR *, int64_t len = -1);
+mpz_ptr hook_FFI_bytes_address(string *bytes);
+block *hook_FFI_free(block *kitem);
+block *hook_FFI_freeAll(void);
+block *hook_FFI_bytes_ref(string *bytes);
+string *hook_FFI_alloc(block *kitem, mpz_t size, mpz_t align);
+bool hook_FFI_allocated(block *kitem);
 
-  list hook_LIST_element(block * value);
-  list hook_LIST_concat(list * l1, list * l2);
-  list hook_LIST_unit();
-  size_t hook_LIST_size_long(list * l);
-  block * hook_LIST_get_long(list * l, ssize_t idx);
+string *makeString(const KCHAR *, int64_t len = -1);
 
-  mpz_ptr move_int(mpz_t i) {
-    mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
-    *result = *i;
-    return result;
-  }
+list hook_LIST_element(block *value);
+list hook_LIST_concat(list *l1, list *l2);
+list hook_LIST_unit();
+size_t hook_LIST_size_long(list *l);
+block *hook_LIST_get_long(list *l, ssize_t idx);
 
-  floating *move_float(floating *i) {
-    floating *result = (floating *)malloc(sizeof(floating));
-    *result = *i;
-    return result;
-  }
+mpz_ptr move_int(mpz_t i) {
+  mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
+  *result = *i;
+  return result;
+}
 
-  block D1 = {{1}};
-  block * DUMMY1 = &D1;
+floating *move_float(floating *i) {
+  floating *result = (floating *)malloc(sizeof(floating));
+  *result = *i;
+  return result;
+}
+
+block D1 = {{1}};
+block *DUMMY1 = &D1;
 }
 
 struct FfiTestFixture {
 
-  ~FfiTestFixture() {
-    hook_FFI_freeAll();
-  }
+  ~FfiTestFixture() { hook_FFI_freeAll(); }
 };
 
 BOOST_FIXTURE_TEST_SUITE(FfiTest, FfiTestFixture)
 
 BOOST_AUTO_TEST_CASE(address) {
-  string * fn = makeString("timesTwo");
+  string *fn = makeString("timesTwo");
   mpz_ptr addr = hook_FFI_address(fn);
   BOOST_CHECK(0 < mpz_cmp_ui(addr, 0));
 
@@ -145,40 +151,44 @@ BOOST_AUTO_TEST_CASE(address) {
 BOOST_AUTO_TEST_CASE(call) {
   /* int timesTwo(int x) */
   int x = -3;
-  string * xargstr = makeString((char *) &x, sizeof(int)); 
+  string *xargstr = makeString((char *)&x, sizeof(int));
 
-  block * xarg = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  xarg->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *xarg
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  xarg->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(xarg->children, &xargstr, sizeof(string *));
 
   list args = hook_LIST_element(xarg);
-  block * type_sint = leaf_block(getTagForSymbolName(TYPETAG(sint)));
+  block *type_sint = leaf_block(getTagForSymbolName(TYPETAG(sint)));
 
-  block * argtype = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  argtype->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
+  block *argtype
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  argtype->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
   memcpy(argtype->children, &type_sint, sizeof(block *));
 
   list types = hook_LIST_element(argtype);
 
-  string * fn = makeString("timesTwo");
+  string *fn = makeString("timesTwo");
   mpz_ptr addr = hook_FFI_address(fn);
 
-  string * bytes = hook_FFI_call(addr, &args, &types, type_sint);
+  string *bytes = hook_FFI_call(addr, &args, &types, type_sint);
 
   BOOST_CHECK(bytes != NULL);
 
-  int ret = *(int *) bytes->data;
+  int ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, x * 2);
 
   /* unsigned int utimesTwo(unsigned int x) */
   x = 4;
-  xargstr = makeString((char *) &x, sizeof(int)); 
+  xargstr = makeString((char *)&x, sizeof(int));
 
   memcpy(xarg->children, &xargstr, sizeof(string *));
 
   args = hook_LIST_element(xarg);
-  block * type_uint = leaf_block(getTagForSymbolName(TYPETAG(uint)));
+  block *type_uint = leaf_block(getTagForSymbolName(TYPETAG(uint)));
   memcpy(argtype->children, &type_uint, sizeof(block *));
 
   types = hook_LIST_element(argtype);
@@ -190,18 +200,20 @@ BOOST_AUTO_TEST_CASE(call) {
 
   BOOST_CHECK(bytes != NULL);
 
-  ret = *(unsigned int *) bytes->data;
+  ret = *(unsigned int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, x * 2);
 
   /* int times(int x, int y) */
   int y = 4;
-  string * yargstr = makeString((char *) &y, sizeof(int));
+  string *yargstr = makeString((char *)&y, sizeof(int));
 
   memcpy(argtype->children, &type_sint, sizeof(block *));
 
-  block * yarg = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  yarg->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *yarg
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  yarg->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(yarg->children, &yargstr, sizeof(string *));
 
   list yargs = hook_LIST_element(yarg);
@@ -212,15 +224,17 @@ BOOST_AUTO_TEST_CASE(call) {
   fn = makeString("times");
   addr = hook_FFI_address(fn);
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, x * y);
 
   /* struct point constructPoint(int x, int y) */
-  block * structType = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  structType->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(TYPETAG(struct)));
+  block *structType
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  structType->h
+      = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(TYPETAG(struct)));
 
-  list * structFields = static_cast<list *>(koreAlloc(sizeof(list)));
+  list *structFields = static_cast<list *>(koreAlloc(sizeof(list)));
   list tmp = hook_LIST_element(argtype);
   tmp = hook_LIST_concat(&tmp, &tmp);
   memcpy(structFields, &tmp, sizeof(list));
@@ -231,7 +245,7 @@ BOOST_AUTO_TEST_CASE(call) {
   addr = hook_FFI_address(fn);
   bytes = hook_FFI_call(addr, &args, &types, structType);
 
-  struct point p = *(struct point *) bytes->data;
+  struct point p = *(struct point *)bytes->data;
   BOOST_CHECK_EQUAL(p.x, x);
   BOOST_CHECK_EQUAL(p.y, y);
 
@@ -239,7 +253,7 @@ BOOST_AUTO_TEST_CASE(call) {
   fn = makeString("getX");
   addr = hook_FFI_address(fn);
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, 1);
 
@@ -252,7 +266,7 @@ BOOST_AUTO_TEST_CASE(call) {
   fn = makeString("getX");
   addr = hook_FFI_address(fn);
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, 2);
 
@@ -263,16 +277,20 @@ BOOST_AUTO_TEST_CASE(call) {
    *
    * int timesPoint(struct point p) */
   p = {.x = 2, .y = 5};
-  string * pargstr = makeString((char *) &p, sizeof(struct point));
+  string *pargstr = makeString((char *)&p, sizeof(struct point));
 
-  block * parg = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  parg->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *parg
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  parg->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(parg->children, &pargstr, sizeof(string *));
 
   args = hook_LIST_element(parg);
 
-  block * new_argtype = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  new_argtype->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
+  block *new_argtype
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  new_argtype->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
   memcpy(new_argtype->children, &structType, sizeof(block *));
   types = hook_LIST_element(new_argtype);
 
@@ -280,7 +298,7 @@ BOOST_AUTO_TEST_CASE(call) {
   addr = hook_FFI_address(fn);
 
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, p.x * p.y);
 
@@ -290,25 +308,29 @@ BOOST_AUTO_TEST_CASE(call) {
    *
    * int timesPoint2(struct point2 p) */
   struct point2 p2 = {.p = p};
-  string * pargstr2 = makeString((char *) &p2, sizeof(struct point2));
+  string *pargstr2 = makeString((char *)&p2, sizeof(struct point2));
 
   memcpy(parg->children, &pargstr2, sizeof(string *));
 
   args = hook_LIST_element(parg);
 
-  block * structType2 = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  structType2->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(TYPETAG(struct)));
+  block *structType2
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  structType2->h
+      = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName(TYPETAG(struct)));
 
-  block * structArgType = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  structArgType->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
+  block *structArgType
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  structArgType->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
   memcpy(structArgType->children, &structType, sizeof(block *));
 
-  list * structFields2 = static_cast<list *>(koreAlloc(sizeof(list)));
+  list *structFields2 = static_cast<list *>(koreAlloc(sizeof(list)));
   list tmp2 = hook_LIST_element(structArgType);
   memcpy(structFields2, &tmp2, sizeof(list));
 
   memcpy(structType2->children, &structFields2, sizeof(list *));
-  
+
   memcpy(new_argtype->children, &structType2, sizeof(block *));
   types = hook_LIST_element(new_argtype);
 
@@ -316,13 +338,13 @@ BOOST_AUTO_TEST_CASE(call) {
   addr = hook_FFI_address(fn);
 
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, p2.p.x * p2.p.y);
 
   /* Make sure there is no double free */
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, p2.p.x * p2.p.y);
 
@@ -331,20 +353,22 @@ BOOST_AUTO_TEST_CASE(call) {
   mpz_t s1, align;
   mpz_init_set_ui(s1, sizeof(int));
   mpz_init_set_ui(align, 16);
-  string * b1 = hook_FFI_alloc(DUMMY1, s1, align);
+  string *b1 = hook_FFI_alloc(DUMMY1, s1, align);
   memcpy(b1->data, &x, sizeof(int));
 
   mpz_ptr addr1 = hook_FFI_bytes_address(b1);
   uintptr_t address1 = mpz_get_ui(addr1);
 
-  string * ptrargstr = makeString((char *) &address1, sizeof(uintptr_t *));
+  string *ptrargstr = makeString((char *)&address1, sizeof(uintptr_t *));
 
-  block * ptrarg = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  ptrarg->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *ptrarg
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  ptrarg->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(ptrarg->children, &ptrargstr, sizeof(string *));
 
   args = hook_LIST_element(ptrarg);
-  block * type_pointer = leaf_block(getTagForSymbolName(TYPETAG(pointer)));
+  block *type_pointer = leaf_block(getTagForSymbolName(TYPETAG(pointer)));
 
   memcpy(argtype->children, &type_pointer, sizeof(block *));
 
@@ -359,7 +383,7 @@ BOOST_AUTO_TEST_CASE(call) {
 
   BOOST_CHECK(bytes != NULL);
 
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, x);
 }
@@ -367,66 +391,77 @@ BOOST_AUTO_TEST_CASE(call) {
 BOOST_AUTO_TEST_CASE(call_variadic) {
   /* int addInts(int x, ...) */
   int n = 1;
-  string * nargstr = makeString((char *) &n, sizeof(int)); 
+  string *nargstr = makeString((char *)&n, sizeof(int));
 
-  block * narg = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  narg->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *narg
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  narg->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(narg->children, &nargstr, sizeof(string *));
 
   list args = hook_LIST_element(narg);
 
   int arg1 = 1;
-  string * arg1str = makeString((char *) &arg1, sizeof(int)); 
+  string *arg1str = makeString((char *)&arg1, sizeof(int));
 
-  block * arg1block = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  arg1block->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *arg1block
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  arg1block->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(arg1block->children, &arg1str, sizeof(string *));
 
   list arg1list = hook_LIST_element(arg1block);
 
   args = hook_LIST_concat(&args, &arg1list);
 
-  block * type_sint = leaf_block(getTagForSymbolName(TYPETAG(sint)));
+  block *type_sint = leaf_block(getTagForSymbolName(TYPETAG(sint)));
 
-  block * fixargtype = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  fixargtype->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
+  block *fixargtype
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  fixargtype->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
   memcpy(fixargtype->children, &type_sint, sizeof(block *));
 
-  block * varargtype = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
-  varargtype->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
+  block *varargtype
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(block *)));
+  varargtype->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortFFIType{}, SortKItem{}}"));
   memcpy(varargtype->children, &type_sint, sizeof(block *));
 
   list fixtypes = hook_LIST_element(fixargtype);
   list vartypes = hook_LIST_element(varargtype);
 
-  string * fn = makeString("addInts");
+  string *fn = makeString("addInts");
   mpz_ptr addr = hook_FFI_address(fn);
 
-  string * bytes = hook_FFI_call_variadic(addr, &args, &fixtypes, &vartypes, type_sint);
+  string *bytes
+      = hook_FFI_call_variadic(addr, &args, &fixtypes, &vartypes, type_sint);
 
   BOOST_CHECK(bytes != NULL);
 
-  int ret = *(int *) bytes->data;
+  int ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, arg1);
 
   /* addInts with 2 var args */
   n = 2;
-  nargstr = makeString((char *) &n, sizeof(int));
+  nargstr = makeString((char *)&n, sizeof(int));
   memcpy(narg->children, &nargstr, sizeof(string *));
   args = hook_LIST_element(narg);
 
   arg1 = 20;
-  arg1str = makeString((char *) &arg1, sizeof(int));
+  arg1str = makeString((char *)&arg1, sizeof(int));
   memcpy(arg1block->children, &arg1str, sizeof(string *));
   arg1list = hook_LIST_element(arg1block);
   args = hook_LIST_concat(&args, &arg1list);
 
   int arg2 = 15;
-  string * arg2str = makeString((char *) &arg2, sizeof(int));
+  string *arg2str = makeString((char *)&arg2, sizeof(int));
 
-  block * arg2block = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
-  arg2block->h = getBlockHeaderForSymbol((uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
+  block *arg2block
+      = static_cast<block *>(koreAlloc(sizeof(block) + sizeof(string *)));
+  arg2block->h = getBlockHeaderForSymbol(
+      (uint64_t)getTagForSymbolName("inj{SortBytes{}, SortKItem{}}"));
   memcpy(arg2block->children, &arg2str, sizeof(string *));
 
   list arg2list = hook_LIST_element(arg2block);
@@ -440,13 +475,13 @@ BOOST_AUTO_TEST_CASE(call_variadic) {
 
   BOOST_CHECK(bytes != NULL);
 
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, arg1 + arg2);
 
   /* addInts with 0 var args */
   n = 0;
-  nargstr = makeString((char *) &n, sizeof(int));
+  nargstr = makeString((char *)&n, sizeof(int));
   memcpy(narg->children, &nargstr, sizeof(string *));
   args = hook_LIST_element(narg);
 
@@ -456,7 +491,7 @@ BOOST_AUTO_TEST_CASE(call_variadic) {
 
   BOOST_CHECK(bytes != NULL);
 
-  ret = *(int *) bytes->data;
+  ret = *(int *)bytes->data;
 
   BOOST_CHECK_EQUAL(ret, 0);
 }
@@ -466,10 +501,10 @@ BOOST_AUTO_TEST_CASE(alloc) {
   mpz_init_set_ui(s1, 1);
   mpz_init_set_ui(s2, 16);
 
-  string * b1 = hook_FFI_alloc(DUMMY1, s1, s2);
+  string *b1 = hook_FFI_alloc(DUMMY1, s1, s2);
   BOOST_CHECK(0 != b1);
 
-  string * b2 = hook_FFI_alloc(DUMMY1, s1, s2);
+  string *b2 = hook_FFI_alloc(DUMMY1, s1, s2);
   BOOST_CHECK_EQUAL(b1, b2);
 }
 
@@ -487,9 +522,9 @@ BOOST_AUTO_TEST_CASE(bytes_ref) {
   mpz_init_set_ui(s1, 1);
   mpz_init_set_ui(s2, 16);
 
-  string * b1 = hook_FFI_alloc(DUMMY1, s1, s2);
+  string *b1 = hook_FFI_alloc(DUMMY1, s1, s2);
 
-  block * i2 = hook_FFI_bytes_ref(b1);
+  block *i2 = hook_FFI_bytes_ref(b1);
 
   BOOST_CHECK_EQUAL(DUMMY1, i2);
 }
@@ -502,7 +537,7 @@ BOOST_AUTO_TEST_CASE(allocated) {
   hook_FFI_alloc(DUMMY1, s1, s2);
   BOOST_CHECK_EQUAL(true, hook_FFI_allocated(DUMMY1));
 
-  block * i2 = (block *) 2;
+  block *i2 = (block *)2;
   BOOST_CHECK_EQUAL(false, hook_FFI_allocated(i2));
 }
 

--- a/unittests/runtime-ffi/lib/foreign.cpp
+++ b/unittests/runtime-ffi/lib/foreign.cpp
@@ -1,64 +1,64 @@
 #include <cstdarg>
 
 extern "C" {
-  struct point {
-    int x;
-    int y;
-  };
+struct point {
+  int x;
+  int y;
+};
 
-  struct point2 {
-    struct point p;
-  };
+struct point2 {
+  struct point p;
+};
 
-  int x = 1;
+int x = 1;
 
-  int timesTwo(int x) {
-    return x * 2;
+int timesTwo(int x) {
+  return x * 2;
+}
+
+unsigned int utimesTwo(unsigned int x) {
+  return x * 2;
+}
+
+int times(int x, int y) {
+  return x * y;
+}
+
+int getX(void) {
+  return x;
+}
+
+void increaseX(void) {
+  x++;
+}
+
+int timesPoint(struct point p) {
+  return p.x * p.y;
+}
+
+int timesPoint2(struct point2 p) {
+  return p.p.x * p.p.y;
+}
+
+struct point constructPoint(int x, int y) {
+  return {.x = x, .y = y};
+}
+
+int addInts(int n, ...) {
+  int sum = 0;
+  va_list vl;
+  va_start(vl, n);
+
+  for (int i = 0; i < n; i++) {
+    sum += va_arg(vl, int);
   }
 
-  unsigned int utimesTwo(unsigned int x) {
-    return x * 2;
-  }
+  va_end(vl);
 
-  int times(int x, int y) {
-    return x * y;
-  }
+  return sum;
+}
 
-  int getX(void) {
-    return x;
-  }
-
-  void increaseX(void) {
-    x++;
-  }
-
-  int timesPoint(struct point p) {
-    return p.x * p.y;
-  }
-
-  int timesPoint2(struct point2 p) {
-    return p.p.x * p.p.y;
-  }
-
-  struct point constructPoint(int x, int y) {
-    return {.x = x, .y = y};
-  }
-
-  int addInts(int n, ...) {
-    int sum = 0;
-    va_list vl;
-    va_start(vl, n);
-
-    for (int i = 0; i < n; i++) {
-      sum += va_arg(vl, int);
-    }
-
-    va_end(vl);
-
-    return sum;
-  }
-
-  int pointerTest(int * x) {
-    return x == 0 ? 0 : *x;
-  }
+int pointerTest(int *x) {
+  return x == 0 ? 0 : *x;
+}
 }

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -1,13 +1,13 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
-#include<mpfr.h>
-#include<cstdint>
-#include<cstdlib>
-#include<cstring>
-#include<time.h>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <gmp.h>
+#include <mpfr.h>
+#include <time.h>
 
-#include "runtime/header.h"
 #include "runtime/alloc.h"
+#include "runtime/header.h"
 
 #include "fcntl.h"
 #include "unistd.h"
@@ -20,64 +20,76 @@ char kompiled_directory[] = "some/test/directory/path";
 #define GETTAG(symbol) "Lbl'Hash'" #symbol "{}"
 #define ERRBLOCK(tag) (uint64_t)(leaf_block(tag))
 #define NUM_SYMBOLS 8
-  const char * symbols[NUM_SYMBOLS] = {GETTAG(EOF), GETTAG(ENOENT), GETTAG(EBADF), "inj{SortInt{}, SortIOInt{}}", "inj{SortIOError{}, SortKItem{}}", "inj{SortString{}, SortKItem{}}", "kseq{}", GETTAG(systemResult)};
+const char *symbols[NUM_SYMBOLS]
+    = {GETTAG(EOF),
+       GETTAG(ENOENT),
+       GETTAG(EBADF),
+       "inj{SortInt{}, SortIOInt{}}",
+       "inj{SortIOError{}, SortKItem{}}",
+       "inj{SortString{}, SortKItem{}}",
+       "kseq{}",
+       GETTAG(systemResult)};
 
-  uint32_t getTagForSymbolName(const char *s) {
-    for (int i = 0; i < NUM_SYMBOLS; i++) {
-      if (0 == strcmp(symbols[i], s)) {
-        return i;
-      }
+uint32_t getTagForSymbolName(const char *s) {
+  for (int i = 0; i < NUM_SYMBOLS; i++) {
+    if (0 == strcmp(symbols[i], s)) {
+      return i;
     }
-
-    return 0;
-  }
-  
-  struct blockheader getBlockHeaderForSymbol(uint32_t tag) {
-    return blockheader {tag};
   }
 
-  bool during_gc() { return false; }
+  return 0;
+}
 
-  void add_hash64(void*, uint64_t) {}
+struct blockheader getBlockHeaderForSymbol(uint32_t tag) {
+  return blockheader{tag};
+}
 
-  void flush_IO_logs();
-  string * makeString(const KCHAR *, int64_t len = -1);
-  blockheader header_err();
-  block * hook_IO_open(string * filename, string * control);
-  block * hook_IO_tell(mpz_t i);
-  block * hook_IO_getc(mpz_t i);
-  block * hook_IO_read(mpz_t i, mpz_t len);
-  block * hook_IO_close(mpz_t i);
-  block * hook_IO_seek(mpz_t i, mpz_t loc);
-  block * hook_IO_seekEnd(mpz_t i, mpz_t loc);
-  block * hook_IO_putc(mpz_t i, mpz_t c);
-  block * hook_IO_write(mpz_t i, string * str);
-  block * hook_IO_lock(mpz_t i, mpz_t len);
-  block * hook_IO_unlock(mpz_t i, mpz_t len);
-  block * hook_IO_log(string * path, string * msg);
-  block * hook_IO_system(string * cmd);
-  mpz_ptr hook_IO_time(void);
-  string * hook_KREFLECTION_kompiledDir(void);
-  list hook_KREFLECTION_argv();
+bool during_gc() {
+  return false;
+}
 
-  extern int llvm_backend_argc;
-  extern char const ** llvm_backend_argv;
+void add_hash64(void *, uint64_t) { }
 
-  mpz_ptr move_int(mpz_t i) {
-    mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
-    *result = *i;
-    return result;
-  }
+void flush_IO_logs();
+string *makeString(const KCHAR *, int64_t len = -1);
+blockheader header_err();
+block *hook_IO_open(string *filename, string *control);
+block *hook_IO_tell(mpz_t i);
+block *hook_IO_getc(mpz_t i);
+block *hook_IO_read(mpz_t i, mpz_t len);
+block *hook_IO_close(mpz_t i);
+block *hook_IO_seek(mpz_t i, mpz_t loc);
+block *hook_IO_seekEnd(mpz_t i, mpz_t loc);
+block *hook_IO_putc(mpz_t i, mpz_t c);
+block *hook_IO_write(mpz_t i, string *str);
+block *hook_IO_lock(mpz_t i, mpz_t len);
+block *hook_IO_unlock(mpz_t i, mpz_t len);
+block *hook_IO_log(string *path, string *msg);
+block *hook_IO_system(string *cmd);
+mpz_ptr hook_IO_time(void);
+string *hook_KREFLECTION_kompiledDir(void);
+list hook_KREFLECTION_argv();
 
-  floating *move_float(floating *i) {
-    floating *result = (floating *)malloc(sizeof(floating));
-    *result = *i;
-    return result;
-  }
+extern int llvm_backend_argc;
+extern char const **llvm_backend_argv;
+
+mpz_ptr move_int(mpz_t i) {
+  mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
+  *result = *i;
+  return result;
+}
+
+floating *move_float(floating *i) {
+  floating *result = (floating *)malloc(sizeof(floating));
+  *result = *i;
+  return result;
+}
 }
 
 int overwriteTestFile() {
-  int fd = ::open("test.txt", O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
+  int fd = ::open(
+      "test.txt", O_RDWR | O_CREAT | O_TRUNC,
+      S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
   BOOST_CHECK_EQUAL(::write(fd, "hello world!", 12), 12);
   ::lseek(fd, 0, SEEK_SET);
   return fd;
@@ -93,13 +105,21 @@ BOOST_AUTO_TEST_CASE(open) {
   auto fakeFilename = makeString("testFake.txt");
   auto control = makeString("r");
 
-  block * b1 = hook_IO_open(realFilename, control);
-  BOOST_CHECK_EQUAL(b1->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK(0 < mpz_cmp_si((mpz_ptr) *(b1->children), 0));
+  block *b1 = hook_IO_open(realFilename, control);
+  BOOST_CHECK_EQUAL(
+      b1->h.hdr, getBlockHeaderForSymbol(
+                     getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                     .hdr);
+  BOOST_CHECK(0 < mpz_cmp_si((mpz_ptr) * (b1->children), 0));
 
-  block * b2 = hook_IO_open(fakeFilename, control);
-  BOOST_CHECK_EQUAL(b2->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(b2->children), ERRBLOCK(getTagForSymbolName(GETTAG(ENOENT))));
+  block *b2 = hook_IO_open(fakeFilename, control);
+  BOOST_CHECK_EQUAL(
+      b2->h.hdr, getBlockHeaderForSymbol(
+                     getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+                     .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (b2->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(ENOENT))));
 }
 
 BOOST_AUTO_TEST_CASE(tell) {
@@ -107,36 +127,61 @@ BOOST_AUTO_TEST_CASE(tell) {
   int fd = overwriteTestFile();
   mpz_init_set_si(f, fd);
 
-  block * b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
+  block *b = hook_IO_tell(f);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      0,
+      mpz_cmp_si((mpz_ptr) * (b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
 
   lseek(mpz_get_si(f), 5, SEEK_CUR);
 
   b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), 5));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), 5));
 
   b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      0,
+      mpz_cmp_si((mpz_ptr) * (b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
 
   lseek(mpz_get_si(f), -4, SEEK_CUR);
 
   b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), 1));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), 1));
 
   b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      0,
+      mpz_cmp_si((mpz_ptr) * (b->children), lseek(mpz_get_si(f), 0, SEEK_CUR)));
 
   ::close(fd);
 
   mpz_set_si(f, -1);
   b = hook_IO_tell(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(getc) {
@@ -144,39 +189,62 @@ BOOST_AUTO_TEST_CASE(getc) {
   int fd = overwriteTestFile();
   mpz_init_set_si(f, fd);
 
-  block * b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), int('h')));
+  block *b = hook_IO_getc(f);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), int('h')));
 
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), int('e')));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), int('e')));
 
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), int('l')));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), int('l')));
 
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), int('l')));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), int('l')));
 
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortInt{}, SortIOInt{}}")).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(b->children), int('o')));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortInt{}, SortIOInt{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (b->children), int('o')));
 
   ::lseek(fd, 0, SEEK_END);
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  const char * temp = GETTAG(EOF);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+                    .hdr);
+  const char *temp = GETTAG(EOF);
   BOOST_CHECK(std::string(temp) != "");
-  BOOST_CHECK_EQUAL((uint64_t)*(b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EOF))));
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EOF))));
 
   ::close(fd);
 
   mpz_set_si(f, -1);
   b = hook_IO_getc(f);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(read) {
@@ -186,29 +254,42 @@ BOOST_AUTO_TEST_CASE(read) {
   mpz_init_set_si(f, fd);
   mpz_init_set_si(len, 6);
 
-  block * b = hook_IO_read(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortString{}, SortIOString{}}")).hdr);
-  string * str = (string *) *(b->children);
+  block *b = hook_IO_read(f, len);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
+                    .hdr);
+  string *str = (string *)*(b->children);
 
   BOOST_CHECK_EQUAL(0, strncmp(str->data, "hello ", 6));
 
   b = hook_IO_read(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortString{}, SortIOString{}}")).hdr);
-  str = (string *) *(b->children);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
+                    .hdr);
+  str = (string *)*(b->children);
   BOOST_CHECK_EQUAL(0, strncmp(str->data, "world!", 6));
 
   ::lseek(fd, 0, SEEK_END);
 
   b = hook_IO_read(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortString{}, SortIOString{}}")).hdr);
-  str = (string *) *(b->children);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortString{}, SortIOString{}}"))
+                    .hdr);
+  str = (string *)*(b->children);
   BOOST_CHECK_EQUAL(0, len(str));
 
   ::close(fd);
 
   b = hook_IO_read(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(
+                    getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+                    .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (b->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(close) {
@@ -227,14 +308,28 @@ BOOST_AUTO_TEST_CASE(close) {
   BOOST_CHECK_EQUAL(-1, fcntl(fd2, F_GETFD));
   BOOST_CHECK_EQUAL(EBADF, errno);
 
-  block * b = hook_IO_close(f1);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  block *b = hook_IO_close(f1);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
   b = hook_IO_close(f2);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(putc) {
@@ -266,10 +361,17 @@ BOOST_AUTO_TEST_CASE(putc) {
 
   ::close(fd);
 
-  block * b = hook_IO_putc(f, c);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  block *b = hook_IO_putc(f, c);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(seek) {
@@ -289,10 +391,17 @@ BOOST_AUTO_TEST_CASE(seek) {
   }
 
   mpz_set_si(f, -1);
-  block * b = hook_IO_seek(f, loc);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  block *b = hook_IO_seek(f, loc);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 BOOST_AUTO_TEST_CASE(seekEnd) {
   mpz_t f;
@@ -305,7 +414,7 @@ BOOST_AUTO_TEST_CASE(seekEnd) {
   int cur, end;
   int deltas[5] = {-5, 0, -3, -4, -2};
 
-  for (int d: deltas) {
+  for (int d : deltas) {
     mpz_set_si(loc, d);
     hook_IO_seekEnd(f, loc);
     cur = lseek(fd, 0, SEEK_CUR);
@@ -314,21 +423,28 @@ BOOST_AUTO_TEST_CASE(seekEnd) {
   }
 
   mpz_set_si(f, -1);
-  block * b = hook_IO_seekEnd(f, loc);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  block *b = hook_IO_seekEnd(f, loc);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(write) {
   mpz_t f;
-  string * msg = makeString("This is a test message\n");
+  string *msg = makeString("This is a test message\n");
   int fd = overwriteTestFile();
   mpz_init_set_si(f, fd);
 
   hook_IO_write(f, msg);
 
-  FILE * file = fopen("test.txt", "r");
+  FILE *file = fopen("test.txt", "r");
   char buf[23];
   BOOST_CHECK_EQUAL(fread(buf, sizeof(char), 23, file), 23);
   fclose(file);
@@ -336,10 +452,17 @@ BOOST_AUTO_TEST_CASE(write) {
   BOOST_CHECK_EQUAL(0, strncmp(buf, "This is a test message\n", 23));
 
   mpz_set_si(f, -1);
-  block * b = hook_IO_write(f, msg);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  block *b = hook_IO_write(f, msg);
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(lock) {
@@ -348,19 +471,29 @@ BOOST_AUTO_TEST_CASE(lock) {
   mpz_init_set_si(f, fd);
   mpz_init_set_si(len, 12);
 
-  block * b = hook_IO_lock(f, len);
+  block *b = hook_IO_lock(f, len);
 
   struct flock lockp = {0};
-  lockp.l_type = F_WRLCK; lockp.l_whence = SEEK_CUR; lockp.l_start = 0; lockp.l_len = 12;
+  lockp.l_type = F_WRLCK;
+  lockp.l_whence = SEEK_CUR;
+  lockp.l_start = 0;
+  lockp.l_len = 12;
   fcntl(fd, F_SETLK, &lockp);
 
   BOOST_CHECK(lockp.l_type != F_UNLCK);
 
   mpz_set_si(f, -1);
   b = hook_IO_lock(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(unlock) {
@@ -369,26 +502,36 @@ BOOST_AUTO_TEST_CASE(unlock) {
   mpz_init_set_si(f, fd);
   mpz_init_set_si(len, 12);
 
-  block * b = hook_IO_unlock(f, len);
+  block *b = hook_IO_unlock(f, len);
 
   struct flock lockp = {0};
-  lockp.l_type = F_WRLCK; lockp.l_whence = SEEK_CUR; lockp.l_start = 0; lockp.l_len = 12;
+  lockp.l_type = F_WRLCK;
+  lockp.l_whence = SEEK_CUR;
+  lockp.l_start = 0;
+  lockp.l_len = 12;
   fcntl(fd, F_SETLK, &lockp);
 
   BOOST_CHECK(lockp.l_type != F_UNLCK);
 
   mpz_set_si(f, -1);
   b = hook_IO_unlock(f, len);
-  BOOST_CHECK_EQUAL(b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
-  BOOST_CHECK_EQUAL(((block*)*(b->children))->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortIOError{}, SortKItem{}}")).hdr);
-  BOOST_CHECK_EQUAL((uint64_t)*(((block*)*(b->children))->children), ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
+  BOOST_CHECK_EQUAL(
+      b->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("kseq{}")).hdr);
+  BOOST_CHECK_EQUAL(
+      ((block *)*(b->children))->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortIOError{}, SortKItem{}}"))
+          .hdr);
+  BOOST_CHECK_EQUAL(
+      (uint64_t) * (((block *)*(b->children))->children),
+      ERRBLOCK(getTagForSymbolName(GETTAG(EBADF))));
 }
 
 BOOST_AUTO_TEST_CASE(log) {
   std::string strPath = "logFile";
   std::string strMsg = "Log1\nLog2\n";
-  string * path = makeString(strPath.c_str());
-  string * msg = makeString(strMsg.c_str());
+  string *path = makeString(strPath.c_str());
+  string *msg = makeString(strMsg.c_str());
 
   hook_IO_log(path, msg);
   msg = makeString("Log3\n");
@@ -396,7 +539,7 @@ BOOST_AUTO_TEST_CASE(log) {
   flush_IO_logs();
 
   std::string PID = std::to_string(getpid());
-  FILE* f = fopen((PID + "_" + strPath).c_str(), "r");
+  FILE *f = fopen((PID + "_" + strPath).c_str(), "r");
   char buf[15];
   BOOST_CHECK_EQUAL(fread(buf, sizeof(char), 15, f), 15);
   fclose(f);
@@ -406,19 +549,21 @@ BOOST_AUTO_TEST_CASE(log) {
 
 BOOST_AUTO_TEST_CASE(system) {
   std::string command = "echo \"hello\"";
-  string * cmd = makeString(command.c_str());
+  string *cmd = makeString(command.c_str());
 
-  block * ret = hook_IO_system(cmd);
+  block *ret = hook_IO_system(cmd);
 
   BOOST_CHECK(ret != NULL);
   BOOST_CHECK(ret->children != NULL);
   BOOST_CHECK((ret->children + 1) != NULL);
   BOOST_CHECK((ret->children + 2) != NULL);
 
-  BOOST_CHECK_EQUAL(ret->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(ret->children), 0));
+  BOOST_CHECK_EQUAL(
+      ret->h.hdr,
+      getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (ret->children), 0));
 
-  string * out = (string *) *(ret->children + 1);
+  string *out = (string *)*(ret->children + 1);
   BOOST_CHECK_EQUAL(0, strncmp(out->data, "hello\n", 6));
   BOOST_CHECK_EQUAL(6, len(out));
 
@@ -431,35 +576,41 @@ BOOST_AUTO_TEST_CASE(system) {
   BOOST_CHECK(ret->children != NULL);
   BOOST_CHECK((ret->children + 1) != NULL);
   BOOST_CHECK((ret->children + 2) != NULL);
-  BOOST_CHECK_EQUAL(ret->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
-  BOOST_CHECK(mpz_cmp_si((mpz_ptr) *(ret->children), 0) > 0);
+  BOOST_CHECK_EQUAL(
+      ret->h.hdr,
+      getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
+  BOOST_CHECK(mpz_cmp_si((mpz_ptr) * (ret->children), 0) > 0);
 
   /* Execute program that segfaults */
   command = "./IOTest 1";
   cmd = makeString(command.c_str());
   ret = hook_IO_system(cmd);
-  out = (string *) *(ret->children + 1);
+  out = (string *)*(ret->children + 1);
   BOOST_CHECK(ret != NULL);
   BOOST_CHECK(ret->children != NULL);
   BOOST_CHECK((ret->children + 1) != NULL);
   BOOST_CHECK((ret->children + 2) != NULL);
-  BOOST_CHECK_EQUAL(ret->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
+  BOOST_CHECK_EQUAL(
+      ret->h.hdr,
+      getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
   // this assertion fails on some platforms
-  //BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(ret->children), 139));
+  // BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(ret->children), 139));
 
   /* Execute program that prints to stderr */
   command = "./IOTest";
   cmd = makeString(command.c_str());
   ret = hook_IO_system(cmd);
-  out = (string *) *(ret->children + 1);
+  out = (string *)*(ret->children + 1);
   BOOST_CHECK(ret != NULL);
   BOOST_CHECK(ret->children != NULL);
   BOOST_CHECK((ret->children + 1) != NULL);
   BOOST_CHECK((ret->children + 2) != NULL);
-  BOOST_CHECK_EQUAL(ret->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) *(ret->children), 0));
+  BOOST_CHECK_EQUAL(
+      ret->h.hdr,
+      getBlockHeaderForSymbol(getTagForSymbolName(GETTAG(systemResult))).hdr);
+  BOOST_CHECK_EQUAL(0, mpz_cmp_si((mpz_ptr) * (ret->children), 0));
 
-  string * err = (string *) *(ret->children + 2);
+  string *err = (string *)*(ret->children + 2);
   BOOST_CHECK_EQUAL(0, strncmp(err->data, "Error", 5));
   BOOST_CHECK_EQUAL(5, len(err));
 }
@@ -483,23 +634,31 @@ BOOST_AUTO_TEST_CASE(kompiledDir) {
 }
 
 BOOST_AUTO_TEST_CASE(argv) {
-    char const *argv[] = {"./a.out", "--help", nullptr};
-    llvm_backend_argv = argv;
-    llvm_backend_argc = 2;
-    list ret = hook_KREFLECTION_argv();
-    BOOST_CHECK(ret.size() == 2);
+  char const *argv[] = {"./a.out", "--help", nullptr};
+  llvm_backend_argv = argv;
+  llvm_backend_argc = 2;
+  list ret = hook_KREFLECTION_argv();
+  BOOST_CHECK(ret.size() == 2);
 
-    BOOST_CHECK(ret[0].elem != nullptr);
-    BOOST_CHECK_EQUAL(ret[0].elem->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortString{}, SortKItem{}}")).hdr);
-    string * arg0 = (string *) *(ret[0].elem->children);
-    BOOST_CHECK_EQUAL(0, strncmp(arg0->data, argv[0], strlen(argv[0])));
-    BOOST_CHECK_EQUAL(strlen(argv[0]), len(arg0));
+  BOOST_CHECK(ret[0].elem != nullptr);
+  BOOST_CHECK_EQUAL(
+      ret[0].elem->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortString{}, SortKItem{}}"))
+          .hdr);
+  string *arg0 = (string *)*(ret[0].elem->children);
+  BOOST_CHECK_EQUAL(0, strncmp(arg0->data, argv[0], strlen(argv[0])));
+  BOOST_CHECK_EQUAL(strlen(argv[0]), len(arg0));
 
-    BOOST_CHECK(ret[1].elem != nullptr);
-    BOOST_CHECK_EQUAL(ret[1].elem->h.hdr, getBlockHeaderForSymbol(getTagForSymbolName("inj{SortString{}, SortKItem{}}")).hdr);
-    string * arg1 = (string *) *(ret[1].elem->children);
-    BOOST_CHECK_EQUAL(0, strncmp(arg1->data, argv[1], strlen(argv[1])));
-    BOOST_CHECK_EQUAL(strlen(argv[1]), len(arg1));
+  BOOST_CHECK(ret[1].elem != nullptr);
+  BOOST_CHECK_EQUAL(
+      ret[1].elem->h.hdr,
+      getBlockHeaderForSymbol(
+          getTagForSymbolName("inj{SortString{}, SortKItem{}}"))
+          .hdr);
+  string *arg1 = (string *)*(ret[1].elem->children);
+  BOOST_CHECK_EQUAL(0, strncmp(arg1->data, argv[1], strlen(argv[1])));
+  BOOST_CHECK_EQUAL(strlen(argv[1]), len(arg1));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/runtime-io/iotest.cpp
+++ b/unittests/runtime-io/iotest.cpp
@@ -1,16 +1,16 @@
 #include <cstdio>
 
 int segfault() {
-  int * x = NULL;
+  int *x = NULL;
   int y = *x;
   return y;
 }
 
 void errtest() {
-  fprintf( stderr, "Error" );
+  fprintf(stderr, "Error");
 }
 
-int main(int argc, char ** argv) {
+int main(int argc, char **argv) {
   if (argc == 2) {
     segfault();
   } else {

--- a/unittests/runtime-strings/bytestest.cpp
+++ b/unittests/runtime-strings/bytestest.cpp
@@ -1,58 +1,72 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
-#include<cstdint>
-#include<cstring>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <cstring>
+#include <gmp.h>
 
-#include "runtime/header.h"
 #include "runtime/alloc.h"
+#include "runtime/header.h"
 
 #define KCHAR char
 extern "C" {
-  uint32_t getTagForSymbolName(const char *s) {
-    return 0;
-  }
+uint32_t getTagForSymbolName(const char *s) {
+  return 0;
+}
 
-  uint64_t tag_big_endian();
-  uint64_t tag_unsigned();
+uint64_t tag_big_endian();
+uint64_t tag_unsigned();
 
-  mpz_ptr hook_BYTES_bytes2int(string *b, uint64_t endianness, uint64_t signedness);
-  string *hook_BYTES_int2bytes(mpz_t len, mpz_t i, uint64_t endianness);
-  string *hook_BYTES_bytes2string(string *b);
-  string *hook_BYTES_string2bytes(string *s);
-  string *hook_BYTES_substr(string *b, mpz_t start, mpz_t end);
-  string *hook_BYTES_replaceAt(string *b, mpz_t start, string *b2);
-  string *hook_BYTES_update(string *b, mpz_t off, mpz_t val);
-  mpz_ptr hook_BYTES_get(string *b, mpz_t off);
-  mpz_ptr hook_BYTES_length(string *b);
-  string *hook_BYTES_padRight(string *b, mpz_t len, mpz_t v);
-  string *hook_BYTES_padLeft(string *b, mpz_t len, mpz_t v);
-  string *hook_BYTES_reverse(string *b);
-  string *hook_BYTES_concat(string *b1, string *);
-  string * makeString(const KCHAR *, int64_t len = -1);
+mpz_ptr
+hook_BYTES_bytes2int(string *b, uint64_t endianness, uint64_t signedness);
+string *hook_BYTES_int2bytes(mpz_t len, mpz_t i, uint64_t endianness);
+string *hook_BYTES_bytes2string(string *b);
+string *hook_BYTES_string2bytes(string *s);
+string *hook_BYTES_substr(string *b, mpz_t start, mpz_t end);
+string *hook_BYTES_replaceAt(string *b, mpz_t start, string *b2);
+string *hook_BYTES_update(string *b, mpz_t off, mpz_t val);
+mpz_ptr hook_BYTES_get(string *b, mpz_t off);
+mpz_ptr hook_BYTES_length(string *b);
+string *hook_BYTES_padRight(string *b, mpz_t len, mpz_t v);
+string *hook_BYTES_padLeft(string *b, mpz_t len, mpz_t v);
+string *hook_BYTES_reverse(string *b);
+string *hook_BYTES_concat(string *b1, string *);
+string *makeString(const KCHAR *, int64_t len = -1);
 }
 
 BOOST_AUTO_TEST_SUITE(BytesTest)
 
 BOOST_AUTO_TEST_CASE(bytes2int) {
   auto empty = makeString("");
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(empty, tag_big_endian(), tag_unsigned()), 0));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(empty, 2, tag_unsigned()), 0));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(empty, tag_big_endian(), 2), 0));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(
+             hook_BYTES_bytes2int(empty, tag_big_endian(), tag_unsigned()), 0));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(empty, 2, tag_unsigned()), 0));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(empty, tag_big_endian(), 2), 0));
   BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(empty, 2, 2), 0));
 
   auto ff = makeString("\xff");
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff, tag_big_endian(), tag_unsigned()), 255));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff, tag_big_endian(), 2), -1));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff, 2, tag_unsigned()), 255));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(
+             hook_BYTES_bytes2int(ff, tag_big_endian(), tag_unsigned()), 255));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(ff, tag_big_endian(), 2), -1));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(ff, 2, tag_unsigned()), 255));
   BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff, 2, 2), -1));
 
   auto _00ff = makeString("\x00\xff", 2);
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(_00ff, tag_big_endian(), tag_unsigned()), 255));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(_00ff, tag_big_endian(), 2), 255));
+  BOOST_CHECK_EQUAL(
+      0,
+      mpz_cmp_si(
+          hook_BYTES_bytes2int(_00ff, tag_big_endian(), tag_unsigned()), 255));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(_00ff, tag_big_endian(), 2), 255));
 
   auto ff00 = makeString("\xff\x00", 2);
   BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff00, 2, 2), 255));
-  BOOST_CHECK_EQUAL(0, mpz_cmp_si(hook_BYTES_bytes2int(ff00, 2, tag_unsigned()), 255));
+  BOOST_CHECK_EQUAL(
+      0, mpz_cmp_si(hook_BYTES_bytes2int(ff00, 2, tag_unsigned()), 255));
 }
 
 BOOST_AUTO_TEST_CASE(int2bytes) {
@@ -134,7 +148,12 @@ BOOST_AUTO_TEST_CASE(int2bytes) {
 
   res = hook_BYTES_int2bytes(_17, num, tag_big_endian());
   BOOST_CHECK_EQUAL(17, len(res));
-  BOOST_CHECK_EQUAL(0, memcmp(res->data, "\xff\x00\x08\x00\x06\xFF\xFE\xFF\xF0\x00\x08\xFF\xFF\xFF\xFF\x08\x01", 17));
+  BOOST_CHECK_EQUAL(
+      0, memcmp(
+             res->data,
+             "\xff\x00\x08\x00\x06\xFF\xFE\xFF\xF0\x00\x08\xFF\xFF\xFF\xFF\x08"
+             "\x01",
+             17));
 }
 
 BOOST_AUTO_TEST_CASE(bytes2string) {
@@ -178,17 +197,22 @@ BOOST_AUTO_TEST_CASE(substr) {
   mpz_init_set_si(_10, 10);
   mpz_init_set_si(_1024, 1024);
   mpz_init_set_si(_4096, 4096);
-  BOOST_CHECK_EQUAL(memcmp(hook_BYTES_substr(catAll, _2, _9)->data, "llohehf", 7), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_BYTES_substr(catAll, _2, _6)->data, "lloh", 4), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_BYTES_substr(catAll, _0, _4)->data, "hell", 4), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_BYTES_substr(catAll, _6, _9)->data, "ehf", 3), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_BYTES_substr(catAll, _2, _9)->data, "llohehf", 7), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_BYTES_substr(catAll, _2, _6)->data, "lloh", 4), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_BYTES_substr(catAll, _0, _4)->data, "hell", 4), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_BYTES_substr(catAll, _6, _9)->data, "ehf", 3), 0);
   BOOST_CHECK_THROW(hook_BYTES_substr(catAll, _7, _40), std::invalid_argument);
   BOOST_CHECK_THROW(hook_BYTES_substr(catAll, _8, _40), std::invalid_argument);
   BOOST_CHECK_EQUAL(memcmp(hook_BYTES_substr(catAll, _8, _9)->data, "f", 1), 0);
   BOOST_CHECK_EQUAL(len(hook_BYTES_substr(catAll, _9, _9)), 0);
   BOOST_CHECK_THROW(hook_BYTES_substr(catAll, _8, _7), std::invalid_argument);
   BOOST_CHECK_THROW(hook_BYTES_substr(catAll, _7, _10), std::invalid_argument);
-  BOOST_CHECK_THROW(hook_BYTES_substr(catAll, _1024, _4096), std::invalid_argument);
+  BOOST_CHECK_THROW(
+      hook_BYTES_substr(catAll, _1024, _4096), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(update) {
@@ -211,8 +235,6 @@ BOOST_AUTO_TEST_CASE(get) {
   auto res = hook_BYTES_get(_1234, _0);
   BOOST_CHECK_EQUAL(0, mpz_cmp_ui(res, '1'));
 }
-
-
 
 BOOST_AUTO_TEST_CASE(replaceAt) {
   auto _1234 = makeString("1234");
@@ -338,7 +360,7 @@ BOOST_AUTO_TEST_CASE(concat) {
   BOOST_CHECK_EQUAL(0, memcmp(emptyCatL->data, a->data, len(emptyCatL)));
   BOOST_CHECK_EQUAL(len(emptyCatL), len(a));
 
-  auto catAll = hook_BYTES_concat(hook_BYTES_concat(a,b), c);
+  auto catAll = hook_BYTES_concat(hook_BYTES_concat(a, b), c);
   auto expected = makeString("hellohehf");
   BOOST_CHECK_EQUAL(0, memcmp(catAll->data, expected->data, len(catAll)));
   BOOST_CHECK_EQUAL(len(catAll), len(expected));

--- a/unittests/runtime-strings/stringtest.cpp
+++ b/unittests/runtime-strings/stringtest.cpp
@@ -1,85 +1,85 @@
-#include<boost/test/unit_test.hpp>
-#include<gmp.h>
-#include<mpfr.h>
-#include<cstdint>
-#include<cstdlib>
-#include<cstring>
+#include <boost/test/unit_test.hpp>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <gmp.h>
+#include <mpfr.h>
 
-#include "runtime/header.h"
 #include "runtime/alloc.h"
+#include "runtime/header.h"
 
 #define KCHAR char
 extern "C" {
-  bool hook_STRING_gt(string *, string *);
-  bool hook_STRING_ge(string *, string *);
-  bool hook_STRING_lt(string *, string *);
-  bool hook_STRING_le(string *, string *);
-  bool hook_STRING_eq(string *, string *);
-  bool hook_STRING_ne(string *, string *);
-  string * hook_STRING_concat(string *, string *);
-  mpz_ptr hook_STRING_length(string *);
-  string * hook_STRING_chr(mpz_t);
-  mpz_ptr hook_STRING_ord(string *);
-  string * hook_STRING_substr(string *, mpz_t, mpz_t);
-  mpz_ptr hook_STRING_find(string *, string *, mpz_ptr);
-  mpz_ptr hook_STRING_rfind(string *, string *, mpz_ptr);
-  mpz_ptr hook_STRING_findChar(string *, string *, mpz_ptr);
-  mpz_ptr hook_STRING_rfindChar(string *, string *, mpz_ptr);
-  mpz_ptr hook_STRING_string2int(string *);
-  floating *hook_STRING_string2float(string *);
-  mpz_ptr hook_STRING_string2base(string *, mpz_t);
-  string * hook_STRING_float2string(floating *);
-  string * hook_STRING_int2string(mpz_t);
-  string * hook_STRING_replaceAll(string *, string *, string *);
-  string * hook_STRING_replace(string *, string *, string *, mpz_t);
-  string * hook_STRING_replaceFirst(string *, string *, string *);
-  mpz_ptr hook_STRING_countAllOccurrences(string *, string *);
-  string * hook_STRING_transcode(string *, string *, string *);
-  string * makeString(const KCHAR *, int64_t len = -1);
-  stringbuffer *hook_BUFFER_empty();
-  stringbuffer *hook_BUFFER_concat(stringbuffer *, string *);
-  string *hook_BUFFER_toString(stringbuffer *);
+bool hook_STRING_gt(string *, string *);
+bool hook_STRING_ge(string *, string *);
+bool hook_STRING_lt(string *, string *);
+bool hook_STRING_le(string *, string *);
+bool hook_STRING_eq(string *, string *);
+bool hook_STRING_ne(string *, string *);
+string *hook_STRING_concat(string *, string *);
+mpz_ptr hook_STRING_length(string *);
+string *hook_STRING_chr(mpz_t);
+mpz_ptr hook_STRING_ord(string *);
+string *hook_STRING_substr(string *, mpz_t, mpz_t);
+mpz_ptr hook_STRING_find(string *, string *, mpz_ptr);
+mpz_ptr hook_STRING_rfind(string *, string *, mpz_ptr);
+mpz_ptr hook_STRING_findChar(string *, string *, mpz_ptr);
+mpz_ptr hook_STRING_rfindChar(string *, string *, mpz_ptr);
+mpz_ptr hook_STRING_string2int(string *);
+floating *hook_STRING_string2float(string *);
+mpz_ptr hook_STRING_string2base(string *, mpz_t);
+string *hook_STRING_float2string(floating *);
+string *hook_STRING_int2string(mpz_t);
+string *hook_STRING_replaceAll(string *, string *, string *);
+string *hook_STRING_replace(string *, string *, string *, mpz_t);
+string *hook_STRING_replaceFirst(string *, string *, string *);
+mpz_ptr hook_STRING_countAllOccurrences(string *, string *);
+string *hook_STRING_transcode(string *, string *, string *);
+string *makeString(const KCHAR *, int64_t len = -1);
+stringbuffer *hook_BUFFER_empty();
+stringbuffer *hook_BUFFER_concat(stringbuffer *, string *);
+string *hook_BUFFER_toString(stringbuffer *);
 
-  mpz_ptr move_int(mpz_t i) {
-    mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
-    *result = *i;
-    return result;
-  }
+mpz_ptr move_int(mpz_t i) {
+  mpz_ptr result = (mpz_ptr)malloc(sizeof(__mpz_struct));
+  *result = *i;
+  return result;
+}
 
-  floating *move_float(floating *i) {
-    floating *result = (floating *)malloc(sizeof(floating));
-    *result = *i;
-    return result;
-  }
+floating *move_float(floating *i) {
+  floating *result = (floating *)malloc(sizeof(floating));
+  *result = *i;
+  return result;
+}
 
-  void add_hash64(void*, uint64_t) {}
+void add_hash64(void *, uint64_t) { }
 }
 
 BOOST_AUTO_TEST_SUITE(StringTest)
 
-  BOOST_AUTO_TEST_CASE(gt) {
-    auto a = makeString("hello");
-    auto b = makeString("he");
-    auto c = makeString("hf");
-    auto d = makeString("");
+BOOST_AUTO_TEST_CASE(gt) {
+  auto a = makeString("hello");
+  auto b = makeString("he");
+  auto c = makeString("hf");
+  auto d = makeString("");
 
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(a,a));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(a,b));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(a,c));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(a,d));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(b,a));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(b,b));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(b,c));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(b,d));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(c,a));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(c,b));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(c,c));
-    BOOST_CHECK_EQUAL(true,  hook_STRING_gt(c,d));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(d,a));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(d,b));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(d,c));
-    BOOST_CHECK_EQUAL(false, hook_STRING_gt(d,d));
-  }
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(a, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(a, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(a, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(a, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(b, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(b, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(b, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(b, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(c, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(c, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(c, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_gt(c, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(d, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(d, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(d, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_gt(d, d));
+}
 
 BOOST_AUTO_TEST_CASE(ge) {
   auto a = makeString("hello");
@@ -87,22 +87,22 @@ BOOST_AUTO_TEST_CASE(ge) {
   auto c = makeString("hf");
   auto d = makeString("");
 
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(a,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(a,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(a,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(a,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(b,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(b,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(b,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(b,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(c,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(c,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(c,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(c,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ge(d,d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(a, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(a, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(a, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(a, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(b, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(b, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(b, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(b, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(c, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(c, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(c, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(c, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ge(d, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ge(d, d));
 }
 
 BOOST_AUTO_TEST_CASE(lt) {
@@ -111,22 +111,22 @@ BOOST_AUTO_TEST_CASE(lt) {
   auto c = makeString("hf");
   auto d = makeString("");
 
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(a,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(b,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(b,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(b,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(b,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(d,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(d,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_lt(d,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_lt(d,d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(a, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(a, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(b, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(b, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(b, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(b, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(c, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(d, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(d, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_lt(d, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_lt(d, d));
 }
 
 BOOST_AUTO_TEST_CASE(le) {
@@ -135,22 +135,22 @@ BOOST_AUTO_TEST_CASE(le) {
   auto c = makeString("hf");
   auto d = makeString("");
 
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(a,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(a,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(a,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(a,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(b,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(b,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(b,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(b,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(c,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(c,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(c,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_le(c,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(d,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(d,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(d,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_le(d,d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(a, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(a, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(a, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(a, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(b, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(b, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(b, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(b, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(c, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(c, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(c, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_le(c, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(d, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(d, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(d, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_le(d, d));
 }
 
 BOOST_AUTO_TEST_CASE(eq) {
@@ -159,22 +159,22 @@ BOOST_AUTO_TEST_CASE(eq) {
   auto c = makeString("hf");
   auto d = makeString("");
 
-  BOOST_CHECK_EQUAL(true,  hook_STRING_eq(a,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_eq(b,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_eq(c,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c,d));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_eq(d,d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_eq(a, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(a, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_eq(b, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(b, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_eq(c, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(c, d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_eq(d, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_eq(d, d));
 }
 
 BOOST_AUTO_TEST_CASE(ne) {
@@ -183,22 +183,22 @@ BOOST_AUTO_TEST_CASE(ne) {
   auto c = makeString("hf");
   auto d = makeString("");
 
-  BOOST_CHECK_EQUAL(false, hook_STRING_ne(a,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(a,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(a,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(a,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(b,a));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ne(b,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(b,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(b,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(c,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(c,b));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ne(c,c));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(c,d));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(d,a));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(d,b));
-  BOOST_CHECK_EQUAL(true,  hook_STRING_ne(d,c));
-  BOOST_CHECK_EQUAL(false, hook_STRING_ne(d,d));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ne(a, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(a, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(a, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(a, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(b, a));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ne(b, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(b, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(b, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(c, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(c, b));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ne(c, c));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(c, d));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(d, a));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(d, b));
+  BOOST_CHECK_EQUAL(true, hook_STRING_ne(d, c));
+  BOOST_CHECK_EQUAL(false, hook_STRING_ne(d, d));
 }
 
 BOOST_AUTO_TEST_CASE(concat) {
@@ -215,20 +215,19 @@ BOOST_AUTO_TEST_CASE(concat) {
   BOOST_CHECK_EQUAL(0, memcmp(emptyCatL->data, a->data, len(emptyCatL)));
   BOOST_CHECK_EQUAL(len(emptyCatL), len(a));
 
-  auto catAll = hook_STRING_concat(hook_STRING_concat(a,b), c);
+  auto catAll = hook_STRING_concat(hook_STRING_concat(a, b), c);
   auto expected = makeString("hellohehf");
   BOOST_CHECK_EQUAL(0, memcmp(catAll->data, expected->data, len(catAll)));
   BOOST_CHECK_EQUAL(len(catAll), len(expected));
 }
-
 
 BOOST_AUTO_TEST_CASE(chr) {
   mpz_t a, b;
   mpz_init_set_ui(a, 65);
   mpz_init_set_ui(b, 32);
 
-  const string * A = hook_STRING_chr(a);
-  const string * space = hook_STRING_chr(b);
+  const string *A = hook_STRING_chr(a);
+  const string *space = hook_STRING_chr(b);
 
   BOOST_CHECK_EQUAL(A->data[0], 'A');
   BOOST_CHECK_EQUAL(len(A), 1);
@@ -268,17 +267,23 @@ BOOST_AUTO_TEST_CASE(substr) {
   mpz_init_set_si(_10, 10);
   mpz_init_set_si(_1024, 1024);
   mpz_init_set_si(_4096, 4096);
-  BOOST_CHECK_EQUAL(memcmp(hook_STRING_substr(catAll, _2, _9)->data, "llohehf", 7), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_STRING_substr(catAll, _2, _6)->data, "lloh", 4), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_STRING_substr(catAll, _0, _4)->data, "hell", 4), 0);
-  BOOST_CHECK_EQUAL(memcmp(hook_STRING_substr(catAll, _6, _9)->data, "ehf", 3), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_STRING_substr(catAll, _2, _9)->data, "llohehf", 7), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_STRING_substr(catAll, _2, _6)->data, "lloh", 4), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_STRING_substr(catAll, _0, _4)->data, "hell", 4), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_STRING_substr(catAll, _6, _9)->data, "ehf", 3), 0);
   BOOST_CHECK_THROW(hook_STRING_substr(catAll, _7, _40), std::invalid_argument);
   BOOST_CHECK_THROW(hook_STRING_substr(catAll, _8, _40), std::invalid_argument);
-  BOOST_CHECK_EQUAL(memcmp(hook_STRING_substr(catAll, _8, _9)->data, "f", 1), 0);
+  BOOST_CHECK_EQUAL(
+      memcmp(hook_STRING_substr(catAll, _8, _9)->data, "f", 1), 0);
   BOOST_CHECK_EQUAL(len(hook_STRING_substr(catAll, _9, _9)), 0);
-BOOST_CHECK_THROW(hook_STRING_substr(catAll, _8, _7), std::invalid_argument);
+  BOOST_CHECK_THROW(hook_STRING_substr(catAll, _8, _7), std::invalid_argument);
   BOOST_CHECK_THROW(hook_STRING_substr(catAll, _7, _10), std::invalid_argument);
-  BOOST_CHECK_THROW(hook_STRING_substr(catAll, _1024, _4096), std::invalid_argument);
+  BOOST_CHECK_THROW(
+      hook_STRING_substr(catAll, _1024, _4096), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(find) {
@@ -313,8 +318,10 @@ BOOST_AUTO_TEST_CASE(findChar) {
   mpz_init_set_si(a, 0);
   mpz_init_set_si(b, 1);
 
-  BOOST_CHECK_EQUAL(mpz_cmp_si(hook_STRING_findChar(haystack, needle, a), 0), 0);
-  BOOST_CHECK_EQUAL(mpz_cmp_si(hook_STRING_findChar(haystack, needle, b), 10), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_si(hook_STRING_findChar(haystack, needle, a), 0), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_si(hook_STRING_findChar(haystack, needle, b), 10), 0);
 }
 
 BOOST_AUTO_TEST_CASE(rfind) {
@@ -353,10 +360,11 @@ BOOST_AUTO_TEST_CASE(rfindChar) {
   mpz_init_set_si(a, 10);
   mpz_init_set_si(b, 9);
 
-  BOOST_CHECK_EQUAL(mpz_cmp_si(hook_STRING_rfindChar(haystack, needle, a), 10), 0);
-  BOOST_CHECK_EQUAL(mpz_cmp_si(hook_STRING_rfindChar(haystack, needle, b), 0), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_si(hook_STRING_rfindChar(haystack, needle, a), 10), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_si(hook_STRING_rfindChar(haystack, needle, b), 0), 0);
 }
-
 
 BOOST_AUTO_TEST_CASE(int2string) {
   mpz_t a;
@@ -422,7 +430,7 @@ BOOST_AUTO_TEST_CASE(string2float) {
   auto _float = makeString("8.0f");
   floating *result;
   result = hook_STRING_string2float(_float);
-  
+
   BOOST_CHECK_EQUAL(24, mpfr_get_prec(result->f));
   BOOST_CHECK_EQUAL(8, result->exp);
   BOOST_CHECK_EQUAL(mpfr_cmp_d(result->f, 8.0), 0);
@@ -472,41 +480,54 @@ BOOST_AUTO_TEST_CASE(replace) {
   mpz_init_set_si(d, 3);
   mpz_init_set_si(e, 4);
 
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replaceAll(replacee, matcher, replacer),
-        makeString("goodbye world goodbye world goodbye world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replace(replacee, matcher, replacer, a),
-        makeString("hello world hello world hello world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replace(replacee, matcher, replacer, b),
-        makeString("goodbye world hello world hello world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replace(replacee, matcher, replacer, c),
-        makeString("goodbye world goodbye world hello world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replace(replacee, matcher, replacer, d),
-        makeString("goodbye world goodbye world goodbye world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replace(replacee, matcher, replacer, e),
-        makeString("goodbye world goodbye world goodbye world he worl")));
-  BOOST_CHECK_EQUAL(true,
-      hook_STRING_eq(hook_STRING_replaceFirst(replacee, matcher, replacer),
-        makeString("goodbye world hello world hello world he worl")));
+  BOOST_CHECK_EQUAL(
+      true,
+      hook_STRING_eq(
+          hook_STRING_replaceAll(replacee, matcher, replacer),
+          makeString("goodbye world goodbye world goodbye world he worl")));
+  BOOST_CHECK_EQUAL(
+      true, hook_STRING_eq(
+                hook_STRING_replace(replacee, matcher, replacer, a),
+                makeString("hello world hello world hello world he worl")));
+  BOOST_CHECK_EQUAL(
+      true, hook_STRING_eq(
+                hook_STRING_replace(replacee, matcher, replacer, b),
+                makeString("goodbye world hello world hello world he worl")));
+  BOOST_CHECK_EQUAL(
+      true, hook_STRING_eq(
+                hook_STRING_replace(replacee, matcher, replacer, c),
+                makeString("goodbye world goodbye world hello world he worl")));
+  BOOST_CHECK_EQUAL(
+      true,
+      hook_STRING_eq(
+          hook_STRING_replace(replacee, matcher, replacer, d),
+          makeString("goodbye world goodbye world goodbye world he worl")));
+  BOOST_CHECK_EQUAL(
+      true,
+      hook_STRING_eq(
+          hook_STRING_replace(replacee, matcher, replacer, e),
+          makeString("goodbye world goodbye world goodbye world he worl")));
+  BOOST_CHECK_EQUAL(
+      true, hook_STRING_eq(
+                hook_STRING_replaceFirst(replacee, matcher, replacer),
+                makeString("goodbye world hello world hello world he worl")));
 }
 
 BOOST_AUTO_TEST_CASE(countAllOccurrences) {
   auto replacee = makeString("hello world hello world hello world he worl");
   auto matcher = makeString("hello");
-  BOOST_CHECK_EQUAL(mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 3), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 3), 0);
 
   replacee = makeString("hel world hel world heo world he worl");
   matcher = makeString("hello");
-  BOOST_CHECK_EQUAL(mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 0), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 0), 0);
 
   replacee = makeString("hel world hel world hello world he worl");
   matcher = makeString("hello");
-  BOOST_CHECK_EQUAL(mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 1), 0);
+  BOOST_CHECK_EQUAL(
+      mpz_cmp_ui(hook_STRING_countAllOccurrences(replacee, matcher), 1), 0);
 }
 
 BOOST_AUTO_TEST_CASE(buffer_empty) {


### PR DESCRIPTION
This PR introduces a global clang-format style, and applies it to the llvm-backend code.

Of the commits in this PR, only https://github.com/kframework/llvm-backend/pull/430/commits/316754483f188151b7ee46f8fda0fb9193841402 is non-trivial.

### Why automatically format?

Adopting a consistent style for our C++ code means that we're all on the same page when formatting, and automating it with clang-format means that we don't have to think about formatting or style when writing the code.

Pretty much every big C++ project will use clang-format to keep things consistent; it's a very standard tool to use, and is well-supported and maintained by the LLVM project.

### Using clang-format

To install clang-format:
```console
brew install clang-format    # macOS / Homebrew
apt install clang-format     # Ubuntu / APT
```

There are several ways to use clang-format:
* **Command line:** you can run it on a single file (in place) with `clang-format -i $FILE`; doing this manually is time consuming for an entire project.
* **Editor support:** every mainstream editor will have a plugin for clang-format that either exposes a formatting shortcut for the current file, or formats automatically on save. This is the best way to use it.
* **Git commit hooks:** it's possible to run clang-format automatically on commit, but this tends to lead to dirty commits and isn't a good way to work.
* **In CI:** usually this is a read-only check on push to make sure that new code is formatted correctly. I can add this to CI if we adopt a style.

Some editor plugins:
* [Vim](https://github.com/rhysd/vim-clang-format)
* [CLion](https://www.jetbrains.com/help/clion/clangformat-as-alternative-formatter.html)
* [Emacs](https://github.com/SavchenkoValeriy/emacs-clang-format-plus)
* [VS Code](https://code.visualstudio.com/docs/cpp/cpp-ide)
* [Sublime Text](https://packagecontrol.io/packages/Clang%20Format) 

### Code style

The tool picks up a style defined in a `.clang-format` file at the root of the project; the style is defined in terms of key-value pairs that usually modify a root style (for example, the style I've defined here is based on the WebKit style).

There are [lots of options here](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) that control how the formatting is applied; I'm more than happy to bikeshed any of the rules I've introduced in this PR.