### PR TITLE
Fix for crash on Apple Silicon

### DIFF
--- a/include/kllvm/codegen/Decision.h
+++ b/include/kllvm/codegen/Decision.h
@@ -366,7 +366,6 @@ private:
   llvm::LLVMContext &Ctx;
   ValueType Cat;
   llvm::PHINode *FailSubject, *FailPattern, *FailSort;
-  llvm::Value *ResultBuffer, *ResultCount, *ResultCapacity;
 
   std::map<var_type, llvm::AllocaInst *> symbols;
 
@@ -383,9 +382,7 @@ public:
       llvm::BasicBlock *FailureBlock, llvm::IndirectBrInst *FailJump,
       llvm::AllocaInst *ChoiceBuffer, llvm::AllocaInst *ChoiceDepth,
       llvm::Module *Module, ValueType Cat, llvm::PHINode *FailSubject,
-      llvm::PHINode *FailPattern, llvm::PHINode *FailSort,
-      llvm::Value *ResultBuffer, llvm::Value *ResultCount,
-      llvm::Value *ResultCapacity)
+      llvm::PHINode *FailPattern, llvm::PHINode *FailSort)
       : Definition(Definition)
       , CurrentBlock(EntryBlock)
       , FailureBlock(FailureBlock)
@@ -398,10 +395,7 @@ public:
       , Cat(Cat)
       , FailSubject(FailSubject)
       , FailPattern(FailPattern)
-      , FailSort(FailSort)
-      , ResultBuffer(ResultBuffer)
-      , ResultCount(ResultCount)
-      , ResultCapacity(ResultCapacity) { }
+      , FailSort(FailSort) { }
 
   /* adds code to the specified basic block to take a single step based on
      the specified decision tree and return the result of taking that step. */

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -10,8 +10,7 @@ static std::vector<block *> stepResults;
 
 extern "C" {
 
-void addSearchResult(
-    block *result, block ***bufPtr, uint64_t *count, uint64_t *capacity) {
+void addSearchResult(block *result) {
   stepResults.push_back(result);
 }
 

--- a/runtime/util/search.cpp
+++ b/runtime/util/search.cpp
@@ -6,22 +6,16 @@
 #include "runtime/collect.h"
 #include "runtime/header.h"
 
+static std::vector<block *> stepResults;
+
 extern "C" {
 
 void addSearchResult(
     block *result, block ***bufPtr, uint64_t *count, uint64_t *capacity) {
-  if (*count == *capacity) {
-    size_t len = *count * sizeof(block *) * 2;
-    block **newBuf = (block **)koreAllocAlwaysGC(len);
-    memcpy(newBuf, *bufPtr, len);
-    *bufPtr = newBuf;
-    *capacity = *capacity * 2;
-  }
-  (*bufPtr)[*count] = result;
-  (*count)++;
+  stepResults.push_back(result);
 }
 
-block **take_search_step(block *, uint64_t *);
+void take_search_step(block *);
 }
 
 static std::list<block *> states;
@@ -38,6 +32,9 @@ blockEnumerator() {
     blocks.push_back(const_cast<block **>(&(keyVal)));
   }
   blocks.push_back(&state);
+  for (auto &keyVal : stepResults) {
+    blocks.push_back(const_cast<block **>(&(keyVal)));
+  }
 
   return std::make_pair(blocks.begin(), blocks.end());
 }
@@ -60,15 +57,15 @@ take_search_steps(int64_t depth, block *subject) {
     states_set.erase(state);
     if (depth > 0)
       depth--;
-    uint64_t count;
-    block **stepResults = take_search_step(state, &count);
-    if (count == 0) {
+    stepResults.clear();
+    take_search_step(state);
+    if (stepResults.size() == 0) {
       results.insert(state);
     } else {
-      for (uint64_t i = 0; i < count; i++) {
-        auto dirty = states_set.insert(stepResults[i]);
+      for (block *result : stepResults) {
+        auto dirty = states_set.insert(result);
         if (dirty.second) {
-          states.push_back(stepResults[i]);
+          states.push_back(result);
         }
       }
     }


### PR DESCRIPTION
This PR cherry-picks a change from the `new-gc` branch by hand to fix a crash with LLVM `--search` on Apple Silicon.

I'm not exactly sure what the cause of this bug is, but I suspect that it's some kind of subtle issue with the interaction between generated LLVM and the C code in the runtime library. The ["packed traversals" fix](https://github.com/kframework/llvm-backend/pull/446) from a while ago was a similar-looking issue.

Pulling in this change (that reduces the amount and complexity of generated code used) fixes the problem, and given that we were planning to make this change anyway I'm inclined to say that it's the most sensible solution.

I can investigate in more detail, but I'm not sure that's a worthwhile use of time given that this is a) only on Apple Silicon and b) fixed neatly by this PR.

The original change by @dwightguth is [here](https://github.com/kframework/llvm-backend/pull/441/commits/338d55fed3eb7c8ca19c43f8d916acabf69a33f8); this isn't a direct cherry-pick as the original commit is on a squashed branch.

Fixes https://github.com/kframework/k/issues/2311