### PR TITLE
Enable collection during allocation

### DIFF
--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -34,7 +34,7 @@ llvm::StructType *getTypeByName(llvm::Module *module, std::string name);
 
 std::string getMangledTypeStr(llvm::Type *Ty, bool &HasUnnamedType);
 
-void insertCallToGC(llvm::BasicBlock *BB, bool afterStep);
+void insertCallToClear(llvm::BasicBlock *BB);
 
 } // namespace kllvm
 

--- a/include/kllvm/codegen/Util.h
+++ b/include/kllvm/codegen/Util.h
@@ -34,6 +34,8 @@ llvm::StructType *getTypeByName(llvm::Module *module, std::string name);
 
 std::string getMangledTypeStr(llvm::Type *Ty, bool &HasUnnamedType);
 
+void insertCallToGC(llvm::BasicBlock *BB, bool afterStep);
+
 } // namespace kllvm
 
 #endif // KLLVM_UTIL_H

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -13,7 +13,6 @@ extern const size_t BLOCK_SIZE;
 
 char youngspace_collection_id(void);
 char oldspace_collection_id(void);
-size_t youngspace_size(void);
 
 // allocates exactly requested bytes into the young generation
 void *koreAlloc(size_t requested);

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -33,7 +33,7 @@ void *koreAllocAlwaysGC(size_t requested);
 // swaps the two semispace of the young generation as part of garbage collection
 // if the swapOld flag is set, it also swaps the two semispaces of the old
 // generation
-void koreAllocSwap(bool swapOld, bool resetAlwaysGC);
+void koreAllocSwap(bool swapOld);
 // resets the alwaysgcspace
 void koreClear(void);
 // resizes the last allocation into the young generation

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -35,6 +35,8 @@ void *koreAllocAlwaysGC(size_t requested);
 // if the swapOld flag is set, it also swaps the two semispaces of the old
 // generation
 void koreAllocSwap(bool swapOld, bool resetAlwaysGC);
+// resets the alwaysgcspace
+void koreClear(void);
 // resizes the last allocation into the young generation
 void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t oldrequest);
 // allocator hook for the GMP library

--- a/include/runtime/alloc.h
+++ b/include/runtime/alloc.h
@@ -34,7 +34,7 @@ void *koreAllocAlwaysGC(size_t requested);
 // swaps the two semispace of the young generation as part of garbage collection
 // if the swapOld flag is set, it also swaps the two semispaces of the old
 // generation
-void koreAllocSwap(bool swapOld);
+void koreAllocSwap(bool swapOld, bool resetAlwaysGC);
 // resizes the last allocation into the young generation
 void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t oldrequest);
 // allocator hook for the GMP library

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -3,6 +3,7 @@
 
 #include "runtime/header.h"
 #include <iterator>
+#include <map>
 #include <type_traits>
 #include <vector>
 
@@ -26,6 +27,13 @@ using set_node = set::iterator::node_t;
 using set_impl = set::iterator::tree_t;
 
 void parseStackMap(void);
+
+struct gc_relocation {
+  layoutitem base;
+  uint64_t derived_offset;
+};
+
+extern std::map<void *, std::vector<gc_relocation>> StackMap;
 
 extern "C" {
 extern size_t numBytesLiveAtCollection[1 << AGE_WIDTH];

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -38,7 +38,7 @@ void migrate_map(void *m);
 void migrate_set(void *s);
 void migrate_collection_node(void **nodePtr);
 void setKoreMemoryFunctionsForGMP(void);
-void koreCollect(void);
+void koreCollect(bool afterStep);
 }
 
 #ifdef GC_DBG

--- a/include/runtime/collect.h
+++ b/include/runtime/collect.h
@@ -46,7 +46,7 @@ void migrate_map(void *m);
 void migrate_set(void *s);
 void migrate_collection_node(void **nodePtr);
 void setKoreMemoryFunctionsForGMP(void);
-void koreCollect(bool afterStep);
+void koreCollect(void);
 }
 
 #ifdef GC_DBG

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -124,6 +124,9 @@ public:
   block *elem;
 };
 
+extern bool gc_enabled;
+extern bool deferred_collection;
+
 struct kore_alloc_heap {
 
   template <typename... Tags>

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -103,6 +103,7 @@ typedef struct {
 
 bool hook_KEQUAL_eq(block *, block *);
 bool during_gc(void);
+void koreCollect(void);
 size_t hash_k(block *);
 void k_hash(block *, void *);
 bool hash_enter(void);

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -134,7 +134,10 @@ struct kore_alloc_heap {
     if (during_gc()) {
       return ::operator new(size);
     } else {
+      bool enabled = gc_enabled;
+      gc_enabled = false;
       string *result = (string *)koreAllocToken(size + sizeof(blockheader));
+      gc_enabled = enabled;
       set_len(result, size);
       return result->data;
     }

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -126,7 +126,6 @@ public:
 };
 
 extern bool gc_enabled;
-extern bool deferred_collection;
 
 struct kore_alloc_heap {
 

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1282,14 +1282,7 @@ bool makeFunction(
     }
   }
 
-  auto koreCollect = getOrInsertFunction(
-      Module, "tryKoreCollect",
-      llvm::FunctionType::get(
-          llvm::Type::getVoidTy(Module->getContext()),
-          {llvm::Type::getInt1Ty(Module->getContext())}, false));
-  llvm::CallInst::Create(
-      koreCollect, {llvm::ConstantInt::getFalse(Module->getContext())}, "",
-      block);
+  insertCallToGC(block, false);
 
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   llvm::Value *retval = creator(pattern).first;
@@ -1399,14 +1392,7 @@ std::string makeApplyRuleFunction(
     }
   }
 
-  auto koreCollect = getOrInsertFunction(
-      Module, "tryKoreCollect",
-      llvm::FunctionType::get(
-          llvm::Type::getVoidTy(Module->getContext()),
-          {llvm::Type::getInt1Ty(Module->getContext())}, false));
-  llvm::CallInst::Create(
-      koreCollect, {llvm::ConstantInt::getFalse(Module->getContext())}, "",
-      block);
+  insertCallToGC(block, false);
 
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   std::vector<llvm::Value *> args;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1281,6 +1281,16 @@ bool makeFunction(
           llvm::dyn_cast<llvm::DIType>(debugArgs[i])->getName().str());
     }
   }
+
+  auto koreCollect = getOrInsertFunction(
+      Module, "tryKoreCollect",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(Module->getContext()),
+          {llvm::Type::getInt1Ty(Module->getContext())}, false));
+  llvm::CallInst::Create(
+      koreCollect, {llvm::ConstantInt::getFalse(Module->getContext())}, "",
+      block);
+
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   llvm::Value *retval = creator(pattern).first;
   if (funcType->getReturnType()
@@ -1388,6 +1398,16 @@ std::string makeApplyRuleFunction(
           llvm::dyn_cast<llvm::DIType>(debugArgs[i])->getName().str());
     }
   }
+
+  auto koreCollect = getOrInsertFunction(
+      Module, "tryKoreCollect",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(Module->getContext()),
+          {llvm::Type::getInt1Ty(Module->getContext())}, false));
+  llvm::CallInst::Create(
+      koreCollect, {llvm::ConstantInt::getFalse(Module->getContext())}, "",
+      block);
+
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   std::vector<llvm::Value *> args;
   std::vector<llvm::Type *> types;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1280,8 +1280,6 @@ bool makeFunction(
     }
   }
 
-  insertCallToGC(block, false);
-
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   llvm::Value *retval = creator(pattern).first;
   if (funcType->getReturnType()
@@ -1389,8 +1387,6 @@ std::string makeApplyRuleFunction(
           llvm::dyn_cast<llvm::DIType>(debugArgs[i])->getName().str());
     }
   }
-
-  insertCallToGC(block, false);
 
   CreateTerm creator = CreateTerm(subst, definition, block, Module, false);
   std::vector<llvm::Value *> args;

--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -1037,13 +1037,6 @@ llvm::Value *CreateTerm::notInjectionCase(
     } else {
       ChildValue = (*this)(child.get()).first;
     }
-    llvm::Type *ChildPtrType
-        = llvm::PointerType::get(BlockType->elements()[idx], 1);
-    if (ChildValue->getType() == ChildPtrType) {
-      ChildValue = new llvm::LoadInst(
-          ChildValue->getType()->getPointerElementType(), ChildValue, "",
-          CurrentBlock);
-    }
     children.push_back(ChildValue);
     idx++;
   }
@@ -1062,6 +1055,11 @@ llvm::Value *CreateTerm::notInjectionCase(
         {llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), 0),
          llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++)},
         "", CurrentBlock);
+    if (ChildValue->getType() == ChildPtr->getType()) {
+      ChildValue = new llvm::LoadInst(
+          ChildValue->getType()->getPointerElementType(), ChildValue, "",
+          CurrentBlock);
+    }
     new llvm::StoreInst(ChildValue, ChildPtr, CurrentBlock);
   }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -643,14 +643,7 @@ void makeEvalOrAnywhereFunction(
   initChoiceBuffer(
       dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
-  auto koreCollect = getOrInsertFunction(
-      module, "tryKoreCollect",
-      llvm::FunctionType::get(
-          llvm::Type::getVoidTy(module->getContext()),
-          {llvm::Type::getInt1Ty(module->getContext())}, false));
-  llvm::CallInst::Create(
-      koreCollect, {llvm::ConstantInt::getFalse(module->getContext())}, "",
-      block);
+  insertCallToGC(block, false);
 
   int i = 0;
   Decision codegen(
@@ -800,15 +793,7 @@ llvm::BasicBlock *stepFunctionHeader(
       module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(stuck, merge, isFinished, block);
 
-  auto koreCollect = getOrInsertFunction(
-      module, "tryKoreCollect",
-      llvm::FunctionType::get(
-          llvm::Type::getVoidTy(module->getContext()),
-          {llvm::Type::getInt1Ty(module->getContext())}, false));
-  auto call = llvm::CallInst::Create(
-      koreCollect, {llvm::ConstantInt::getTrue(module->getContext())}, "",
-      merge);
-  setDebugLoc(call);
+  insertCallToGC(merge, true);
   return merge;
 }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -882,10 +882,7 @@ void makeStepFunction(
     auto result = new llvm::LoadInst(bufType, resultBuffer, "", stuck);
     llvm::ReturnInst::Create(module->getContext(), result, stuck);
   } else {
-    auto phi = llvm::PHINode::Create(val->getType(), 2, "phi_1", stuck);
-    phi->addIncoming(val, block);
-    phi->addIncoming(val, pre_stuck);
-    llvm::ReturnInst::Create(module->getContext(), phi, stuck);
+    llvm::ReturnInst::Create(module->getContext(), val, stuck);
   }
 
   codegen(dt);

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -643,8 +643,6 @@ void makeEvalOrAnywhereFunction(
   initChoiceBuffer(
       dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
-  insertCallToGC(block, false);
-
   int i = 0;
   Decision codegen(
       definition, block, fail, jump, choiceBuffer, choiceDepth, module,
@@ -793,7 +791,7 @@ llvm::BasicBlock *stepFunctionHeader(
       module->getContext(), "step", block->getParent());
   llvm::BranchInst::Create(stuck, merge, isFinished, block);
 
-  insertCallToGC(merge, true);
+  insertCallToClear(merge);
   return merge;
 }
 

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -643,6 +643,15 @@ void makeEvalOrAnywhereFunction(
   initChoiceBuffer(
       dt, module, block, stuck, fail, &choiceBuffer, &choiceDepth, &jump);
 
+  auto koreCollect = getOrInsertFunction(
+      module, "tryKoreCollect",
+      llvm::FunctionType::get(
+          llvm::Type::getVoidTy(module->getContext()),
+          {llvm::Type::getInt1Ty(module->getContext())}, false));
+  llvm::CallInst::Create(
+      koreCollect, {llvm::ConstantInt::getFalse(module->getContext())}, "",
+      block);
+
   int i = 0;
   Decision codegen(
       definition, block, fail, jump, choiceBuffer, choiceDepth, module,

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -778,7 +778,7 @@ void makeAnywhereFunction(
   makeEvalOrAnywhereFunction(function, definition, module, dt, addOwise);
 }
 
-std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
+llvm::BasicBlock *stepFunctionHeader(
     unsigned ordinal, llvm::Module *module, KOREDefinition *definition,
     llvm::BasicBlock *block, llvm::BasicBlock *stuck,
     std::vector<llvm::Value *> args, std::vector<ValueType> types) {
@@ -787,30 +787,20 @@ std::pair<std::vector<llvm::Value *>, llvm::BasicBlock *> stepFunctionHeader(
       llvm::FunctionType::get(
           llvm::Type::getInt1Ty(module->getContext()), {}, false));
   auto isFinished = llvm::CallInst::Create(finished, {}, "", block);
-  auto checkCollect = llvm::BasicBlock::Create(
-      module->getContext(), "checkCollect", block->getParent());
-  llvm::BranchInst::Create(stuck, checkCollect, isFinished, block);
-
-  auto collection = getOrInsertFunction(
-      module, "is_collection",
-      llvm::FunctionType::get(
-          llvm::Type::getInt1Ty(module->getContext()), {}, false));
-  auto isCollection = llvm::CallInst::Create(collection, {}, "", checkCollect);
-  setDebugLoc(isCollection);
-  auto collect = llvm::BasicBlock::Create(
-      module->getContext(), "isCollect", block->getParent());
   auto merge = llvm::BasicBlock::Create(
       module->getContext(), "step", block->getParent());
-  llvm::BranchInst::Create(collect, merge, isCollection, checkCollect);
+  llvm::BranchInst::Create(stuck, merge, isFinished, block);
 
   auto koreCollect = getOrInsertFunction(
-      module, "koreCollect",
+      module, "tryKoreCollect",
       llvm::FunctionType::get(
-          llvm::Type::getVoidTy(module->getContext()), {}, false));
-  auto call = llvm::CallInst::Create(koreCollect, {}, "", collect);
+          llvm::Type::getVoidTy(module->getContext()),
+          {llvm::Type::getInt1Ty(module->getContext())}, false));
+  auto call = llvm::CallInst::Create(
+      koreCollect, {llvm::ConstantInt::getTrue(module->getContext())}, "",
+      merge);
   setDebugLoc(call);
-  llvm::BranchInst::Create(merge, collect);
-  return std::make_pair(args, merge);
+  return merge;
 }
 
 void makeStepFunction(
@@ -888,23 +878,19 @@ void makeStepFunction(
   llvm::BranchInst::Create(stuck, pre_stuck);
   auto result = stepFunctionHeader(
       0, module, definition, block, stuck, {val}, {{SortCategory::Symbol, 0}});
-  auto collectedVal = result.first[0];
-  collectedVal->setName("_1");
+  val->setName("_1");
   Decision codegen(
-      definition, result.second, fail, jump, choiceBuffer, choiceDepth, module,
+      definition, result, fail, jump, choiceBuffer, choiceDepth, module,
       {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, resultBuffer,
       resultCount, resultCapacity);
-  codegen.store(
-      std::make_pair(collectedVal->getName().str(), collectedVal->getType()),
-      collectedVal);
+  codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
   if (search) {
     auto result = new llvm::LoadInst(bufType, resultBuffer, "", stuck);
     llvm::ReturnInst::Create(module->getContext(), result, stuck);
   } else {
-    auto phi
-        = llvm::PHINode::Create(collectedVal->getType(), 2, "phi_1", stuck);
+    auto phi = llvm::PHINode::Create(val->getType(), 2, "phi_1", stuck);
     phi->addIncoming(val, block);
-    phi->addIncoming(collectedVal, pre_stuck);
+    phi->addIncoming(val, pre_stuck);
     llvm::ReturnInst::Create(module->getContext(), phi, stuck);
   }
 
@@ -1084,10 +1070,10 @@ void makeStepFunction(
       axiom->getOrdinal(), module, definition, block, stuck, args, types);
   i = 0;
   Decision codegen(
-      definition, header.second, fail, jump, choiceBuffer, choiceDepth, module,
+      definition, header, fail, jump, choiceBuffer, choiceDepth, module,
       {SortCategory::Symbol, 0}, nullptr, nullptr, nullptr, nullptr, nullptr,
       nullptr);
-  for (auto val : header.first) {
+  for (auto val : args) {
     val->setName(res.residuals[i].occurrence.substr(0, max_name_length));
     codegen.store(std::make_pair(val->getName().str(), val->getType()), val);
     stuckSubst.insert({val->getName(), phis[i]});

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -104,18 +104,13 @@ llvm::StructType *getTypeByName(llvm::Module *module, std::string name) {
   return t;
 }
 
-void insertCallToGC(llvm::BasicBlock *block, bool afterStep) {
+void insertCallToClear(llvm::BasicBlock *block) {
   llvm::Module *Module = block->getParent()->getParent();
-  auto koreCollect = getOrInsertFunction(
-      Module, "tryKoreCollect",
+  auto koreClear = getOrInsertFunction(
+      Module, "koreClear",
       llvm::FunctionType::get(
-          llvm::Type::getVoidTy(Module->getContext()),
-          {llvm::Type::getInt1Ty(Module->getContext())}, false));
-  llvm::CallInst::Create(
-      koreCollect,
-      {llvm::ConstantInt::get(
-          llvm::Type::getInt1Ty(Module->getContext()), afterStep)},
-      "", block);
+          llvm::Type::getVoidTy(Module->getContext()), {}, false));
+  llvm::CallInst::Create(koreClear, {}, "", block);
 }
 
 } // namespace kllvm

--- a/lib/codegen/Util.cpp
+++ b/lib/codegen/Util.cpp
@@ -113,7 +113,9 @@ void insertCallToGC(llvm::BasicBlock *block, bool afterStep) {
           {llvm::Type::getInt1Ty(Module->getContext())}, false));
   llvm::CallInst::Create(
       koreCollect,
-      {llvm::ConstantInt::getBool(Module->getContext(), afterStep)}, "", block);
+      {llvm::ConstantInt::get(
+          llvm::Type::getInt1Ty(Module->getContext()), afterStep)},
+      "", block);
 }
 
 } // namespace kllvm

--- a/lib/llvm/EmitGCLayoutInfo.cpp
+++ b/lib/llvm/EmitGCLayoutInfo.cpp
@@ -55,28 +55,20 @@ struct EmitGCLayoutInfo : public ModulePass {
 #else
             for (auto &R : S->getRelocates()) {
 #endif
-              auto BaseArg = R->getBasePtr();
-              auto DerivedArg = R->getDerivedPtr();
-              std::string name;
-              StructType *StructTy;
-              if (BaseArg != DerivedArg) {
-                name = "block";
-                StructTy = nullptr;
-              } else {
-                auto *Ty = BaseArg->getType()->getPointerElementType();
-                if (Ty->isIntegerTy()) {
-                  i++;
-                  continue;
-                }
-                if (!Ty->isStructTy()) {
-                  error(Ty);
-                }
-                StructTy = cast<StructType>(Ty);
-                if (!StructTy->hasName()) {
-                  error(StructTy);
-                }
-                name = StructTy->getName().str();
+              auto Arg = R->getBasePtr();
+              auto *Ty = Arg->getType()->getPointerElementType();
+              if (Ty->isIntegerTy()) {
+                i++;
+                continue;
               }
+              if (!Ty->isStructTy()) {
+                error(Ty);
+              }
+              auto StructTy = cast<StructType>(Ty);
+              if (!StructTy->hasName()) {
+                error(StructTy);
+              }
+              std::string name = StructTy->getName().str();
               ValueType cat;
               cat.bits = 0;
               if (name == "map") {

--- a/lib/llvm/EmitGCLayoutInfo.cpp
+++ b/lib/llvm/EmitGCLayoutInfo.cpp
@@ -61,12 +61,9 @@ struct EmitGCLayoutInfo : public ModulePass {
                 i++;
                 continue;
               }
-              if (!Ty->isStructTy()) {
+              auto StructTy = dyn_cast<StructType>(Ty);
+              if (!StructTy || !StructTy->hasName()) {
                 error(Ty);
-              }
-              auto StructTy = cast<StructType>(Ty);
-              if (!StructTy->hasName()) {
-                error(StructTy);
               }
               std::string name = StructTy->getName().str();
               ValueType cat;

--- a/lib/llvm/EmitGCLayoutInfo.cpp
+++ b/lib/llvm/EmitGCLayoutInfo.cpp
@@ -55,20 +55,28 @@ struct EmitGCLayoutInfo : public ModulePass {
 #else
             for (auto &R : S->getRelocates()) {
 #endif
-              auto Arg = R->getBasePtr();
-              auto *Ty = Arg->getType()->getPointerElementType();
-              if (Ty->isIntegerTy()) {
-                i++;
-                continue;
+              auto BaseArg = R->getBasePtr();
+              auto DerivedArg = R->getDerivedPtr();
+              std::string name;
+              StructType *StructTy;
+              if (BaseArg != DerivedArg) {
+                name = "block";
+                StructTy = nullptr;
+              } else {
+                auto *Ty = BaseArg->getType()->getPointerElementType();
+                if (Ty->isIntegerTy()) {
+                  i++;
+                  continue;
+                }
+                if (!Ty->isStructTy()) {
+                  error(Ty);
+                }
+                StructTy = cast<StructType>(Ty);
+                if (!StructTy->hasName()) {
+                  error(StructTy);
+                }
+                name = StructTy->getName().str();
               }
-              if (!Ty->isStructTy()) {
-                error(Ty);
-              }
-              auto StructTy = cast<StructType>(Ty);
-              if (!StructTy->hasName()) {
-                error(StructTy);
-              }
-              std::string name = StructTy->getName().str();
               ValueType cat;
               cat.bits = 0;
               if (name == "map") {

--- a/lib/llvm/EmitGCLayoutInfo.cpp
+++ b/lib/llvm/EmitGCLayoutInfo.cpp
@@ -19,9 +19,9 @@ struct EmitGCLayoutInfo : public ModulePass {
       : ModulePass(ID) { }
 
   void error(Type *Ty) {
-    llvm::errs() << "Could not identify garbage collection information! This "
-                    "is a bug in the llvm backend of K\n";
-    Ty->print(llvm::errs());
+    errs() << "Could not identify garbage collection information! This "
+              "is a bug in the llvm backend of K\n";
+    Ty->print(errs());
     abort();
   }
 
@@ -64,7 +64,7 @@ struct EmitGCLayoutInfo : public ModulePass {
               if (!Ty->isStructTy()) {
                 error(Ty);
               }
-              auto StructTy = llvm::cast<StructType>(Ty);
+              auto StructTy = cast<StructType>(Ty);
               if (!StructTy->hasName()) {
                 error(StructTy);
               }

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -56,9 +56,11 @@ bool youngspaceAlmostFull(size_t threshold) {
   return (totalBytes - freeBytes) * 100 > threshold * 95;
 }
 
-void koreAllocSwap(bool swapOld) {
+void koreAllocSwap(bool swapOld, bool resetAlwaysGC) {
   arenaSwapAndClear(&youngspace);
-  arenaClear(&alwaysgcspace);
+  if (resetAlwaysGC) {
+    arenaClear(&alwaysgcspace);
+  }
   if (swapOld) {
     arenaSwapAndClear(&oldspace);
   }

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -39,23 +39,6 @@ char oldspace_collection_id() {
   return getArenaCollectionSemispaceID(&oldspace);
 }
 
-size_t youngspace_size(void) {
-  return arenaSize(&youngspace);
-}
-
-bool youngspaceAlmostFull(size_t threshold) {
-  char *nextBlock = *(char **)youngspace.block_start;
-  if (nextBlock) {
-    // not on the last block, so short circuit and assume that we can keep
-    // allocating for now.
-    return false;
-  }
-  ptrdiff_t freeBytes = youngspace.block_end - youngspace.block;
-  size_t totalBytes
-      = youngspace.num_blocks * (BLOCK_SIZE - sizeof(memory_block_header));
-  return (totalBytes - freeBytes) * 100 > threshold * 95;
-}
-
 void koreAllocSwap(bool swapOld, bool resetAlwaysGC) {
   arenaSwapAndClear(&youngspace);
   if (resetAlwaysGC) {

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -66,6 +66,10 @@ void koreAllocSwap(bool swapOld, bool resetAlwaysGC) {
   }
 }
 
+void koreClear() {
+  arenaClear(&alwaysgcspace);
+}
+
 void setKoreMemoryFunctionsForGMP() {
   mp_set_memory_functions(koreAllocMP, koreReallocMP, koreFree);
 }

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -125,13 +125,19 @@ void *koreResizeLastAlloc(void *oldptr, size_t newrequest, size_t last_size) {
 }
 
 void *koreAllocMP(size_t requested) {
+  bool enabled = gc_enabled;
+  gc_enabled = false;
   string *_new = (string *)koreAllocToken(sizeof(string) + requested);
+  gc_enabled = enabled;
   set_len(_new, requested);
   return _new->data;
 }
 
 void *koreReallocMP(void *ptr, size_t old_size, size_t new_size) {
+  bool enabled = gc_enabled;
+  gc_enabled = false;
   string *_new = (string *)koreAllocToken(sizeof(string) + new_size);
+  gc_enabled = enabled;
   size_t min = old_size > new_size ? new_size : old_size;
   memcpy(_new->data, ptr, min);
   set_len(_new, new_size);

--- a/runtime/alloc/alloc.cpp
+++ b/runtime/alloc/alloc.cpp
@@ -39,11 +39,8 @@ char oldspace_collection_id() {
   return getArenaCollectionSemispaceID(&oldspace);
 }
 
-void koreAllocSwap(bool swapOld, bool resetAlwaysGC) {
+void koreAllocSwap(bool swapOld) {
   arenaSwapAndClear(&youngspace);
-  if (resetAlwaysGC) {
-    arenaClear(&alwaysgcspace);
-  }
   if (swapOld) {
     arenaSwapAndClear(&oldspace);
   }

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -113,7 +113,6 @@ static void freshBlock(struct arena *Arena) {
 }
 
 bool gc_enabled;
-bool deferred_collection;
 
 static __attribute__((noinline)) void *
 doAllocSlow(size_t requested, struct arena *Arena) {
@@ -125,8 +124,6 @@ doAllocSlow(size_t requested, struct arena *Arena) {
   } else {
     if (gc_enabled && !during_gc()) {
       koreCollect();
-    } else if (!during_gc()) {
-      deferred_collection = true;
     }
     if (Arena->block + requested <= Arena->block_end) {
       void *result = Arena->block;

--- a/runtime/alloc/arena.cpp
+++ b/runtime/alloc/arena.cpp
@@ -143,9 +143,11 @@ doAllocSlow(size_t requested, struct arena *Arena) {
   }
 }
 
+#define COLLECT_BUFFER_SIZE 1024
+
 __attribute__((always_inline)) void *
 arenaAlloc(struct arena *Arena, size_t requested) {
-  if (Arena->block + requested > Arena->block_end) {
+  if (Arena->block + requested + COLLECT_BUFFER_SIZE > Arena->block_end) {
     return doAllocSlow(requested, Arena);
   }
   void *result = Arena->block;

--- a/runtime/collect/StackMapParser.cpp
+++ b/runtime/collect/StackMapParser.cpp
@@ -18,45 +18,63 @@ struct StackMapFunction {
 // see https://llvm.org/docs/StackMaps.html
 void parseStackMap() {
   char *stackMap = getStackMap();
+  // Header[0]
   char version = *stackMap;
   if (version != 3) {
     abort();
   }
+  // NumFunctions
   uint32_t NumFunctions = *(uint32_t *)(stackMap + 4);
+  // NumConstants
   uint32_t NumConstants = *(uint32_t *)(stackMap + 8);
   std::vector<StackMapFunction> functions;
   for (int i = 0; i < NumFunctions; i++) {
+    // StkSizeRecord[i].Function Address
     uint64_t address = *(uint64_t *)(stackMap + 16 + i * 24);
+    // StkSizeRecord[i].Record Count
     uint64_t records = *(uint64_t *)(stackMap + 32 + i * 24);
     functions.push_back({address, records});
   }
+  // StkMapRecord[0]
   char *stackMapRecord = stackMap + 16 + NumFunctions * 24 + NumConstants * 8;
   for (StackMapFunction func : functions) {
     for (int i = 0; i < func.NumRecords; i++) {
+      // StkMapRecord[i].PatchPoint ID
       uint64_t StatepointId = *(uint64_t *)(stackMapRecord);
+      // StkMapRecord[i].Instruction Offset
       uint32_t InstructionOffset = *(uint32_t *)(stackMapRecord + 8);
+      // StkMapRecord[i].NumLocations
       uint16_t NumLocations = *(uint16_t *)(stackMapRecord + 14);
       void *ip = (void *)(func.FunctionAddress + InstructionOffset);
+      // third location record in a statepoint is always the number of Deopt
+      // Locations StkMapRecord[i].Location[2].SmallConstant
       int32_t NumDeopts = *(int32_t *)(stackMapRecord + 24 + 2 * 12);
       uint16_t RelocationOffset = 0;
+      // after the three constant Locations in a statepoint, and after any Deopt
+      // Locations that exist, the remaining locations are in pairs and
+      // represent relocations
       for (uint16_t j = 3 + NumDeopts; j < NumLocations; j += 2) {
+        // StkMapRecord[i].Location[j].Type
         uint8_t base_type = *(uint8_t *)(stackMapRecord + 16 + j * 12);
-        if (base_type == 5) {
-          // a ConstantOffset gc root is one which corresponds to something the
+        if (base_type == 5 /* ConstIndex */) {
+          // a ConstIndex gc root is one which corresponds to something the
           // compiler was able to statically determine was a constructor with
           // zero children. Such terms do not actually live on the heap and
           // thus do not need to be relocated.
           RelocationOffset++;
           continue;
         }
-        if (base_type != 3) {
+        if (base_type != 3 /* Indirect */) {
           abort();
         }
+        // StkMapRecord[i].Location[j+1].Type
         uint8_t derived_type = *(uint8_t *)(stackMapRecord + 16 + (j + 1) * 12);
         if (derived_type != base_type) {
           abort();
         }
+        // StkMapRecord[i].Location[j].Offset
         int32_t base_offset = *(int32_t *)(stackMapRecord + 24 + j * 12);
+        // StkMapRecord[i].Location[j+1].Offset
         int32_t derived_offset
             = *(int32_t *)(stackMapRecord + 24 + (j + 1) * 12);
         layoutitem layout;
@@ -70,15 +88,21 @@ void parseStackMap() {
         StackMap[ip].push_back(reloc);
         RelocationOffset++;
       }
+      // StkMapRecord[i].Location[NumLocations] (ie, end of Locations)
       stackMapRecord += 16 + NumLocations * 12;
       if (NumLocations % 2 == 1) {
+        // StkMapRecord[i].Padding
         stackMapRecord += 4;
       }
+      // StkMapRecord[i].NumLiveOuts
       uint16_t NumLiveOuts = *(uint16_t *)(stackMapRecord + 2);
+      // StkMapRecord[i].LiveOuts[NumLiveOuts] (ie, end of LiveOuts)
       stackMapRecord += 4 + 4 * NumLiveOuts;
       if (NumLiveOuts % 2 == 0) {
+        // StkMapRecord[i].Padding
         stackMapRecord += 4;
       }
+      // stackMapRecord is now at StkMapRecord[i+1]
     }
   }
 }

--- a/runtime/collect/StackMapParser.cpp
+++ b/runtime/collect/StackMapParser.cpp
@@ -8,7 +8,7 @@ extern char gc_stackmap_layoutinfo[];
 extern unsigned int gc_stackmap_num_relocations;
 }
 
-std::map<void *, std::vector<layoutitem>> StackMap;
+std::map<void *, std::vector<gc_relocation>> StackMap;
 
 struct StackMapFunction {
   uint64_t FunctionAddress;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -394,16 +394,6 @@ void koreCollect(void) {
   is_gc = false;
 }
 
-void tryKoreCollect(bool afterStep) {
-  if (deferred_collection && gc_enabled) {
-    koreCollect();
-    deferred_collection = false;
-  }
-  if (afterStep) {
-    koreClear();
-  }
-}
-
 void freeAllKoreMem() {
   koreCollect();
   koreClear();

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -298,7 +298,7 @@ static std::vector<gc_root> scanStackRoots(void) {
   return gc_roots;
 }
 
-void koreCollect(void) {
+void koreCollect(bool afterStep) {
   is_gc = true;
   collect_old = shouldCollectOldGen();
   MEM_LOG("Starting garbage collection\n");
@@ -311,7 +311,7 @@ void koreCollect(void) {
   }
   char *current_alloc_ptr = *young_alloc_ptr();
 #endif
-  koreAllocSwap(collect_old);
+  koreAllocSwap(collect_old, afterStep);
 #ifdef GC_DBG
   for (int i = 0; i < 2048; i++) {
     numBytesLiveAtCollection[i] = 0;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -297,9 +297,14 @@ static std::vector<gc_root> scanStackRoots(void) {
           char **base_ptr = (char **)(((char *)sp) + Reloc.base.offset);
           char **derived_ptr = (char **)(((char *)sp) + Reloc.derived_offset);
           ptrdiff_t derived_offset = *derived_ptr - *base_ptr;
-          gc_roots.push_back(
-              {base_ptr, derived_ptr, Reloc.base.cat, derived_offset,
-               newBasePtr});
+          if (derived_offset != 0) {
+            gc_roots.push_back(
+                {base_ptr, derived_ptr, SYMBOL_LAYOUT, derived_offset,
+                 newBasePtr});
+          } else {
+            gc_roots.push_back(
+                {base_ptr, derived_ptr, Reloc.base.cat, 0, newBasePtr});
+          }
         }
       }
     }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -328,6 +328,14 @@ void koreCollect(bool afterStep) {
     char **derived_ptr
         = (char **)(((char *)roots[i].bp) + roots[i].layout.derived_offset);
     ptrdiff_t derived_offset = *derived_ptr - *base_ptr;
+    if (*base_ptr == nullptr) {
+      // this can happen because RewriteStatepointsForGC treats the base pointer
+      // of undef as equal to null. As a result, the case where the base pointer
+      // is null is a case when the stack map contains a particular entry, but
+      // it is dynamically dead on this particular loop iteration. We can thus
+      // skip this relocation since there is no live object here.
+      continue;
+    }
     migrate_child(roots[i].bp, &roots[i].layout.base, 0, true);
     if (base_ptr != derived_ptr) {
       *derived_ptr = *base_ptr + derived_offset;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -348,14 +348,14 @@ void koreCollect(bool afterStep) {
     if (mem_block_start(previous_oldspace_alloc_ptr + 1)
         == previous_oldspace_alloc_ptr) {
       // this means that the previous oldspace allocation pointer points to an
-      // address that is megabyte-aligned. This can only happen if we have just
-      // filled up a block but have not yet allocated the next block in the
-      // sequence at the start of the collection cycle. This means that the
-      // allocation pointer is invalid and does not actually point to the next
-      // address that would have been allocated at, according to the logic of
-      // arenaAlloc, which will have allocated a fresh memory block and put
-      // the allocation at the start of it. Thus, we use movePtr with a size
-      // of zero to adjust and get the true address of the allocation.
+      // address that is megabyte-aligned. This can only happen if we have
+      // just filled up a block but have not yet allocated the next block in
+      // the sequence at the start of the collection cycle. This means that
+      // the allocation pointer is invalid and does not actually point to the
+      // next address that would have been allocated at, according to the
+      // logic of arenaAlloc, which will have allocated a fresh memory block
+      // and put the allocation at the start of it. Thus, we use movePtr with
+      // a size of zero to adjust and get the true address of the allocation.
       scan_ptr = movePtr(previous_oldspace_alloc_ptr, 0, *old_alloc_ptr());
     } else {
       scan_ptr = previous_oldspace_alloc_ptr;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -31,8 +31,6 @@ static char *last_alloc_ptr;
 #endif
 
 size_t numBytesLiveAtCollection[1 << AGE_WIDTH];
-void set_gc_threshold(size_t);
-size_t get_gc_threshold(void);
 bool youngspaceAlmostFull(size_t);
 
 bool during_gc() {
@@ -394,7 +392,6 @@ void koreCollect(bool afterStep) {
 #endif
   MEM_LOG("Finishing garbage collection\n");
   is_gc = false;
-  set_gc_threshold(youngspace_size());
 }
 
 bool gc_enabled;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -372,9 +372,11 @@ void koreCollect(bool afterStep) {
   set_gc_threshold(youngspace_size());
 }
 
+bool gc_enabled;
+
 void tryKoreCollect(bool afterStep) {
   size_t threshold = get_gc_threshold();
-  if (youngspaceAlmostFull(threshold)) {
+  if (youngspaceAlmostFull(threshold) && gc_enabled) {
     koreCollect(afterStep);
   }
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -307,7 +307,7 @@ static std::vector<gc_root> scanStackRoots(void) {
   return gc_roots;
 }
 
-void koreCollect(bool afterStep) {
+void koreCollect(void) {
   is_gc = true;
   collect_old = shouldCollectOldGen();
   MEM_LOG("Starting garbage collection\n");
@@ -320,7 +320,7 @@ void koreCollect(bool afterStep) {
   }
   char *current_alloc_ptr = *young_alloc_ptr();
 #endif
-  koreAllocSwap(collect_old, afterStep);
+  koreAllocSwap(collect_old);
 #ifdef GC_DBG
   for (int i = 0; i < 2048; i++) {
     numBytesLiveAtCollection[i] = 0;
@@ -406,6 +406,7 @@ void tryKoreCollect(bool afterStep) {
 }
 
 void freeAllKoreMem() {
-  koreCollect(true);
+  koreCollect();
+  koreClear();
 }
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -372,12 +372,14 @@ void koreCollect(bool afterStep) {
   set_gc_threshold(youngspace_size());
 }
 
-void freeAllKoreMem() {
-  koreCollect();
+void tryKoreCollect(bool afterStep) {
+  size_t threshold = get_gc_threshold();
+  if (youngspaceAlmostFull(threshold)) {
+    koreCollect(afterStep);
+  }
 }
 
-bool is_collection() {
-  size_t threshold = get_gc_threshold();
-  return youngspaceAlmostFull(threshold);
+void freeAllKoreMem() {
+  koreCollect(true);
 }
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -264,10 +264,8 @@ void initStaticObjects(void) {
 
 struct gc_root {
   void *bp;
-  layoutitem layout;
+  gc_relocation layout;
 };
-
-extern std::map<void *, std::vector<layoutitem>> StackMap;
 
 static std::vector<gc_root> scanStackRoots(void) {
   unw_cursor_t cursor;

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -323,7 +323,15 @@ void koreCollect(bool afterStep) {
   char *previous_oldspace_alloc_ptr = *old_alloc_ptr();
   // migrate stack roots
   for (int i = 0; i < roots.size(); i++) {
-    migrate_child(roots[i].bp, &roots[i].layout, 0, true);
+    char **base_ptr
+        = (char **)(((char *)roots[i].bp) + roots[i].layout.base.offset);
+    char **derived_ptr
+        = (char **)(((char *)roots[i].bp) + roots[i].layout.derived_offset);
+    ptrdiff_t derived_offset = *derived_ptr - *base_ptr;
+    migrate_child(roots[i].bp, &roots[i].layout.base, 0, true);
+    if (base_ptr != derived_ptr) {
+      *derived_ptr = *base_ptr + derived_offset;
+    }
   }
   // migrate global variable roots
   migrateRoots();

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -378,6 +378,8 @@ void tryKoreCollect(bool afterStep) {
   size_t threshold = get_gc_threshold();
   if (youngspaceAlmostFull(threshold) && gc_enabled) {
     koreCollect(afterStep);
+  } else if (afterStep) {
+    koreClear();
   }
 }
 

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -394,13 +394,12 @@ void koreCollect(void) {
   is_gc = false;
 }
 
-bool gc_enabled;
-
 void tryKoreCollect(bool afterStep) {
-  size_t threshold = get_gc_threshold();
-  if (youngspaceAlmostFull(threshold) && gc_enabled) {
-    koreCollect(afterStep);
-  } else if (afterStep) {
+  if (deferred_collection) {
+    koreCollect();
+    deferred_collection = false;
+  }
+  if (afterStep) {
     koreClear();
   }
 }

--- a/runtime/collect/collect.cpp
+++ b/runtime/collect/collect.cpp
@@ -395,7 +395,7 @@ void koreCollect(void) {
 }
 
 void tryKoreCollect(bool afterStep) {
-  if (deferred_collection) {
+  if (deferred_collection && gc_enabled) {
     koreCollect();
     deferred_collection = false;
   }

--- a/runtime/take_steps.ll
+++ b/runtime/take_steps.ll
@@ -10,17 +10,6 @@ declare tailcc %block** @stepAll(%block*, i64*)
 @depth = thread_local global i64 zeroinitializer
 @steps = thread_local global i64 zeroinitializer
 @current_interval = thread_local global i64 0
-@GC_THRESHOLD = thread_local global i64 @GC_THRESHOLD@
-
-define void @set_gc_threshold(i64 %threshold) {
-  store i64 %threshold, i64* @GC_THRESHOLD
-  ret void
-}
-
-define i64 @get_gc_threshold() {
-  %threshold = load i64, i64* @GC_THRESHOLD
-  ret i64 %threshold
-}
 
 define i1 @finished_rewriting() {
 entry:

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -41,8 +41,6 @@ struct construction {
   size_t nchildren;
 };
 
-extern bool gc_enabled;
-
 static void *constructInitialConfiguration(const KOREPattern *initial) {
   gc_enabled = false;
   std::vector<std::variant<const KOREPattern *, construction>> workList{

--- a/runtime/util/ConfigurationParser.cpp
+++ b/runtime/util/ConfigurationParser.cpp
@@ -41,7 +41,10 @@ struct construction {
   size_t nchildren;
 };
 
+extern bool gc_enabled;
+
 static void *constructInitialConfiguration(const KOREPattern *initial) {
+  gc_enabled = false;
   std::vector<std::variant<const KOREPattern *, construction>> workList{
       initial};
   std::vector<void *> output;
@@ -124,6 +127,7 @@ static void *constructInitialConfiguration(const KOREPattern *initial) {
       output.push_back(Block);
     }
   }
+  gc_enabled = true;
   return output[0];
 }
 

--- a/unittests/runtime-collections/lists.cpp
+++ b/unittests/runtime-collections/lists.cpp
@@ -55,6 +55,8 @@ block D1 = {{1}};
 block *DUMMY1 = &D1;
 }
 
+bool gc_enabled;
+
 BOOST_AUTO_TEST_SUITE(ListTest)
 
 BOOST_AUTO_TEST_CASE(element) {

--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -67,6 +67,8 @@ bool during_gc() {
   return false;
 }
 
+void koreCollect() { }
+
 void printConfigurationInternal(
     writer *file, block *subject, const char *sort, bool) { }
 void sfprintf(writer *, const char *, ...) { }

--- a/unittests/runtime-io/io.cpp
+++ b/unittests/runtime-io/io.cpp
@@ -48,6 +48,8 @@ bool during_gc() {
   return false;
 }
 
+void koreCollect() { }
+
 void add_hash64(void *, uint64_t) { }
 
 void flush_IO_logs();

--- a/unittests/runtime-strings/stringtest.cpp
+++ b/unittests/runtime-strings/stringtest.cpp
@@ -55,6 +55,11 @@ floating *move_float(floating *i) {
 void add_hash64(void *, uint64_t) { }
 }
 
+bool during_gc() {
+  return false;
+}
+void koreCollect() { }
+
 BOOST_AUTO_TEST_SUITE(StringTest)
 
 BOOST_AUTO_TEST_CASE(gt) {


### PR DESCRIPTION
We add a call to koreCollect in `arenaAlloc` if we are close to running out of free space, and only allocate a new block if we're still out of space after the collection. We also modify the behavior of the alwaysgcspace so that it is cleared after each rewrite step.

This ought to ensure that there is never a long period of time where collection cannot occur, since collection can occur during any allocation with the exception of some allocations from inside hooks. It also makes it much less likely that the application will allocate more blocks than are strictly needed, thus reducing memory usage. Additionally, since we are no longer periodically making an expensive check about whether or not to perform a collection, there is a slight improvement in runtime performance.

Limitations: we still only collect things allocated via koreAllocAlwaysGC after each rewrite step. This needs to be improved in future PRs.