### PR TITLE
better way to disable arch linux build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,10 @@ pipeline {
     }
     stage('Build and Test on Arch Linux') {
       options { timeout(time: 25, unit: 'MINUTES') }
+      when {
+        expression { return false }
+        beforeAgent true
+      }
       agent {
         dockerfile {
           filename 'Dockerfile.arch'
@@ -18,12 +22,11 @@ pipeline {
       }
       steps {
         sh '''
-          #./ciscript Debug
-          #./ciscript Release
-          #./ciscript RelWithDebInfo
-          #./ciscript FastBuild
-          #./ciscript GcStats
-
+          ./ciscript Debug
+          ./ciscript Release
+          ./ciscript RelWithDebInfo
+          ./ciscript FastBuild
+          ./ciscript GcStats
         '''
       }
     }


### PR DESCRIPTION
We currently don't test on arch linux, but it was still building the arch linux dockerfile, which can lead to build failures if the build times out due to the dockerfile taking a long time to build. Thus, I choose to disable the tests at the level of Jenkins rather than from within the bash script. this ought to mean that the dockerfile isn't build, thus fixing the timeouts.