### PR TITLE
Make unit testing more idiomatic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(LLVMKompilePrelude)
 project (KLLVM CXX C)
 
+include(CTest)
+
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 set(CMAKE_CXX_STANDARD 17)
@@ -260,5 +262,9 @@ include_directories(${KLLVM_AUTOGEN_INCLUDE_DIR})
 add_subdirectory(lib)
 add_subdirectory(tools)
 add_subdirectory(runtime)
-add_subdirectory(unittests)
+
+if(BUILD_TESTS)
+  add_subdirectory(unittests)
+endif()
+
 #add_subdirectory(test)

--- a/ciscript
+++ b/ciscript
@@ -16,13 +16,20 @@ fi
 rm -rf build
 mkdir -p build
 cd build
-cmake .. -DCMAKE_BUILD_TYPE=$1 -DCMAKE_INSTALL_PREFIX=install -DGC_THRESHOLD=1
+
+cmake .. \
+  -DCMAKE_BUILD_TYPE=$1 \
+  -DCMAKE_INSTALL_PREFIX=install \
+  -DGC_THRESHOLD=1 \
+  -DBUILD_TESTS=On
+
 make -j`nproc`
 if [[ "$1" == "GcStats"* ]]; then
   make install
   exit 0
 fi
-make run-unittests
+
+make test
 cd ../matching
 mvn verify -U
 cd ../build

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -49,6 +49,7 @@ stdenv.mkDerivation {
     ''-DLLVM_CONFIG_PATH=${lib.getBin llvmPackages.libllvm.dev}/bin/llvm-config''
     ''-DUSE_NIX=TRUE''
     ''-DCMAKE_SKIP_BUILD_RPATH=FALSE''
+    ''-DBUILD_TESTS=True''
   ];
 
   cmakeBuildType = if release then "Release" else "FastBuild";

--- a/nix/llvm-backend.nix
+++ b/nix/llvm-backend.nix
@@ -65,7 +65,7 @@ stdenv.mkDerivation {
       # Primarily, this allows linking to paths in the build tree.
       # The setting is only applied to the unit tests, which are not installed.
       export NIX_ENFORCE_PURITY=0
-      make run-unittests
+      make test
     )
 
     runHook postCheck

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,25 +1,11 @@
-add_custom_target(unittests)
-add_custom_target(run-unittests)
-
 macro(add_kllvm_unittest test_name)
   # add target for building the test
   kllvm_add_tool(${test_name} ${ARGN})
 
-  # exclude unit tests from the default target
-  set_target_properties(${test_name} PROPERTIES EXCLUDE_FROM_ALL TRUE)
-
-  # add a dependency to the global unit test build target
-  add_dependencies(unittests ${test_name})
-
-  # add target for running the test
-  add_custom_target(run-${test_name}
-    COMMAND ./${test_name}
-    COMMENT "Running unit tests: ${test_name}"
+  add_test(
+    NAME ${test_name}
+    COMMAND ${test_name}
   )
-  add_dependencies(run-${test_name} ${test_name})
-
-  # add a dependency to the global unit test run target
-  add_dependencies(run-unittests run-${test_name})
 endmacro(add_kllvm_unittest test_name)
 
 add_subdirectory(runtime-arithmetic)


### PR DESCRIPTION
CMake has built-in support for unit test frameworks; this PR rewrites the unit testing build script to use this support more idiomatically. The changes are:
* Instead of excluding unit-test targets from the default build target, the inclusion of the unit tests subdirectory is gated behind the CMake configuration variable `BUILD_TESTS`. If the option is enabled, `make` will build the unit tests as well as the backend itself.
* Rather than manually tracking dependencies between a phony `run-unittests` target and the individual executables, use `add_test` to get CMake to do it for us.
* Update the CI script to use the new invocations.