### PR TITLE
Update to latest master branch of immer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/immer"]
 	path = deps/immer
-	url = https://github.com/arximboldi/immer.git
+	url = https://github.com/runtimeverification/immer.git
 [submodule "deps/rapidjson"]
 	path = deps/rapidjson
 	url = https://github.com/Tencent/rapidjson

--- a/include/runtime/header.h
+++ b/include/runtime/header.h
@@ -156,7 +156,8 @@ struct KEq {
 
 using list = immer::flex_vector<
     KElem, immer::memory_policy<
-               immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy>>;
+               immer::heap_policy<kore_alloc_heap>, immer::no_refcount_policy,
+               immer::no_lock_policy>>;
 using map = immer::map<
     KElem, KElem, HashBlock, std::equal_to<KElem>, list::memory_policy>;
 using set

--- a/runtime/collect/migrate_roots.cpp
+++ b/runtime/collect/migrate_roots.cpp
@@ -12,12 +12,14 @@ extern "C" {
 void migrate(block **blockPtr);
 
 void migrateRoots() {
-  auto &l = list_impl::empty();
-  migrate_list((void *)&l);
+  auto &l1 = list_impl::empty_root();
+  migrate_collection_node((void **)&l1);
+  auto &l2 = list_impl::empty_tail();
+  migrate_collection_node((void **)&l2);
   auto &s = set_impl::empty();
-  migrate_set((void *)&s);
+  migrate_collection_node((void **)&s);
   auto &m = map_impl::empty();
-  migrate_map((void *)&m);
+  migrate_collection_node((void **)&m);
   if (kllvm_randStateInitialized) {
     auto &rand = kllvm_randState->_mp_seed->_mp_d;
     string *limbs = struct_base(string, data, rand);


### PR DESCRIPTION
I am updating to the latest master branch of immer because the new_gc branch seems to need custom support from the immer library in order to be able to correctly evacuate map and set iterators that are roots on the stack. I want to make the changes to immer in a manner that is suitable for being merged upstream, so it will prove helpful to first be based on the latest master of immer.

Note we do not use the exact commit of the latest master, because it turns out the latest master includes some changes that introduce a regression for the `migrateRoots` function in our llvm backend runtime which handles migrating global variable pointers into the kore heap. I had to make some minor tweaks to the immer library to make it work again, and thus I am currently pointing our submodule to our fork of immer, where I have pushed the changes I made. I already created a PR upstream in the immer repository (arximboldi/immer#189) which contains the changes I have made which I hope to get merged upstream. The plan is to point the submodule back at the upstream repository on the master branch once my changes get merged upstream.

Not ready for review yet; still testing everything still works.