### PR TITLE
Pick up the correct environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fl
 
 if(APPLE)
   if(NOT USE_NIX)
-    if(DEFINED ENV{PREFIX})
+    if(DEFINED ENV{HOMEBREW_PREFIX})
       set(BREW_PREFIX $ENV{HOMEBREW_PREFIX})
     else()
       execute_process(
@@ -44,7 +44,7 @@ if(APPLE)
         message(WARNING "Error running brew --prefix; you may need to manually configure package search paths.")
         message(WARNING "  : ${BREW_ERROR}")
       endif() # BREW_RESULT
-    endif() # ENV{PREFIX}
+    endif() # ENV{HOMEBREW_PREFIX}
 
     message(STATUS "Looking for Homebrew dependencies in ${BREW_PREFIX}")
     include_directories(AFTER SYSTEM "${BREW_PREFIX}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,7 @@ if(APPLE)
       endif() # BREW_RESULT
     endif() # ENV{PREFIX}
 
+    message(STATUS "Looking for Homebrew dependencies in ${BREW_PREFIX}")
     include_directories(AFTER SYSTEM "${BREW_PREFIX}/include")
     link_directories(AFTER "${BREW_PREFIX}/lib")
     set(ENV{PKG_CONFIG_PATH} "${BREW_PREFIX}/opt/libffi/lib/pkgconfig")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fl
 if(APPLE)
   if(NOT USE_NIX)
     if(DEFINED ENV{PREFIX})
-      set(BREW_PREFIX $ENV{PREFIX})
+      set(BREW_PREFIX $ENV{HOMEBREW_PREFIX})
     else()
       execute_process(
         COMMAND brew --prefix


### PR DESCRIPTION
Matches https://github.com/kframework/homebrew-k/pull/10 in the Homebrew formula.

My previous change made a silly error and didn't pick up the correct prefix variable; this change should fix that and get the actual homebrew root (`/usr/local` rather than `/usr/local/Cellar/kframework/5.1.246`, say).