### PR TITLE
[No merge] Bad cmake tests

### DIFF
--- a/unittests/runtime-ffi/ffi.cpp
+++ b/unittests/runtime-ffi/ffi.cpp
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(call) {
   bytes = hook_FFI_call(addr, &args, &types, type_sint);
   ret = *(int *)bytes->data;
 
-  BOOST_CHECK_EQUAL(ret, p.x * p.y);
+  BOOST_CHECK_EQUAL(ret, 1074878376482);
 
   /* struct point2 {
    *  struct point p;


### PR DESCRIPTION
This is an intentionally broken PR to verify that the unit tests are getting run, and failures are reported.