### PR TITLE
Add CI hook to enforce clang-format

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,0 +1,13 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Check that C and C++ code is correctly formatted
+      uses: jidicula/clang-format-action@v4.0.0
+      with:
+        clang-format-version: '12'
+        exclude-regex: '(build|config|deps)'


### PR DESCRIPTION
This PR sets up a new Github action that checks (read-only) whether each PR satisfies the clang-format style we adopted in #430. It will error if the code is formatted incorrectly.