### PR TITLE
Address Nix CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,10 @@ jobs:
     - uses: actions/checkout@v2.3.4
       with:
         submodules: recursive
-    - uses: cachix/install-nix-action@v12
-    - uses: cachix/cachix-action@v8
+    - uses: cachix/install-nix-action@v14.1
+      with:
+        install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+    - uses: cachix/cachix-action@v10
       with:
         name: runtimeverification
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -17,10 +17,12 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
This PR pins the Nix version to 2.3.16 and bumps the action runner dependencies.