### PR TITLE
Replace uses of getPointerElementType used as convenience

### DIFF
--- a/lib/codegen/CreateTerm.cpp
+++ b/lib/codegen/CreateTerm.cpp
@@ -776,7 +776,7 @@ llvm::Value *CreateTerm::createHook(
       return result;
     } else if (nwords == 1) {
       auto Word = new llvm::LoadInst(
-          Ptr->getType()->getPointerElementType(), Ptr, "word", CurrentBlock);
+          llvm::Type::getInt64Ty(Ctx), Ptr, "word", CurrentBlock);
       if (cat.bits == 64) {
         return Word;
       } else {
@@ -786,7 +786,7 @@ llvm::Value *CreateTerm::createHook(
     } else { // nwords >= 2
       for (size_t i = 0; i < nwords; i++) {
         auto Word = new llvm::LoadInst(
-            Ptr->getType()->getPointerElementType(), Ptr, "word", CurrentBlock);
+            llvm::Type::getInt64Ty(Ctx), Ptr, "word", CurrentBlock);
         auto Zext = new llvm::ZExtInst(Word, Type, "extended", CurrentBlock);
         auto Shl = llvm::BinaryOperator::Create(
             llvm::Instruction::Shl, result, llvm::ConstantInt::get(Type, 64),

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -230,16 +230,16 @@ void SwitchNode::codegen(Decision *d) {
                  llvm::Type::getInt32Ty(d->Ctx), offset + 2)},
             "", d->CurrentBlock);
         llvm::Value *Child;
-        switch (dynamic_cast<KORECompositeSort *>(
-                    _case.getConstructor()->getArguments()[offset].get())
-                    ->getCategory(d->Definition)
-                    .cat) {
+        ValueType cat = dynamic_cast<KORECompositeSort *>(
+                _case.getConstructor()->getArguments()[offset].get())
+                ->getCategory(d->Definition);
+        switch (cat.cat) {
         case SortCategory::Map:
         case SortCategory::List:
         case SortCategory::Set: Child = ChildPtr; break;
         default:
           Child = new llvm::LoadInst(
-              ChildPtr->getType()->getPointerElementType(), ChildPtr,
+              getValueType(cat, d->Module), ChildPtr,
               binding.first.substr(0, max_name_length), d->CurrentBlock);
           break;
         }

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -230,9 +230,10 @@ void SwitchNode::codegen(Decision *d) {
                  llvm::Type::getInt32Ty(d->Ctx), offset + 2)},
             "", d->CurrentBlock);
         llvm::Value *Child;
-        ValueType cat = dynamic_cast<KORECompositeSort *>(
-                _case.getConstructor()->getArguments()[offset].get())
-                ->getCategory(d->Definition);
+        ValueType cat
+            = dynamic_cast<KORECompositeSort *>(
+                  _case.getConstructor()->getArguments()[offset].get())
+                  ->getCategory(d->Definition);
         switch (cat.cat) {
         case SortCategory::Map:
         case SortCategory::List:
@@ -571,7 +572,7 @@ static void initChoiceBuffer(
   auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
       ty, choiceBuffer, {zero, currDepth}, "", fail);
   llvm::LoadInst *failAddress = new llvm::LoadInst(
-      llvm::Type::getInt8PtrTy(module->getContext()) , currentElt, "", fail);
+      llvm::Type::getInt8PtrTy(module->getContext()), currentElt, "", fail);
   auto newDepth = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, currDepth,
       llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1),

--- a/lib/codegen/Decision.cpp
+++ b/lib/codegen/Decision.cpp
@@ -567,11 +567,11 @@ static void initChoiceBuffer(
       llvm::BlockAddress::get(block->getParent(), stuck), firstElt, block);
 
   llvm::LoadInst *currDepth = new llvm::LoadInst(
-      choiceDepth->getType()->getPointerElementType(), choiceDepth, "", fail);
+      llvm::Type::getInt64Ty(module->getContext()), choiceDepth, "", fail);
   auto currentElt = llvm::GetElementPtrInst::CreateInBounds(
       ty, choiceBuffer, {zero, currDepth}, "", fail);
   llvm::LoadInst *failAddress = new llvm::LoadInst(
-      currentElt->getType()->getPointerElementType(), currentElt, "", fail);
+      llvm::Type::getInt8PtrTy(module->getContext()) , currentElt, "", fail);
   auto newDepth = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, currDepth,
       llvm::ConstantInt::get(llvm::Type::getInt64Ty(module->getContext()), 1),

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -140,8 +140,7 @@ static void emitDataTableForSymbol(
   auto retval = llvm::GetElementPtrInst::Create(
       tableType, globalVar, {zero, offset}, "", MergeBlock);
   MergeBlock->insertInto(func);
-  auto load = new llvm::LoadInst(
-      ty, retval, "", MergeBlock);
+  auto load = new llvm::LoadInst(ty, retval, "", MergeBlock);
   llvm::ReturnInst::Create(Ctx, load, MergeBlock);
   addAbort(stuck, module);
   stuck->insertInto(func);
@@ -276,8 +275,8 @@ static llvm::Value *getArgValue(
       llvm::ArrayType::get(llvm::Type::getInt8PtrTy(Ctx), 0), ArgumentsArray,
       {zero, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), idx)}, "",
       CaseBlock);
-  llvm::Value *arg = new llvm::LoadInst(
-      llvm::Type::getInt8PtrTy(Ctx), addr, "", CaseBlock);
+  llvm::Value *arg
+      = new llvm::LoadInst(llvm::Type::getInt8PtrTy(Ctx), addr, "", CaseBlock);
   switch (cat.cat) {
   case SortCategory::Bool:
   case SortCategory::MInt: {
@@ -548,8 +547,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     case SortCategory::Int: {
       const auto &thirdArg = func->arg_begin() + 2;
       llvm::Value *FirstChar = new llvm::LoadInst(
-          llvm::Type::getInt8Ty(Ctx), thirdArg, "",
-          CaseBlock);
+          llvm::Type::getInt8Ty(Ctx), thirdArg, "", CaseBlock);
       llvm::Constant *asciiPlus
           = llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), 43);
       auto icmpFirst = new llvm::ICmpInst(
@@ -613,8 +611,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
   auto BlockSize
       = module->getOrInsertGlobal("BLOCK_SIZE", llvm::Type::getInt64Ty(Ctx));
   auto BlockSizeVal = new llvm::LoadInst(
-      llvm::Type::getInt64Ty(Ctx), BlockSize, "",
-      CurrentBlock);
+      llvm::Type::getInt64Ty(Ctx), BlockSize, "", CurrentBlock);
   auto BlockAllocSize = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, BlockSizeVal,
       llvm::ConstantExpr::getSizeOf(llvm::Type::getInt8PtrTy(Ctx)), "",

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -909,7 +909,7 @@ static void getVisitor(
         {zero, llvm::ConstantInt::get(llvm::Type::getInt32Ty(Ctx), idx++ + 2)},
         "", CaseBlock);
     llvm::Value *Child = new llvm::LoadInst(
-        ChildPtr->getType()->getPointerElementType(), ChildPtr, "", CaseBlock);
+        getValueType(cat, module), ChildPtr, "", CaseBlock);
     std::ostringstream Out;
     sort->print(Out);
     auto Str = llvm::ConstantDataArray::getString(Ctx, Out.str(), true);
@@ -971,8 +971,7 @@ static void getVisitor(
       break;
     case SortCategory::MInt: {
       llvm::Value *mint = new llvm::LoadInst(
-          ChildPtr->getType()->getPointerElementType(), ChildPtr, "mint",
-          CaseBlock);
+          getValueType(cat, module), ChildPtr, "mint", CaseBlock);
       size_t nwords = (cat.bits + 63) / 64;
       auto nbits
           = llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), cat.bits);

--- a/lib/codegen/EmitConfigParser.cpp
+++ b/lib/codegen/EmitConfigParser.cpp
@@ -141,7 +141,7 @@ static void emitDataTableForSymbol(
       tableType, globalVar, {zero, offset}, "", MergeBlock);
   MergeBlock->insertInto(func);
   auto load = new llvm::LoadInst(
-      retval->getType()->getPointerElementType(), retval, "", MergeBlock);
+      ty, retval, "", MergeBlock);
   llvm::ReturnInst::Create(Ctx, load, MergeBlock);
   addAbort(stuck, module);
   stuck->insertInto(func);
@@ -277,7 +277,7 @@ static llvm::Value *getArgValue(
       {zero, llvm::ConstantInt::get(llvm::Type::getInt64Ty(Ctx), idx)}, "",
       CaseBlock);
   llvm::Value *arg = new llvm::LoadInst(
-      addr->getType()->getPointerElementType(), addr, "", CaseBlock);
+      llvm::Type::getInt8PtrTy(Ctx), addr, "", CaseBlock);
   switch (cat.cat) {
   case SortCategory::Bool:
   case SortCategory::MInt: {
@@ -548,7 +548,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
     case SortCategory::Int: {
       const auto &thirdArg = func->arg_begin() + 2;
       llvm::Value *FirstChar = new llvm::LoadInst(
-          thirdArg->getType()->getPointerElementType(), thirdArg, "",
+          llvm::Type::getInt8Ty(Ctx), thirdArg, "",
           CaseBlock);
       llvm::Constant *asciiPlus
           = llvm::ConstantInt::get(llvm::Type::getInt8Ty(Ctx), 43);
@@ -613,7 +613,7 @@ static void emitGetToken(KOREDefinition *definition, llvm::Module *module) {
   auto BlockSize
       = module->getOrInsertGlobal("BLOCK_SIZE", llvm::Type::getInt64Ty(Ctx));
   auto BlockSizeVal = new llvm::LoadInst(
-      BlockSize->getType()->getPointerElementType(), BlockSize, "",
+      llvm::Type::getInt64Ty(Ctx), BlockSize, "",
       CurrentBlock);
   auto BlockAllocSize = llvm::BinaryOperator::Create(
       llvm::Instruction::Sub, BlockSizeVal,


### PR DESCRIPTION
This pull request contains changes to address LLVM's eventual deprecation of the use of PointerType::getElementType and Type::getPointerElementType. This set of changes is a first attempt to removing uses of these API's that are relatively straight forward to replace.