### PR TITLE
Check $PREFIX before running brew

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,21 +30,25 @@ set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fl
 
 if(APPLE)
   if(NOT USE_NIX)
-    execute_process(
-      COMMAND brew --prefix
-      OUTPUT_VARIABLE BREW_PREFIX
-      ERROR_VARIABLE BREW_ERROR
-      RESULT_VARIABLE BREW_RESULT
-      OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    if(BREW_RESULT EQUAL 0)
-      include_directories(AFTER SYSTEM "${BREW_PREFIX}/include")
-      link_directories(AFTER "${BREW_PREFIX}/lib")
-      set(ENV{PKG_CONFIG_PATH} "${BREW_PREFIX}/opt/libffi/lib/pkgconfig")
+    if(DEFINED ENV{PREFIX})
+      set(BREW_PREFIX $ENV{PREFIX})
     else()
-      message(WARNING "Error running brew --prefix; you may need to manually configure package search paths.")
-      set(BREW_PREFIX "/usr/local")
-    endif()
+      execute_process(
+        COMMAND brew --prefix
+        OUTPUT_VARIABLE BREW_PREFIX
+        ERROR_VARIABLE BREW_ERROR
+        RESULT_VARIABLE BREW_RESULT
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+      if(BREW_RESULT NOT EQUAL 0)
+        message(WARNING "Error running brew --prefix; you may need to manually configure package search paths.")
+        message(WARNING "  : ${BREW_ERROR}")
+      endif() # BREW_RESULT
+    endif() # ENV{PREFIX}
+
+    include_directories(AFTER SYSTEM "${BREW_PREFIX}/include")
+    link_directories(AFTER "${BREW_PREFIX}/lib")
+    set(ENV{PKG_CONFIG_PATH} "${BREW_PREFIX}/opt/libffi/lib/pkgconfig")
   endif() # USE_NIX
 endif() # APPLE
 

--- a/matching/pom.xml
+++ b/matching/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.kframework.mpfr_java</groupId>
       <artifactId>mpfr_java</artifactId>
-      <version>1.2</version>
+      <version>1.4</version>
     </dependency>
 
     <dependency>

--- a/nix/llvm-backend-matching.mavenix.lock
+++ b/nix/llvm-backend-matching.mavenix.lock
@@ -5686,20 +5686,16 @@
       "sha1": "34346a37a2ae0397ece7a64bb61c5618f32a91c6"
     },
     {
-      "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2.jar",
-      "sha1": "77eadc5127adf6144cbb52fdb383c3dc9c02838d"
-    },
-    {
-      "path": "org/kframework/mpfr_java/mpfr_java/1.2/mpfr_java-1.2.pom",
-      "sha1": "5dd43a87e562c333d89d692e7438d34640d2e2d8"
-    },
-    {
       "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4-linux64.jar",
       "sha1": "78c13578c9052e9f9dcb6723a267fb183e5ebdac"
     },
     {
       "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4-osx.jar",
       "sha1": "e9b757d86b6777dafc45d5fda43151483ed553d3"
+    },
+    {
+      "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4.jar",
+      "sha1": "326d809a7d7ebd9b648e10ab2e3ec17fa8bab20d"
     },
     {
       "path": "org/kframework/mpfr_java/mpfr_java/1.4/mpfr_java-1.4.pom",


### PR DESCRIPTION
We experienced a [packaging failure](https://office.runtimeverification.com/jenkins/blue/rest/organizations/jenkins/pipelines/K/branches/release/runs/153/nodes/51/steps/104/log/?start=0) on macOS that was caused by `brew --prefix` failing during CMake.

To fix this, check for the `$PREFIX` environment variable before trying to run `brew`. This variable [is set](https://github.com/kframework/homebrew-k/blob/ba124232d8d2a0e97668960119e8292f5f713524/Formula/kframework.rb#L28) in the Homebrew formula we use, so should get picked up appropriately during packaging.

Minor: also fixes a version bump of MPFR 1.2 -> 1.4; only the Java code was missed, which is identical across these versions so there should be no impact from this other than consistency.