### PR TITLE
Recurse into sub-collections when sorting

### DIFF
--- a/lib/ast/AST.cpp
+++ b/lib/ast/AST.cpp
@@ -862,12 +862,12 @@ KORECompositePattern::sortCollections(PrettyPrintData const &data) {
     for (auto &item : printed) {
       items.push_back(item.second);
     }
-    sptr<KOREPattern> result = items[0];
+    sptr<KOREPattern> result = items[0]->sortCollections(data);
     for (int i = 1; i < items.size(); ++i) {
       sptr<KORECompositePattern> tmp
           = KORECompositePattern::Create(constructor.get());
       tmp->addArgument(result);
-      tmp->addArgument(items[i]);
+      tmp->addArgument(items[i]->sortCollections(data));
       result = tmp;
     }
     return result;

--- a/test/unparse/subst/subst.cfg.kore.out
+++ b/test/unparse/subst/subst.cfg.kore.out
@@ -2,12 +2,12 @@
     one[0m ~> .
   </k>[0m
 #Or
-    <k>[0m
-      ?_0:Int ~> .
-    </k>[0m
-  #And
     #Not ( {
       ?_0:Int
     #Equals
       1
     } )
+  #And
+    <k>[0m
+      ?_0:Int ~> .
+    </k>[0m


### PR DESCRIPTION
This makes sure that the whole content of the collection is sorted when
pretty-printing, avoiding bugs where test case outputs are reordered in
the frontend test suite.