### PR TITLE
Bump MPFR version

### DIFF
--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -52,13 +52,13 @@
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
       <version>1.4</version>
-      <classifier>linux64</classifier>
+      <classifier>osx</classifier>
     </dependency>
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
       <version>1.4</version>
-      <classifier>osx</classifier>
+      <classifier>linux64</classifier>
     </dependency>
   </dependencies>
 

--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -45,26 +45,20 @@
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>0.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>0.2</version>
       <classifier>linux64</classifier>
     </dependency>
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>0.2</version>
       <classifier>osx</classifier>
-    </dependency>
-    <dependency>
-      <groupId>org.kframework.mpfr_java</groupId>
-      <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
-      <classifier>osx-arm</classifier>
     </dependency>
   </dependencies>
 
@@ -133,4 +127,96 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>linux64</id>
+      <activation>
+        <os>
+          <family>Unix</family>
+          <name>!mac os x</name>
+          <arch>amd64</arch>
+        </os>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kframework.mpfr_java</groupId>
+          <artifactId>mpfr_java</artifactId>
+          <version>1.3</version>
+          <classifier>linux64</classifier>
+        </dependency>
+      </dependencies>
+
+      <properties>
+        <native.arch.classifier>64</native.arch.classifier>
+        <native.classifier>linux64</native.classifier>
+        <native.os.classifier>linux</native.os.classifier>
+        <native.exe.type>uexe</native.exe.type>
+        <native.exe.extension />
+        <native.script.extension />
+        <make.args>--output-sync</make.args>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>osx</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>x86_64</arch>
+        </os>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kframework.mpfr_java</groupId>
+          <artifactId>mpfr_java</artifactId>
+          <version>1.3</version>
+          <classifier>osx</classifier>
+        </dependency>
+      </dependencies>
+
+      <properties>
+        <native.arch.classifier>64</native.arch.classifier>
+        <native.classifier>osx-arm</native.classifier>
+        <native.os.classifier>osx-arm</native.os.classifier>
+        <native.exe.type>uexe</native.exe.type>
+        <native.exe.extension />
+        <native.script.extension />
+        <prefix.path>/usr/local/opt/llvm/;/usr/local/opt/flex;/usr/local/opt/libffi</prefix.path>
+        <make.args />
+      </properties>
+    </profile>
+
+    <profile>
+      <id>osx-arm</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.kframework.mpfr_java</groupId>
+          <artifactId>mpfr_java</artifactId>
+          <version>1.3</version>
+          <classifier>osx-arm</classifier>
+        </dependency>
+      </dependencies>
+
+      <properties>
+        <native.arch.classifier>64</native.arch.classifier>
+        <native.classifier>osx-arm</native.classifier>
+        <native.os.classifier>osx-arm</native.os.classifier>
+        <native.exe.type>uexe</native.exe.type>
+        <native.exe.extension />
+        <native.script.extension />
+        <prefix.path>/opt/homebrew/opt/llvm/;/opt/homebrew/opt/flex;/opt/homebrew/opt/libffi</prefix.path>
+        <make.args />
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -60,12 +60,6 @@
       <version>1.4</version>
       <classifier>osx</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.kframework.mpfr_java</groupId>
-      <artifactId>mpfr_java</artifactId>
-      <version>1.4</version>
-      <classifier>osx-arm</classifier>
-    </dependency>
   </dependencies>
 
   <build>

--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -45,20 +45,26 @@
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>0.2</version>
+      <version>1.2</version>
     </dependency>
 
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>0.2</version>
+      <version>1.2</version>
       <classifier>linux64</classifier>
     </dependency>
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>0.2</version>
+      <version>1.2</version>
       <classifier>osx</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.kframework.mpfr_java</groupId>
+      <artifactId>mpfr_java</artifactId>
+      <version>1.2</version>
+      <classifier>osx-arm</classifier>
     </dependency>
   </dependencies>
 
@@ -127,96 +133,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>linux64</id>
-      <activation>
-        <os>
-          <family>Unix</family>
-          <name>!mac os x</name>
-          <arch>amd64</arch>
-        </os>
-      </activation>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.kframework.mpfr_java</groupId>
-          <artifactId>mpfr_java</artifactId>
-          <version>1.3</version>
-          <classifier>linux64</classifier>
-        </dependency>
-      </dependencies>
-
-      <properties>
-        <native.arch.classifier>64</native.arch.classifier>
-        <native.classifier>linux64</native.classifier>
-        <native.os.classifier>linux</native.os.classifier>
-        <native.exe.type>uexe</native.exe.type>
-        <native.exe.extension />
-        <native.script.extension />
-        <make.args>--output-sync</make.args>
-      </properties>
-    </profile>
-
-    <profile>
-      <id>osx</id>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>x86_64</arch>
-        </os>
-      </activation>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.kframework.mpfr_java</groupId>
-          <artifactId>mpfr_java</artifactId>
-          <version>1.3</version>
-          <classifier>osx</classifier>
-        </dependency>
-      </dependencies>
-
-      <properties>
-        <native.arch.classifier>64</native.arch.classifier>
-        <native.classifier>osx-arm</native.classifier>
-        <native.os.classifier>osx-arm</native.os.classifier>
-        <native.exe.type>uexe</native.exe.type>
-        <native.exe.extension />
-        <native.script.extension />
-        <prefix.path>/usr/local/opt/llvm/;/usr/local/opt/flex;/usr/local/opt/libffi</prefix.path>
-        <make.args />
-      </properties>
-    </profile>
-
-    <profile>
-      <id>osx-arm</id>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-
-      <dependencies>
-        <dependency>
-          <groupId>org.kframework.mpfr_java</groupId>
-          <artifactId>mpfr_java</artifactId>
-          <version>1.3</version>
-          <classifier>osx-arm</classifier>
-        </dependency>
-      </dependencies>
-
-      <properties>
-        <native.arch.classifier>64</native.arch.classifier>
-        <native.classifier>osx-arm</native.classifier>
-        <native.os.classifier>osx-arm</native.os.classifier>
-        <native.exe.type>uexe</native.exe.type>
-        <native.exe.extension />
-        <native.script.extension />
-        <prefix.path>/opt/homebrew/opt/llvm/;/opt/homebrew/opt/flex;/opt/homebrew/opt/libffi</prefix.path>
-        <make.args />
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -51,19 +51,19 @@
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
       <classifier>linux64</classifier>
     </dependency>
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
       <classifier>osx</classifier>
     </dependency>
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
       <classifier>osx-arm</classifier>
     </dependency>
   </dependencies>

--- a/nix/llvm-backend-matching.mavenix.lock
+++ b/nix/llvm-backend-matching.mavenix.lock
@@ -5686,24 +5686,24 @@
       "sha1": "34346a37a2ae0397ece7a64bb61c5618f32a91c6"
     },
     {
-      "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2-linux64.jar",
-      "sha1": "f81a9fba413318be7a2997b9b605784a948be065"
-    },
-    {
-      "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2-osx-arm.jar",
-      "sha1": "36817ef1378dbb3b1bfcb82daf7a191219964d63"
-    },
-    {
-      "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2-osx.jar",
-      "sha1": "b1998d734e2ee88e2e99717aa1c1aa596d4a18cd"
-    },
-    {
       "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2.jar",
       "sha1": "77eadc5127adf6144cbb52fdb383c3dc9c02838d"
     },
     {
       "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2.pom",
       "sha1": "5dd43a87e562c333d89d692e7438d34640d2e2d8"
+    },
+    {
+      "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4-linux64.jar",
+      "sha1": "78c13578c9052e9f9dcb6723a267fb183e5ebdac"
+    },
+    {
+      "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4-osx.jar",
+      "sha1": "e9b757d86b6777dafc45d5fda43151483ed553d3"
+    },
+    {
+      "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4.pom",
+      "sha1": "0be0710dd4702726211e61ce6dd3b56acc2d052f"
     },
     {
       "path": "org/mockito/mockito-core/1.9.5/mockito-core-1.9.5.jar",


### PR DESCRIPTION
This updates to follow the deployment of a new version of MPFR; see https://github.com/kframework/mpfr-java/pull/16.

@dwightguth I've remade this PR to get around the Nix problems with the minimum amount of effort.