### PR TITLE
Add pass manager flag to llvm-kompile script

### DIFF
--- a/bin/llvm-kompile
+++ b/bin/llvm-kompile
@@ -49,7 +49,7 @@ if $compile; then
   "$(dirname "$0")"/llvm-kompile-codegen "$definition" "$dt_dir"/dt.yaml "$dt_dir" $debug > "$mod"
 
   # optimization
-  @OPT@ -load "$(dirname "$0")"/../lib/kllvm/libLLVMPass.so -mem2reg -tailcallelim $opt_flags -mark-tail-calls-as-gc-leaf -rewrite-statepoints-for-gc -dce -emit-gc-layout-info "$mod" -o "$modopt"
+  @OPT@ -load "$(dirname "$0")"/../lib/kllvm/libLLVMPass.so -enable-new-pm=0 -mem2reg -tailcallelim $opt_flags -mark-tail-calls-as-gc-leaf -rewrite-statepoints-for-gc -dce -emit-gc-layout-info "$mod" -o "$modopt"
   @LLVM_LINK@ "$modopt" "$(dirname "$0")"/../lib/kllvm/llvm/opaque/opaque.ll -o "$modcombined"
   @OPT@ "$modcombined" -always-inline -o "$modcombinedopt"
 else


### PR DESCRIPTION
This flag opts into the old pass manager infrastructure on newer versions of LLVM (>= 13). See the discussion [here](https://groups.google.com/g/llvm-dev/c/kQYV9dCAfSg) for context.